### PR TITLE
feat: support installing multiple agents in a single command

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,25 +14,33 @@ Each agent is a self-contained package with custom tools, slash commands, skills
 
 ## Quick Start
 
-Install an agent with a single command -- no need to clone the repo first:
+Install an agent into your current project (no clone needed):
 
 ```bash
-# Navigate to your project
-cd /path/to/your/project
-
-# Install the git-ops agent
 curl -fsSL https://raw.githubusercontent.com/kunallimaye/lib-agents/main/install.sh | bash -s -- git-ops
+```
 
-# Or install globally (available in all projects)
-curl -fsSL https://raw.githubusercontent.com/kunallimaye/lib-agents/main/install.sh | bash -s -- git-ops --global
+Install multiple agents at once:
 
-# List available agents
-curl -fsSL https://raw.githubusercontent.com/kunallimaye/lib-agents/main/install.sh | bash -s -- --list
+```bash
+curl -fsSL https://raw.githubusercontent.com/kunallimaye/lib-agents/main/install.sh | bash -s -- git-ops docs
+```
+
+Install all agents:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/kunallimaye/lib-agents/main/install.sh | bash -s -- --all
+```
+
+Install globally (available in all projects):
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/kunallimaye/lib-agents/main/install.sh | bash -s -- --all --global
 ```
 
 ### Local install (for development)
 
-If you want to contribute or customize agents, clone the repo and use `--link`:
+Clone the repo and use `--link` so changes reflect immediately:
 
 ```bash
 git clone https://github.com/kunallimaye/lib-agents.git


### PR DESCRIPTION
## Summary

The installer only accepted a single agent name — running `./install.sh git-ops docs` silently dropped `git-ops` and only installed `docs`. This PR adds multi-agent and `--all` support.

## Changes

- Replace scalar `AGENT_NAME=""` with `AGENT_NAMES=()` array so positional args are collected, not overwritten
- Add `--all` / `-a` flag to install every agent in the repo
- Wrap `check_prerequisites` + `install_agent` in a `for` loop over the array
- Update `usage()` text and header comments for new syntax
- Update README quickstart with single-command copy-paste examples instead of a multi-line code block

## Testing

- `bash -n install.sh` — syntax check passes
- `./install.sh git-ops docs --check` — checks both agents sequentially
- `./install.sh --all --check` — discovers all 3 agents (devops, docs, git-ops)
- Multi-agent install in temp dir — both agents installed with correct dependency resolution
- `--all` install in temp dir — all 3 agents installed with automatic dependency handling

## Related Issues

Closes #1