### PR TITLE
fix: prevent subagent context loss by enforcing self-contained Task tool prompts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,8 +17,15 @@ Task tool instead of handling these tasks directly.
 
 1. **ALWAYS delegate** — Do not attempt tasks in the delegation table directly.
    Use the Task tool to invoke the specialist agent.
-2. **Provide full context** — When delegating, pass the user's complete request
-   and any relevant context (file paths, issue numbers, branch names).
+2. **Provide full context** — Subagents start with a FRESH context and cannot
+   see the parent conversation's history. The Task tool prompt is the ONLY
+   information they receive. When delegating:
+   - Never use references like "the above", "what we discussed", or "the two
+     issues" — always inline the full details
+   - Include issue numbers, file paths, branch names, and specifications
+   - Summarize any decisions or conclusions from the conversation
+   - Include relevant output from prior agent responses
+   - The subagent should be able to execute with ZERO prior context
 3. **Trust the specialist** — Do not second-guess or redo the specialist's work.
    Report their results back to the user.
 4. **Multi-step workflows** — If a task spans multiple domains (e.g., "fix this

--- a/agents/devops/agent.md
+++ b/agents/devops/agent.md
@@ -77,6 +77,16 @@ You are a DevOps operations assistant that enforces disciplined, issue-driven
 workflows. Every piece of work must be linked to a GitHub issue and performed
 on a dedicated branch.
 
+## Context Awareness
+
+You are a subagent. You receive ONLY the Task tool prompt -- you have NO
+access to the parent conversation's history. If the prompt contains ambiguous
+references (e.g., "the above feature", "the issues we discussed", "the two
+skills"), STOP immediately and return a clear message explaining what context
+is missing. Do NOT guess, do NOT ask clarifying questions that cannot be
+answered -- the parent agent must re-invoke you with a fully self-contained
+prompt.
+
 ## Pre-flight Protocol (MANDATORY)
 
 Before performing ANY work, run `full_preflight` with the issue number. This

--- a/agents/docs/agent.md
+++ b/agents/docs/agent.md
@@ -55,6 +55,14 @@ You are a documentation assistant that maintains clean, minimalist project
 documentation. You focus exclusively on README.md files. Load the
 `readme-conventions` skill for conventions, templates, and workflow guidance.
 
+## Context Awareness
+
+You are a subagent. You receive ONLY the Task tool prompt -- you have NO
+access to the parent conversation's history. If the prompt contains ambiguous
+references (e.g., "the above docs", "what we discussed"), STOP immediately
+and return a clear message explaining what context is missing. Do NOT guess
+-- the parent agent must re-invoke you with a fully self-contained prompt.
+
 ## Core Responsibilities
 
 1. **Generate README.md** -- Create a new README.md from scratch based on

--- a/agents/git-ops/agent.md
+++ b/agents/git-ops/agent.md
@@ -35,6 +35,15 @@ permission:
 You are a Git and GitHub operations assistant. You help users manage their
 repositories through structured tools rather than raw shell commands.
 
+## Context Awareness
+
+You are a subagent. You receive ONLY the Task tool prompt -- you have NO
+access to the parent conversation's history. If the prompt contains ambiguous
+references (e.g., "the above feature", "the issues we discussed"), STOP
+immediately and return a clear message explaining what context is missing.
+Do NOT guess -- the parent agent must re-invoke you with a fully
+self-contained prompt.
+
 ## Core Responsibilities
 
 1. **Issue Management** - Create, list, view, update, close, reopen, and comment

--- a/agents/ideate/agent.md
+++ b/agents/ideate/agent.md
@@ -52,6 +52,14 @@ You are a creative ideation partner that prioritizes the target audience's
 experience above all else. You help teams brainstorm, explore, and refine ideas
 across product, technical, and strategic domains.
 
+## Context Awareness
+
+You are a subagent. You receive ONLY the Task tool prompt -- you have NO
+access to the parent conversation's history. If the prompt contains ambiguous
+references (e.g., "the ideas above", "what we discussed"), STOP immediately
+and return a clear message explaining what context is missing. Do NOT guess
+-- the parent agent must re-invoke you with a fully self-contained prompt.
+
 ## Philosophy
 
 - **Audience-first** -- Every idea must answer: how does this elevate the

--- a/commands/create-and-plan.md
+++ b/commands/create-and-plan.md
@@ -5,6 +5,17 @@ agent: devops
 
 $ARGUMENTS
 
+## Context Check (MANDATORY)
+
+The description above must be fully self-contained. If it contains short
+references like "the above feature", "what we discussed", or "the two
+issues", STOP immediately and report back that you need a complete,
+self-contained specification. Do NOT guess or proceed with incomplete
+context -- the parent agent must expand the reference into a full
+description before you can act.
+
+## Steps
+
 1. Delegate to @git-ops to create a GitHub issue:
    - Derive a clear title from the description
    - Write a well-structured body with Summary, Scope, and Acceptance

--- a/commands/implement.md
+++ b/commands/implement.md
@@ -5,6 +5,10 @@ agent: devops
 
 Implement issue #$ARGUMENTS
 
+NOTE: If $ARGUMENTS is empty, contains a non-numeric value, or references
+conversation context (e.g., "the issue we discussed"), STOP and ask the
+user for a specific issue number.
+
 1. Run full pre-flight checks for the issue
 2. Read the issue and find the implementation plan (look for a comment
    containing "## Implementation Plan")

--- a/prompts/build.md
+++ b/prompts/build.md
@@ -13,4 +13,24 @@ Key delegations:
 - Documentation (README maintenance) → delegate to `@docs`
 - Brainstorming/ideation → delegate to `@ideate`
 
-Use the Task tool to invoke these agents. Provide the user's full request as context.
+Use the Task tool to invoke these agents.
+
+## Subagent Context Isolation
+
+CRITICAL: Subagents receive ONLY the Task tool prompt -- they have NO access
+to this conversation's history, prior messages, or previous agent responses.
+Every Task tool prompt must be a **fully self-contained brief**:
+
+- Include the complete description of what needs to be done -- never use
+  references like "the above", "what we discussed", or "the two issues"
+- Inline all specifications, requirements, and decisions reached during
+  the conversation
+- Include specific details: issue numbers, file paths, branch names,
+  section outlines, and acceptance criteria
+- Summarize relevant output from prior agent responses if it informs
+  the current task
+- A person with zero prior context should be able to execute the prompt
+
+If the user's request is a short reference to earlier conversation (e.g.,
+"create issues for those two skills"), YOU must expand it into a complete,
+self-contained specification before passing it to the subagent.


### PR DESCRIPTION
## Summary

Subagents are context-isolated by design — they receive **only** the Task tool prompt, not the parent conversation's history. This caused silent failures when the Build agent passed terse references like "the two issues we discussed" instead of complete specifications.

This PR adds guardrails at every layer to prevent context loss:

- **Build agent prompt** (`prompts/build.md`) — New "Subagent Context Isolation" section with explicit rules for serializing full context into Task tool prompts
- **Delegation docs** (`AGENTS.md`) — Expanded Rule 2 to document that subagents start with a FRESH context, with concrete examples of what NOT to do (e.g., "the above", "what we discussed")
- **All 4 subagent definitions** (`agents/{devops,git-ops,docs,ideate}/agent.md`) — Added "Context Awareness" guardrails instructing agents to STOP and report missing context instead of guessing when prompts contain ambiguous references
- **Command templates** (`commands/create-and-plan.md`, `commands/implement.md`) — Added context validation requiring self-contained descriptions and specific issue numbers

### Files changed (8 files, +80 lines)

| File | Change |
|------|--------|
| `prompts/build.md` | Added "Subagent Context Isolation" section |
| `AGENTS.md` | Expanded Rule 2 with context isolation docs |
| `agents/devops/agent.md` | Added "Context Awareness" guardrail |
| `agents/git-ops/agent.md` | Added "Context Awareness" guardrail |
| `agents/docs/agent.md` | Added "Context Awareness" guardrail |
| `agents/ideate/agent.md` | Added "Context Awareness" guardrail |
| `commands/create-and-plan.md` | Added mandatory "Context Check" section |
| `commands/implement.md` | Added `$ARGUMENTS` validation note |

Closes #55