### PR TITLE
feat: add agent delegation routing for Build and Plan agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,39 @@
+# Project Agent Delegation
+
+This project uses specialized agents for different domains. The primary agents
+(Build and Plan) MUST delegate to the appropriate specialist agent using the
+Task tool instead of handling these tasks directly.
+
+## Delegation Table
+
+| When the user asks about... | Delegate to | The agent handles... |
+|---|---|---|
+| Issues, PRs, commits, branches, reviews, releases | `@git-ops` | All Git and GitHub operations with safety rails and conventional commits |
+| Scaffolding, containers, Terraform, CI/CD, GCP, deployment | `@devops` | Issue-driven DevOps workflows with pre-flight checks |
+| README, documentation | `@docs` | Minimalist README maintenance and validation |
+| Brainstorming, ideation, feature exploration | `@ideate` | Audience-first creative ideation with structured evaluation |
+
+## Rules
+
+1. **ALWAYS delegate** — Do not attempt tasks in the delegation table directly.
+   Use the Task tool to invoke the specialist agent.
+2. **Provide full context** — When delegating, pass the user's complete request
+   and any relevant context (file paths, issue numbers, branch names).
+3. **Trust the specialist** — Do not second-guess or redo the specialist's work.
+   Report their results back to the user.
+4. **Multi-step workflows** — If a task spans multiple domains (e.g., "fix this
+   bug, commit, and open a PR"), delegate each step to the appropriate agent
+   in sequence.
+
+## Quick Reference
+
+- "create an issue" / "file a bug" / "track this" → `@git-ops`
+- "commit these changes" / "open a PR" / "merge" → `@git-ops`
+- "review this PR" / "create a release" → `@git-ops`
+- "scaffold a Makefile" / "set up CI/CD" → `@devops`
+- "deploy this" / "run terraform plan" → `@devops`
+- "build the container" / "manage pods" → `@devops`
+- "update the README" / "generate docs" → `@docs`
+- "validate documentation" / "check the README" → `@docs`
+- "brainstorm ideas" / "explore features" → `@ideate`
+- "what should we build?" / "creative session" → `@ideate`

--- a/opencode.json
+++ b/opencode.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "agent": {
+    "build": {
+      "prompt": "{file:.opencode/prompts/build.md}",
+      "tools": {
+        "gh-issue_*": false,
+        "gh-pr_*": false,
+        "gh-release_*": false,
+        "gh-review_*": false,
+        "git-branch_*": false,
+        "git-commit_*": false,
+        "git-conflict_*": false,
+        "git-ops-init": false,
+        "git-ops-init_*": false,
+        "git-status_*": false,
+        "scaffold_*": false,
+        "cloudbuild_*": false,
+        "podman_*": false,
+        "gcloud_*": false,
+        "terraform_*": false,
+        "troubleshoot_*": false,
+        "devops-preflight_*": false,
+        "branch-cleanup_*": false,
+        "readme-analyze": false,
+        "readme-scaffold": false,
+        "readme-validate": false
+      }
+    },
+    "plan": {
+      "prompt": "{file:.opencode/prompts/plan.md}"
+    }
+  }
+}

--- a/prompts/build.md
+++ b/prompts/build.md
@@ -1,0 +1,16 @@
+You are the Build agent with full access to file operations and system commands
+for implementation work.
+
+## Delegation
+
+This project has specialist agents for specific domains. You MUST delegate
+to them instead of handling their domains directly. See the AGENTS.md file
+for the full delegation table.
+
+Key delegations:
+- Git/GitHub operations (issues, PRs, commits, reviews, releases) → delegate to `@git-ops`
+- DevOps/infrastructure (scaffolding, containers, Terraform, CI/CD) → delegate to `@devops`
+- Documentation (README maintenance) → delegate to `@docs`
+- Brainstorming/ideation → delegate to `@ideate`
+
+Use the Task tool to invoke these agents. Provide the user's full request as context.

--- a/prompts/plan.md
+++ b/prompts/plan.md
@@ -1,0 +1,13 @@
+You are the Plan agent. You analyze code and create plans without making changes.
+
+## Delegation
+
+This project has specialist agents. When the user's request falls into a
+specialist domain, recommend delegation:
+
+- For brainstorming/ideation → suggest the user invoke `@ideate` or use `/ideate`
+- For implementation planning that involves DevOps → note that `@devops` should handle execution
+- For documentation analysis → suggest `@docs` for README validation
+
+Since you are read-only, you cannot delegate via the Task tool yourself.
+Instead, clearly recommend which agent should handle the execution phase.


### PR DESCRIPTION
## Summary

- **`AGENTS.md`** — Delegation routing table mapping user intents to specialist agents (`@git-ops`, `@devops`, `@docs`, `@ideate`), with rules for delegation behavior and a quick-reference phrase guide
- **`opencode.json`** — Configures Build agent tool restrictions (disables all 21 specialist tool patterns) and references prompt files for both Build and Plan agents
- **`prompts/build.md`** — Build agent prompt reinforcing delegation via Task tool to specialist agents
- **`prompts/plan.md`** — Plan agent prompt recommending specialist agents for execution (read-only, cannot delegate directly)
- **`install.sh`** — Updated to deploy prompt files to `.opencode/prompts/` and project-root config files (`AGENTS.md`, `opencode.json`) to target projects, with skip-if-exists safety

### Design Decisions

- Build agent retains `read`, `write`, `edit`, `bash`, `Task` for implementation work — only specialist tools are restricted
- Plan agent gets prompt guidance only (no tool restrictions needed since it's read-only)
- `AGENTS.md` lives at project root for visibility to all agents and repo users
- Installer follows existing patterns: centralized source dirs → `.opencode/` target, with link/copy modes and skip-if-exists for root files

Closes #46