### PR TITLE
feat: add /implement and /create-and-plan slash commands

### DIFF
--- a/commands/create-and-plan.md
+++ b/commands/create-and-plan.md
@@ -1,0 +1,23 @@
+---
+description: Create a feature request issue and plan its implementation
+agent: devops
+---
+
+$ARGUMENTS
+
+1. Delegate to @git-ops to create a GitHub issue:
+   - Derive a clear title from the description
+   - Write a well-structured body with Summary, Scope, and Acceptance
+     Criteria sections
+   - Apply appropriate labels (feature, bug, chore, and priority level)
+   - Return the issue number
+
+2. Analyze the codebase to understand existing patterns, conventions,
+   and files that will need to be created or modified
+
+3. Write a detailed implementation plan as a comment on the issue:
+   - Prerequisites and delivery details (files, branch name)
+   - Step-by-step implementation instructions with specific content
+   - Verification checklist
+
+4. Report the issue URL and a summary of the plan

--- a/commands/implement.md
+++ b/commands/implement.md
@@ -1,0 +1,20 @@
+---
+description: Implement an issue from its plan, commit, create PR, and optionally merge
+agent: devops
+---
+
+Implement issue #$ARGUMENTS
+
+1. Run full pre-flight checks for the issue
+2. Read the issue and find the implementation plan (look for a comment
+   containing "## Implementation Plan")
+3. If no plan exists, stop and tell the user to add a plan first
+4. Execute each step in the plan sequentially
+5. After all steps are complete, follow the post-work protocol:
+   - Run test validation
+   - Stage and commit with conventional commit message referencing the issue
+   - Create a PR that closes the issue
+6. Report the PR URL and a summary of changes made
+7. Ask the user: "PR #N is ready to merge. Merge? [yes/no]"
+   - If yes, squash merge the PR and delete the branch
+   - If no, leave the PR open for manual review


### PR DESCRIPTION
## Summary
- Adds two new slash commands that automate the issue-to-merge lifecycle
- Commands compose together: `/create-and-plan` creates an issue with a plan, `/implement` executes it

## Changes
- **`commands/implement.md`** (18 lines) — Delegates to devops agent. Reads implementation plan from issue, executes steps, commits, creates PR, asks user to confirm merge.
- **`commands/create-and-plan.md`** (22 lines) — Delegates to devops agent. Creates a feature request issue via @git-ops, analyzes codebase, writes implementation plan as issue comment.

## Usage

```
/create-and-plan add a rust-pro skill for pro Rust engineering
```
Creates issue #N with a detailed implementation plan.

```
/implement 42
```
Reads plan from issue #42, implements all steps, creates PR, asks "Merge? [yes/no]".

## Design Decisions
- `/implement` always asks for merge confirmation (not automatic) — preserves human checkpoint
- `/create-and-plan` delegates to `devops` agent which orchestrates `@git-ops` for issue creation
- Both follow existing command conventions (frontmatter with description + agent, `$ARGUMENTS`, structured instructions)
- Merge uses squash merge + branch deletion (matching project conventions)

## Related Issues
Closes #48