### PR TITLE
chore: add root .gitignore and remove TODO.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,28 @@
+# OpenCode local install artifacts
+.opencode/
+
+# Dependencies
+node_modules/
+
+# Build output
+dist/
+
+# Environment variables
+.env
+.env.*
+
+# Logs
+*.log
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Editor/IDE
+.vscode/
+.idea/
+*.swp
+*~
+
+# TODO tracking (use GitHub issues instead)
+TODO.md


### PR DESCRIPTION
## Summary

- Adds a root `.gitignore` with entries for `.opencode/` (local install artifact), `node_modules/`, `dist/`, environment files, logs, OS files, editor artifacts, and `TODO.md`
- Removes `TODO.md` from the working directory — its sole item (multi-agent install support) is already tracked as #1

Closes #2