### PR TITLE
fix: add skippable docs validation step before committing in devops agent

### DIFF
--- a/agents/devops/agent.md
+++ b/agents/devops/agent.md
@@ -209,6 +209,7 @@ You MUST delegate to the appropriate agent for:
 ### `@docs` -- All documentation tasks
 - Generating, updating, or validating README.md
 - Project analysis for documentation purposes
+- Pre-commit documentation validation (when not skipped by user)
 
 Scaffolding (Makefile, scripts, CI/CD) is handled by the `scaffold` tool
 directly -- do NOT delegate scaffolding to other agents.
@@ -219,13 +220,24 @@ When delegating, provide the agent with complete context about what to do.
 
 After completing the requested work:
 
-1. **Stage and commit** -- Delegate to `@git-ops` to stage relevant changes
+1. **Validate documentation** (skippable) -- Ask the user if they want to
+   validate documentation before committing. If yes (or no response within
+   the flow), delegate to `@docs` to run `readme-validate` on the project.
+   - If issues are found that relate to the current changes and are small
+     (e.g., stale quickstart commands, missing prerequisites), delegate to
+     `@docs` to fix them inline so they are included in the same commit.
+   - If issues are found that are large or unrelated to the current changes,
+     delegate to `@git-ops` to create a GitHub issue with the `docs` label
+     to track them separately.
+   - If no README exists or no issues are found, proceed.
+   - If the user chose to skip, proceed immediately.
+2. **Stage and commit** -- Delegate to `@git-ops` to stage relevant changes
    and create a conventional commit.
-2. **Create PR** -- Delegate to `@git-ops` to create a pull request that:
+3. **Create PR** -- Delegate to `@git-ops` to create a pull request that:
    - Has a descriptive title following conventional commit format
    - Links back to the issue using `Closes #<number>` in the body
    - Uses `delete_branch: true` so the remote branch is cleaned up on merge
-3. **Report back** -- Summarize what was done, the PR URL, and the linked issue.
+4. **Report back** -- Summarize what was done, the PR URL, and the linked issue.
 
 ## Safety Rules
 

--- a/agents/devops/commands/deploy.md
+++ b/agents/devops/commands/deploy.md
@@ -44,5 +44,9 @@ If arguments mention Google Cloud or GCP:
 2. Execute the requested GCP operation.
 
 After completing the deployment:
-1. Delegate to @git-ops to commit any configuration changes.
-2. Delegate to @git-ops to create a PR linking to the issue.
+1. Ask the user if they want to validate docs before committing.
+   If yes, delegate to @docs to run readme-validate and fix small
+   related issues inline or create tracking issues for larger ones.
+   If the user skips, proceed directly.
+2. Delegate to @git-ops to commit any configuration changes.
+3. Delegate to @git-ops to create a PR linking to the issue.

--- a/agents/devops/commands/devops.md
+++ b/agents/devops/commands/devops.md
@@ -16,6 +16,10 @@ Before doing any work, run the full pre-flight check:
 4. Only after pre-flight passes, proceed with the requested work.
 
 After completing the work:
-1. Delegate to @git-ops to stage and commit changes.
-2. Delegate to @git-ops to create a PR that closes the linked issue.
-3. Report the PR URL and linked issue back to the user.
+1. Ask the user if they want to validate docs before committing.
+   If yes, delegate to @docs to run readme-validate and fix small
+   related issues inline or create tracking issues for larger ones.
+   If the user skips, proceed directly.
+2. Delegate to @git-ops to stage and commit changes.
+3. Delegate to @git-ops to create a PR that closes the linked issue.
+4. Report the PR URL and linked issue back to the user.

--- a/agents/devops/commands/infra.md
+++ b/agents/devops/commands/infra.md
@@ -36,5 +36,9 @@ If arguments mention GCP resources:
 3. Show the results.
 
 After making infrastructure changes:
-1. Delegate to @git-ops to commit any Terraform file changes.
-2. Delegate to @git-ops to create a PR linking to the issue.
+1. Ask the user if they want to validate docs before committing.
+   If yes, delegate to @docs to run readme-validate and fix small
+   related issues inline or create tracking issues for larger ones.
+   If the user skips, proceed directly.
+2. Delegate to @git-ops to commit any Terraform file changes.
+3. Delegate to @git-ops to create a PR linking to the issue.

--- a/agents/devops/commands/scaffold.md
+++ b/agents/devops/commands/scaffold.md
@@ -22,5 +22,9 @@ After pre-flight passes:
    Build (plan on PR, apply on merge).
 4. Run the appropriate scaffold tool exports (or `full_scaffold` for everything).
 5. Show a summary of all files created/skipped.
-6. Delegate to @git-ops to stage all new files and create a commit.
-7. Delegate to @git-ops to create a PR linking to the issue.
+6. Ask the user if they want to validate docs before committing.
+   If yes, delegate to @docs to run readme-validate and fix small
+   related issues inline or create tracking issues for larger ones.
+   If the user skips, proceed directly.
+7. Delegate to @git-ops to stage all new files and create a commit.
+8. Delegate to @git-ops to create a PR linking to the issue.


### PR DESCRIPTION
## Summary

The devops agent previously committed code without checking whether documentation needed updating, leading to documentation drift. This adds a skippable pre-commit docs validation step using a hybrid approach.

## Changes

- **`agents/devops/agent.md`**: Added `readme-validate` delegation to `@docs` section. Inserted new step 1 in post-work protocol with full hybrid logic (fix small issues inline, create tracking issues for large/unrelated ones, skip if user declines).
- **`agents/devops/commands/devops.md`**: Added docs validation step before commit delegation.
- **`agents/devops/commands/deploy.md`**: Same.
- **`agents/devops/commands/infra.md`**: Same.
- **`agents/devops/commands/scaffold.md`**: Same.

## Design

- **Skippable**: Agent asks the user before running validation — avoids noise on trivial commits.
- **Hybrid**: Small related fixes go inline (same commit). Large or unrelated issues become GitHub issues with `docs` label.
- **No new tools**: Uses existing `readme-validate` and `@docs` delegation — pure prompt changes.
- **`cleanup.md` excluded**: Branch pruning has no code changes, so no docs validation needed.

## Related Issues

Closes #9