### PR TITLE
fix: add local branch cleanup step to devops post-work protocol

### DIFF
--- a/agents/devops/agent.md
+++ b/agents/devops/agent.md
@@ -238,6 +238,9 @@ After completing the requested work:
    - Links back to the issue using `Closes #<number>` in the body
    - Uses `delete_branch: true` so the remote branch is cleaned up on merge
 4. **Report back** -- Summarize what was done, the PR URL, and the linked issue.
+5. **Local cleanup** -- After the PR is created, switch back to `main`,
+   pull latest changes, delete the local feature branch, and run
+   `git fetch --prune` to clean up stale remote-tracking references.
 
 ## Safety Rules
 


### PR DESCRIPTION
## Summary

Issue #5 was largely already implemented (`branch-cleanup.ts`, `/cleanup` command, `delete_branch: true` in PR creation). The only gap was that the post-work protocol didn't instruct the agent to clean up the local branch after PR creation.

## Changes

- **`agents/devops/agent.md`**: Added step 5 to the post-work protocol — after creating the PR, switch back to `main`, pull latest, delete the local feature branch, and run `git fetch --prune`.

## Related Issues

Closes #5