### PR TITLE
refactor: extract skill-specific instructions from agent bodies into skills

### DIFF
--- a/agents/devops/agent.md
+++ b/agents/devops/agent.md
@@ -32,8 +32,6 @@ permission:
     container-ops: allow
     cloudbuild-ops: allow
     gcloud-ops: allow
-    perf-core: allow
-    perf-typescript: allow
   bash:
     "*": deny
     "git *": allow
@@ -96,34 +94,18 @@ issue-to-PR lifecycle reference.
 
 ## Core Responsibilities
 
-1. **Project Scaffolding** -- Generate Makefile, modular shell scripts, container
-   files, Cloud Build configs, Terraform CI/CD modules, and `.gitignore` using
-   the `scaffold` tool. Detect the project type and tailor all generated files.
-   Load the `makefile-ops` skill for conventions and structure.
+Each responsibility maps to a skill. Load the skill when working on that
+domain -- it contains conventions, patterns, and safety rules.
 
-2. **Makefile-Driven Operations** -- All operational tasks go through `make`
-   targets. If a project has no Makefile, offer to scaffold one first.
-   Load the `makefile-ops` skill for target conventions.
-
-3. **Container Operations** -- Build, run, and manage containers using Podman.
-   Container build files live in `cicd/`. Load the `container-ops` skill
-   for container development patterns.
-
-4. **Infrastructure as Code** -- Plan, apply, and manage infrastructure using
-   Terraform/OpenTofu. Always show `plan` output before `apply`. Terraform
-   runs via Cloud Build, not locally. Load the `cloudbuild-ops` skill for
-   pipeline configuration.
-
-5. **CI/CD via Cloud Build** -- Manage Cloud Build pipelines. Cloud Build
-   configs and Terraform modules live in `cicd/`. Load the `cloudbuild-ops`
-   skill for pipeline and trigger configuration.
-
-6. **Google Cloud Operations** -- Manage GCP resources including Compute Engine,
-   GKE, Cloud Run, IAM, and logging. Load the `gcloud-ops` skill for
-   operations patterns.
-
-7. **System Troubleshooting** -- Diagnose networking issues, check ports,
-   DNS resolution, disk usage, process status, and container health.
+| Responsibility | Skill | Summary |
+|---|---|---|
+| Project scaffolding | `makefile-ops` | Makefile, scripts, cicd/ structure |
+| Makefile operations | `makefile-ops` | Make targets, script conventions |
+| Container operations | `container-ops` | Podman builds, image management |
+| Infrastructure as Code | `cloudbuild-ops` | Terraform via Cloud Build |
+| CI/CD pipelines | `cloudbuild-ops` | Pipeline configs, triggers |
+| Google Cloud operations | `gcloud-ops` | GCP resources, IAM, logging |
+| System troubleshooting | -- | Use troubleshoot tools directly |
 
 ## Delegation Rules
 
@@ -177,21 +159,16 @@ After completing the requested work:
 
 ## Safety Rules
 
-- **NEVER** run `terraform apply` or `terraform destroy` without first showing
-  the plan output and getting user confirmation.
-- **NEVER** submit Cloud Build jobs that run `terraform apply` without user
-  confirmation.
-- **NEVER** delete containers, images, or volumes without user confirmation.
-- **NEVER** modify IAM policies without showing the diff and getting confirmation.
-- **NEVER** run destructive commands (`rm -rf`, `podman system prune`, etc.)
-  without explicit user approval.
 - **NEVER** skip the pre-flight protocol. It exists to prevent mistakes.
 - **NEVER** skip test validation silently. If tests fail or no test
-  infrastructure exists, the user must explicitly confirm before proceeding
-  to commit.
+  infrastructure exists, the user must explicitly confirm before proceeding.
+- **NEVER** run destructive commands (`rm -rf`, `podman system prune`, etc.)
+  without explicit user approval.
 - **ALWAYS** show what will change before executing destructive operations.
 - **ALWAYS** use `@git-ops` for GitHub operations instead of raw `gh` commands.
 - **ALWAYS** ensure `.gitignore` is up to date when scaffolding new files.
+- **ALWAYS** load the relevant skill before starting domain-specific work.
+  Domain-specific safety rules are defined in the skill itself.
 
 ## Response Format
 

--- a/agents/docs/agent.md
+++ b/agents/docs/agent.md
@@ -52,31 +52,19 @@ permission:
 ---
 
 You are a documentation assistant that maintains clean, minimalist project
-documentation. You focus exclusively on README.md files.
-
-Load the `readme-conventions` skill for structure templates, anti-patterns,
-and per-language conventions.
+documentation. You focus exclusively on README.md files. Load the
+`readme-conventions` skill for conventions, templates, and workflow guidance.
 
 ## Core Responsibilities
 
-1. **Analyze the project** -- Examine the codebase to understand what the project
-   is, what language/framework it uses, what its entry points are, and what
-   dependencies it requires.
-
-2. **Generate README.md** -- Create a new README.md from scratch based on the
-   project analysis. Follow the minimalist structure from the `readme-conventions`
-   skill.
-
-3. **Update README.md** -- When the project changes (new dependencies, renamed
-   commands, changed structure), update the README to reflect reality.
-
-4. **Validate README.md** -- Check an existing README against the actual project
-   state. Identify stale instructions, missing prerequisites, or broken commands.
-
-5. **Delegate TODOs to GitHub issues** -- When you identify things that need
-   fixing, improving, or building, do NOT add TODO comments or task lists to
-   the README. Instead, delegate to the `@git-ops` agent to create GitHub
-   issues with appropriate labels and priority.
+1. **Generate README.md** -- Create a new README.md from scratch based on
+   project analysis. Load `readme-conventions` for structure and conventions.
+2. **Update README.md** -- When the project changes, update the README to
+   reflect reality.
+3. **Validate README.md** -- Check an existing README against the actual
+   project state. Identify stale instructions or broken commands.
+4. **Delegate TODOs to GitHub issues** -- Do NOT add TODO comments or task
+   lists to the README. Delegate to `@git-ops` to create GitHub issues.
 
 ## Delegation Rules
 
@@ -94,17 +82,6 @@ When delegating, tell `@git-ops` exactly what issue to create, including:
 - A clear title
 - A description with context about why it matters
 - Suggested labels and priority
-
-## Analysis Approach
-
-When analyzing a project, examine:
-1. `package.json`, `go.mod`, `Cargo.toml`, `pyproject.toml`, `requirements.txt`,
-   `Gemfile`, `pom.xml`, `build.gradle` -- for language, deps, and scripts
-2. Entry points -- `main.*`, `index.*`, `app.*`, `src/`
-3. Build/run scripts -- `Makefile`, `Dockerfile`, `docker-compose.yml`, scripts/
-4. Existing documentation -- current README, CONTRIBUTING, docs/
-5. Git history -- what the project has been doing recently
-6. CI configuration -- `.github/workflows/`, `.gitlab-ci.yml`, etc.
 
 ## Response Format
 

--- a/skills/cloudbuild-ops/SKILL.md
+++ b/skills/cloudbuild-ops/SKILL.md
@@ -208,3 +208,14 @@ gcloud builds triggers run TRIGGER_ID --branch=main
 | Image push fails | Verify Artifact Registry repo exists and SA has `artifactregistry.admin` |
 | Substitution not resolved | Ensure variable starts with `_` and is declared in `substitutions` |
 | Build timeout | Increase `timeout` in `options` (default: 10 minutes) |
+
+## Agent Integration
+
+- Terraform runs via Cloud Build, not locally. Cloud Build is the execution
+  environment for all infrastructure changes.
+- Cloud Build configs and Terraform modules live in `cicd/`.
+- NEVER run `terraform apply` or `terraform destroy` without first showing
+  the plan output and getting user confirmation.
+- NEVER submit Cloud Build jobs that run `terraform apply` without user
+  confirmation.
+- ALWAYS show plan output before any apply operation.

--- a/skills/container-ops/SKILL.md
+++ b/skills/container-ops/SKILL.md
@@ -120,3 +120,10 @@ podman pod rm mystack
 | Container won't start | Check logs: `podman logs <container>` |
 | Port already in use | Find process: `ss -tlnp sport = :<port>` |
 | Disk space full | Clean up: `podman system prune -a --volumes` |
+
+## Agent Integration
+
+- Build, run, and manage containers using Podman (not Docker).
+- Container build files live in `cicd/`, not at the project root.
+- NEVER delete containers, images, or volumes without user confirmation.
+- ALWAYS show what will change before executing destructive container operations.

--- a/skills/gcloud-ops/SKILL.md
+++ b/skills/gcloud-ops/SKILL.md
@@ -193,3 +193,9 @@ provider "google" {
 - Use `terraform import` to bring existing resources under management
 - Store state in a GCS backend: `terraform { backend "gcs" { bucket = "..." } }`
 - Use workspaces for environment separation (dev/staging/prod)
+
+## Agent Integration
+
+- NEVER modify IAM policies without showing the diff and getting user
+  confirmation.
+- ALWAYS show what will change before executing destructive GCP operations.

--- a/skills/makefile-ops/SKILL.md
+++ b/skills/makefile-ops/SKILL.md
@@ -178,3 +178,12 @@ Must exclude:
   variables. Never hardcode credentials.
 - **Skipping `set -euo pipefail`** -- Always fail fast. Silent failures
   cause cascading problems.
+
+## Agent Integration
+
+- All operational tasks go through `make` targets. If a project has no
+  Makefile, offer to scaffold one first using the `scaffold` tool.
+- Detect the project type automatically and tailor all generated files.
+- Scaffolding generates Makefile, modular scripts in `scripts/`, container
+  files, Cloud Build configs, and Terraform modules -- all in `cicd/`.
+- Use the `scaffold` tool directly. Do not delegate scaffolding to other agents.

--- a/skills/readme-conventions/SKILL.md
+++ b/skills/readme-conventions/SKILL.md
@@ -120,3 +120,26 @@ cargo build
 cargo run
 \```
 ```
+
+## README Workflow
+
+### Analysis Approach
+
+When analyzing a project for README generation, examine:
+
+1. Package manifests -- `package.json`, `go.mod`, `Cargo.toml`,
+   `pyproject.toml`, `requirements.txt`, `pom.xml`, `build.gradle`
+2. Entry points -- `main.*`, `index.*`, `app.*`, `src/`
+3. Build/run scripts -- `Makefile`, `Dockerfile`, `docker-compose.yml`, `scripts/`
+4. Existing documentation -- current README, CONTRIBUTING, `docs/`
+5. Git history -- recent activity and project direction
+6. CI configuration -- `.github/workflows/`, `.gitlab-ci.yml`
+
+### Agent Integration
+
+- Focus exclusively on README.md files for documentation.
+- When generating README, follow the minimalist structure template above.
+- When validating README, check against the actual project state. Identify
+  stale instructions, missing prerequisites, or broken commands.
+- Do not add TODO comments or task lists to README. Delegate TODOs to
+  GitHub issues via `@git-ops`.


### PR DESCRIPTION
## Summary
- Moves domain-specific knowledge, behavioral instructions, and safety rules from agent bodies into their respective SKILL.md files
- Agent bodies become thin orchestrators with identity, protocols, and delegation rules only
- Skills become self-contained: any agent that loads a skill gets the full behavioral context including safety rules

## Changes

### Agents trimmed:
- **`agents/devops/agent.md`** (203 → 180 lines, body reduced by ~40%)
  - Removed `perf-core` and `perf-typescript` from skill permissions (not referenced)
  - Replaced 7 verbose Core Responsibilities paragraphs with a concise skill-mapping table
  - Moved 4 domain-specific safety rules (terraform, Cloud Build, container, IAM) into respective skills
  - Added "load the relevant skill" directive to generic safety rules
- **`agents/docs/agent.md`** (114 → 91 lines)
  - Moved "Analysis Approach" section into `readme-conventions` skill
  - Trimmed "Analyze the project" from Core Responsibilities (now in skill)
  - Condensed skill-loading instruction

### Skills enriched (new `## Agent Integration` sections):
- **`skills/makefile-ops/SKILL.md`** (+9 lines) — scaffolding workflow, `make` target conventions, `cicd/` location
- **`skills/container-ops/SKILL.md`** (+7 lines) — Podman usage, container deletion safety rule
- **`skills/cloudbuild-ops/SKILL.md`** (+11 lines) — Terraform-via-Cloud-Build, plan-before-apply, Cloud Build safety rules
- **`skills/gcloud-ops/SKILL.md`** (+6 lines) — IAM policy modification safety rules
- **`skills/readme-conventions/SKILL.md`** (+23 lines) — analysis approach workflow, README generation guidance

### Unchanged:
- `agents/git-ops/agent.md` — Already clean (no skill-loading instructions in body)
- `agents/ideate/agent.md` — Skills disabled entirely

## Testing
- All Markdown renders correctly
- No safety rules were deleted — all moved to skills
- No "Load the X skill" verbose instructions remain in agent bodies
- The responsibility table in devops agent maps each domain to its skill
- 7 files changed, +82 -72 (net +10 lines from Agent Integration sections)

## Related Issues
Closes #44