### PR TITLE
feat(skills): add system design skill family — core, web3, defi, arbitrage

### DIFF
--- a/skills/design-arbitrage/SKILL.md
+++ b/skills/design-arbitrage/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: design-arbitrage
+description: Latency-sensitive trading and arbitrage system design — execution engines, risk management, and cross-venue patterns
+---
+
+## What I do
+
+- Provide architecture frameworks for latency-sensitive trading systems
+- Document tick-to-trade pipeline design and execution engine patterns
+- Define risk management as a first-class design constraint
+- Cover cross-venue and cross-chain arbitrage patterns
+
+## When to use me
+
+Use this skill when designing trading systems, arbitrage bots, or
+latency-sensitive execution infrastructure. Pair with `design-core` for
+foundational design principles and decision frameworks.
+
+## Latency Budget Framework
+
+Allocate your total latency budget across pipeline stages. Every microsecond
+matters -- measure, don't guess.
+
+| Pipeline Stage | Target (CEX) | Target (DEX) | Optimization Lever |
+|---|---|---|---|
+| Market data ingestion | <100 us | <10 ms | Binary protocols, kernel bypass, co-location |
+| Signal generation | <50 us | <5 ms | Pre-computed tables, SIMD, branch-free logic |
+| Risk check | <10 us | <1 ms | Lock-free data structures, pre-validated limits |
+| Order construction | <20 us | <5 ms | Pre-built templates, connection pooling |
+| Network transit | <1 ms | <100 ms | Co-location, direct market access, private mempools |
+| Execution confirmation | <5 ms | 1-12 s | Optimistic execution, parallel confirmation |
+
+**Rule:** Measure end-to-end latency at p99, not p50. The tail kills profits.
+
+## Tick-to-Trade Pipeline Architecture
+
+```
+Market Data Feed(s)
+  |
+  v
+Feed Handler (normalize, deduplicate, sequence)
+  |
+  v
+Order Book Reconstruction (L2/L3 book maintenance)
+  |
+  v
+Signal Engine (strategy logic, opportunity detection)
+  |
+  v
+Risk Gate (pre-trade checks, position limits, exposure)
+  |
+  v
+Execution Engine (order routing, smart order routing)
+  |
+  v
+Confirmation Handler (fill tracking, position update)
+  |
+  v
+Post-Trade (reconciliation, PnL, reporting)
+```
+
+**Critical path:** Feed Handler -> Signal -> Risk -> Execution. Everything
+else is off the hot path. Never add latency to the critical path for
+logging, metrics, or persistence.
+
+## Market Data Normalization & Distribution
+
+- **Feed handlers** -- One per venue. Normalize to internal format at the
+  edge. Binary protocols (FIX/FAST, WebSocket binary) over JSON.
+- **Order book reconstruction** -- Maintain local order book from incremental
+  updates. Detect gaps and request snapshots. Never trust stale books.
+- **Multi-venue aggregation** -- Merge books across venues for best
+  bid/offer (BBO). Account for fees, latency, and fill probability.
+- **Distribution** -- Shared memory or lock-free ring buffers for
+  intra-process. Kernel bypass (DPDK, io_uring) for inter-process.
+
+## Execution Engine Patterns
+
+| Pattern | Latency | Complexity | Best For |
+|---|---|---|---|
+| Event-driven (single-threaded) | Lowest | Low | Simple strategies, single venue |
+| Actor model | Low | Medium | Multi-strategy, multi-venue |
+| Lock-free pipeline | Very low | High | Ultra-low-latency, dedicated hardware |
+| Thread-per-venue | Medium | Low | Moderate latency requirements |
+
+**Default choice:** Event-driven single-threaded for simplicity. Move to
+lock-free pipeline only when measured latency demands it.
+
+### Smart Order Routing
+
+- **Venue selection** -- Route to venue with best price after fees. Factor
+  in historical fill rates and latency.
+- **Order splitting** -- Split large orders across venues to minimize
+  market impact. Use TWAP/VWAP for size.
+- **Retry logic** -- Rejected orders retry on alternate venues. Never
+  retry without checking current position and risk limits.
+
+## Risk Management as Design Constraint
+
+Risk checks are on the critical path. They must be fast AND correct.
+
+| Risk Check | Enforcement | Bypass = |
+|---|---|---|
+| Position limits | Per-instrument and portfolio-wide | Unbounded loss exposure |
+| Notional limits | Maximum value per order and per time window | Single trade blows up account |
+| Loss limits | Daily, hourly, per-strategy drawdown limits | Bleeding capital on broken strategy |
+| Rate limits | Maximum orders per second per venue | Exchange ban, API revocation |
+| Kill switch | Hardware or software emergency stop | No way to stop a runaway system |
+
+**Kill switch is non-negotiable.** It must work independently of the trading
+system. Hardware kill switch preferred. Test it weekly.
+
+## Co-location & Infrastructure Decisions
+
+- **Co-locate** when latency is the primary competitive advantage
+- **Central hub** with low-latency links for cross-venue strategies
+- **Own node** for DEX strategies; connect to block builders / private mempools
+- **Cloud** in nearest region for moderate latency requirements
+- **Hardware** -- FPGA for nanosecond-critical feed handling; GPU for parallel
+  signal computation; commodity hardware for everything else
+- **Network** -- Dedicated NICs, kernel bypass (DPDK), jumbo frames.
+  Measure and minimize jitter, not just average latency.
+
+## Cross-venue / Cross-chain Arbitrage Patterns
+
+| Pattern | Execution | Risk | Latency |
+|---|---|---|---|
+| CEX-CEX | Simultaneous limit orders | Leg risk (partial fill) | Microseconds |
+| CEX-DEX | CEX order + DEX swap | Leg risk + MEV extraction | Milliseconds-seconds |
+| DEX-DEX (same chain) | Atomic via flash loan or multicall | No leg risk if atomic | Block time |
+| DEX-DEX (cross-chain) | Bridge or intent-based | Bridge risk + timing risk | Minutes |
+| Atomic (flash loan) | Borrow, swap, repay in one tx | Reverts if unprofitable | Block time |
+
+**Atomic execution eliminates leg risk** but limits you to single-chain,
+single-block opportunities. Non-atomic execution accesses more opportunities
+but requires hedging and position management.
+
+## Anti-Patterns
+
+| Anti-Pattern | Why It Fails | What To Do Instead |
+|---|---|---|
+| GC in hot path | Stop-the-world pauses cause missed opportunities | Use GC-free languages (C, Rust) or pre-allocate in Java/Go |
+| Unnecessary serialization | JSON/protobuf encoding adds microseconds per message | Use shared memory, zero-copy, or fixed-size binary formats |
+| Blocking I/O in critical path | Thread blocks waiting for network; latency spikes | Non-blocking I/O, io_uring, or dedicated I/O threads |
+| No kill switch | Runaway system trades until account is empty | Independent kill switch; test weekly |
+| Untested failover | Primary fails; backup has never been tested | Regular failover drills; automated health checks |
+| Logging on hot path | Disk I/O or lock contention in critical path | Async logging with ring buffer; sample in hot path |
+| Backtesting without slippage | Strategy looks profitable but fails with real market impact | Model slippage, fees, and latency in backtests |

--- a/skills/design-core/SKILL.md
+++ b/skills/design-core/SKILL.md
@@ -1,0 +1,179 @@
+---
+name: design-core
+description: System design foundations — first-principles thinking, evolution stages, and decision frameworks
+---
+
+## What I do
+
+- Provide first-principles decomposition for system design problems
+- Document mental models, evolution stages, and architecture decision trees
+- Define design review checklists and common anti-patterns
+- Supply cross-references to domain-specific design skills
+
+## When to use me
+
+Use this skill as the entry point for any system design task. Pair with a
+domain-specific skill (`design-web3`, `design-defi`, `design-arbitrage`)
+for specialized guidance.
+
+## Core Mental Models
+
+| Mental Model | What It Means | When To Apply |
+|---|---|---|
+| Trade-offs all the way down | Every design choice sacrifices something; make the sacrifice explicit | Architecture decisions, technology selection |
+| Boundaries first | Define system boundaries and interfaces before internals | Service decomposition, API design |
+| Complexity is debt | Every abstraction, dependency, and indirection has carrying cost | Adding components, choosing patterns |
+| Prove it works | A running prototype beats a perfect diagram | Early design phases, technology evaluation |
+| Scale is earned | Design for current load + 10x; re-architect at 100x | Capacity planning, infrastructure decisions |
+| Failure is default | Systems fail; design for graceful degradation, not perfection | Reliability engineering, error handling |
+| Delete before add | Removing complexity is more valuable than adding capability | Feature creep, refactoring decisions |
+
+## Core Principles
+
+1. **Decompose to atoms first** -- Break the problem into its smallest
+   independent sub-problems before proposing any architecture.
+2. **Simplest working system first** -- Build the simplest thing that
+   validates your core hypothesis. Add complexity only when forced by
+   real constraints.
+3. **Working software over hypothesis** -- A running, verifiable system
+   always beats a theoretical design. Ship, measure, iterate.
+4. **Make failure cheap** -- Design so that failures are detected fast,
+   blast radius is contained, and recovery is automated.
+5. **Explicit over implicit** -- State assumptions, constraints, and
+   trade-offs in writing. Implicit knowledge is a single point of failure.
+6. **Gradual evolution** -- Tune and alter incrementally as usage grows
+   or real issues emerge. Avoid big-bang rewrites.
+7. **Pragmatic over elegant** -- Choose what works and is maintainable
+   over what is theoretically beautiful.
+
+## System Evolution Stages
+
+| Stage | Scale Trigger | Architectural Response |
+|---|---|---|
+| 0 - Prototype | 0-100 users | Monolith, single database, manual deployment |
+| 1 - Validated | 100-10K users | Read replicas, CDN, CI/CD pipeline, basic monitoring |
+| 2 - Growing | 10K-100K users | Cache layer, async processing, horizontal scaling, load balancing |
+| 3 - Scaling | 100K-1M users | Service decomposition, event-driven architecture, distributed tracing |
+| 4 - Platform | 1M+ users | Multi-region, CQRS/event sourcing, dedicated teams per service |
+
+Enter each stage only when the previous stage's limits are hit. Premature
+advancement is the most common and most expensive architectural mistake.
+
+## First-Principles Decomposition Protocol
+
+1. **State the problem** -- One sentence: what must the system do?
+2. **Identify inputs, outputs, and invariants** -- What goes in, what
+   comes out, what must always be true?
+3. **Find the hardest sub-problem** -- Which component has the tightest
+   constraints (latency, consistency, throughput)?
+4. **Design the simplest solution for the hardest part** -- Solve the
+   constraint that matters most with the least complexity.
+5. **Verify with back-of-envelope math** -- Will it handle the load?
+   Storage? Bandwidth? Latency budget?
+6. **Iterate** -- Add the next hardest sub-problem. Repeat until the
+   system is complete.
+
+## Architecture Decision Trees
+
+### Data Store Selection
+
+```
+Need ACID transactions across multiple entities?
+  YES --> Relational DB (PostgreSQL, MySQL)
+  NO  |
+      v
+Need flexible schema or document storage?
+  YES --> Document DB (MongoDB, Firestore)
+  NO  |
+      v
+Need sub-millisecond key-value lookups?
+  YES --> In-memory store (Redis, Memcached)
+  NO  |
+      v
+Need full-text search?
+  YES --> Search engine (Elasticsearch, Typesense)
+  NO  |
+      v
+Need time-series or append-only writes?
+  YES --> Time-series DB (TimescaleDB, InfluxDB)
+  NO  --> Start with PostgreSQL (most versatile default)
+```
+
+### Communication Patterns
+
+```
+Need immediate response from the receiver?
+  YES --> Synchronous (HTTP/gRPC)
+  NO  |
+      v
+Need guaranteed delivery with ordering?
+  YES --> Message queue (Kafka, Pub/Sub)
+  NO  |
+      v
+Need fan-out to multiple consumers?
+  YES --> Pub/Sub (Cloud Pub/Sub, SNS)
+  NO  |
+      v
+Need real-time bidirectional communication?
+  YES --> WebSockets or SSE
+  NO  --> Async HTTP with polling or webhooks
+```
+
+### Deployment Topology
+
+```
+Single team, single service?
+  YES --> Monolith on managed compute (Cloud Run, App Engine)
+  NO  |
+      v
+Multiple teams, clear domain boundaries?
+  YES --> Service per bounded context (Kubernetes, Cloud Run)
+  NO  |
+      v
+Need extreme scale for specific components?
+  YES --> Decompose hot path only; keep the rest monolithic
+  NO  --> Modular monolith with clear internal boundaries
+```
+
+## Design Review Checklist
+
+### Simplicity
+- [ ] Can any component be removed without breaking the core use case?
+- [ ] Are there fewer than 3 synchronous hops in the critical path?
+- [ ] Is the data model normalized to the simplest correct form?
+- [ ] Could a simpler technology achieve the same result?
+
+### Failure Modes
+- [ ] What happens when each dependency is unavailable for 5 minutes?
+- [ ] Are timeouts, retries, and circuit breakers configured?
+- [ ] Is there a kill switch for every non-critical feature?
+- [ ] Can the system degrade gracefully under partial failure?
+
+### Evolution
+- [ ] Can the schema evolve without downtime?
+- [ ] Are service interfaces versioned?
+- [ ] Can components be replaced independently?
+- [ ] Is there a rollback plan for every deployment?
+
+## Anti-Patterns
+
+| Anti-Pattern | Why It Fails | What To Do Instead |
+|---|---|---|
+| Premature microservices | Distributed complexity without distributed team or load | Start monolithic; decompose when forced by scale or team boundaries |
+| Resume-driven architecture | Technology chosen for career value, not problem fit | Choose the most boring technology that solves the problem |
+| Diagram-driven development | Architecture diagrams without running code | Build a walking skeleton first; diagram what you built |
+| Speculative generality | Building for hypothetical future requirements | YAGNI -- build for today's requirements, design for tomorrow's |
+| Distributed monolith | Microservices that must deploy together | If services share a release cycle, they are one service |
+| Shared mutable state | Multiple services writing to the same database | Each service owns its data; communicate via APIs or events |
+| No back-of-envelope math | Designing without validating capacity assumptions | Estimate QPS, storage, bandwidth before choosing architecture |
+
+## Domain-Specific Skills
+
+After establishing foundations with this skill, load the appropriate
+domain-specific skill for specialized guidance:
+
+| Domain | Skill | Coverage |
+|---|---|---|
+| Web3 and blockchain | `design-web3` | On-chain/off-chain decisions, smart contract patterns, gas optimization |
+| DeFi protocols | `design-defi` | Protocol composability, invariant design, economic security |
+| Trading and arbitrage | `design-arbitrage` | Latency budgets, execution engines, risk management as design constraint |

--- a/skills/design-defi/SKILL.md
+++ b/skills/design-defi/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: design-defi
+description: DeFi protocol design — composability, invariant design, economic security, and attack surface analysis
+---
+
+## What I do
+
+- Provide protocol design frameworks for DeFi systems
+- Document composability risks, invariant design, and economic security analysis
+- Cover MEV exposure, governance patterns, and token economic constraints
+- Supply attack surface analysis and anti-patterns for protocol designers
+
+## When to use me
+
+Use this skill when designing DeFi protocols, analyzing economic security,
+or evaluating protocol composability. Pair with `design-core` for foundational
+design principles and `design-web3` for blockchain architecture decisions.
+
+## DeFi Protocol Taxonomy
+
+| Category | Examples | Core Mechanism | Primary Risk |
+|---|---|---|---|
+| AMM | Uniswap, Curve, Balancer | Constant-function market making | Impermanent loss, MEV extraction |
+| Lending/Borrowing | Aave, Compound, Morpho | Collateralized debt positions | Liquidation cascades, oracle failure |
+| Yield Aggregator | Yearn, Beefy | Strategy routing across protocols | Composability risk, strategy bugs |
+| Derivatives | GMX, dYdX, Synthetix | Synthetic exposure or perpetuals | Oracle manipulation, funding rate attacks |
+| Stablecoins | MakerDAO, Frax, Ethena | Peg maintenance via collateral or algorithm | De-peg events, bank run dynamics |
+| Liquid Staking | Lido, Rocket Pool | Tokenized staking positions | Validator slashing, redemption delays |
+
+## Composability Risk Matrix
+
+| Interaction | Risk Level | Failure Mode |
+|---|---|---|
+| Protocol A reads Protocol B's price | High | Oracle manipulation propagates across protocols |
+| Protocol A holds Protocol B's LP tokens | Medium | IL or exploit in B drains A's reserves |
+| Protocol A uses Protocol B as collateral | High | De-peg or exploit in B triggers cascading liquidations |
+| Protocol A routes through Protocol B | Medium | B's downtime or exploit blocks A's core function |
+| Protocol A governs Protocol B's parameters | Low-Medium | Governance attack on A compromises B |
+
+**Rule:** Every external protocol dependency is an attack surface. Map all
+dependencies before launch. Have circuit breakers for each.
+
+## Invariant Design by Protocol Type
+
+| Protocol Type | Core Invariant | Violation Consequence |
+|---|---|---|
+| AMM (x*y=k) | Reserve product is non-decreasing after fees | Funds drained via price manipulation |
+| Lending | Total borrows <= total collateral * LTV | Protocol insolvency, bad debt |
+| Stablecoin | Collateral value >= outstanding supply * target ratio | De-peg, bank run |
+| Vault/Aggregator | Share price is monotonically non-decreasing | Depositors lose principal |
+| Derivatives | Sum of all positions' PnL + fees = 0 (zero-sum) | Protocol takes unhedged directional risk |
+
+**Test invariants continuously.** Every state transition must preserve
+invariants. Fuzz with adversarial sequences, not just single operations.
+
+## Economic Security Analysis Framework
+
+1. **Oracle dependencies** -- List every price feed. What happens if each
+   returns stale data, zero, or max uint? Use TWAP over spot where possible.
+2. **Liquidation cascades** -- Model what happens when collateral drops 30%
+   in one block. Can liquidators process the volume? Is there bad debt?
+3. **Flash loan attack surface** -- Can any function be exploited when an
+   attacker has unlimited capital for one transaction? Test every public
+   function with flash-loaned inputs.
+4. **Price manipulation vectors** -- Can a large trade in a low-liquidity
+   pool move a price that your protocol depends on? Calculate cost of attack
+   vs profit.
+5. **Governance attack cost** -- How much capital to acquire enough votes
+   to pass a malicious proposal? Is it less than the protocol's TVL?
+
+## MEV Exposure Assessment
+
+| MEV Type | Affected Protocols | Mitigation |
+|---|---|---|
+| Sandwich attacks | AMMs, DEX aggregators | Slippage limits, private mempools, batch auctions |
+| Frontrunning | Liquidations, NFT mints | Commit-reveal schemes, Flashbots Protect |
+| Backrunning | Oracle updates, large trades | Design for it; let arbitrageurs correct prices |
+| JIT liquidity | Concentrated liquidity AMMs | Accept as feature; benefits traders |
+| Liquidation MEV | Lending protocols | Dutch auction liquidations, gradual liquidation |
+
+## Protocol Upgrade & Governance Patterns
+
+| Pattern | Speed | Security | Best For |
+|---|---|---|---|
+| Immutable | N/A | Maximum | Simple, audited, final protocols |
+| Timelock + multi-sig | Days | High | Production protocols with known admin set |
+| Governor + token voting | Days-weeks | Medium | Decentralized protocols with active community |
+| Emergency shutdown | Immediate | Situational | Circuit breaker for critical vulnerabilities |
+| Optimistic governance | Days (unless vetoed) | Medium-High | Frequent parameter updates with safety net |
+
+**Default:** Timelock (48h minimum) + multi-sig (3/5 or higher) for all
+privileged operations. Emergency shutdown as a separate, faster path.
+
+## Token Economic Design Constraints
+
+- **Supply mechanics** -- Fixed supply, inflationary, or deflationary. Each
+  creates different holder incentives and long-term sustainability.
+- **Incentive alignment** -- Token holders, LPs, and users must all benefit
+  from protocol growth. Misalignment leads to mercenary capital.
+- **ve-token models** -- Lock tokens for voting power and boosted rewards.
+  Aligns long-term holders but creates liquidity risk and governance capture.
+- **Fee distribution** -- Protocol fees to token holders, treasury, or
+  buyback-and-burn. Each has regulatory and incentive implications.
+- **Emission schedules** -- Front-loaded emissions attract early users but
+  create sell pressure. Gradual emissions sustain longer but grow slower.
+
+## Anti-Patterns
+
+| Anti-Pattern | Why It Fails | What To Do Instead |
+|---|---|---|
+| Unbounded composability | Each integration multiplies attack surface | Whitelist integrations; circuit breakers per dependency |
+| Single oracle dependency | Oracle failure or manipulation breaks the protocol | Multiple oracle sources with median or fallback logic |
+| No circuit breakers | Exploits drain entire TVL before anyone reacts | Pause functions, rate limits, maximum single-tx value |
+| Rug-pullable admin keys | Single EOA controls protocol funds or parameters | Timelock + multi-sig; progressive decentralization |
+| Untested invariants | Invariant violations discovered in production | Fuzz invariants with adversarial sequences before launch |
+| Ignoring flash loan context | Functions assume capital constraints that flash loans remove | Test every public function with flash-loaned inputs |
+| Copy-paste tokenomics | Token model from unrelated protocol misaligns incentives | Design token mechanics for your specific value flows |

--- a/skills/design-web3/SKILL.md
+++ b/skills/design-web3/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: design-web3
+description: Web3 system design — blockchain architecture, on-chain/off-chain decisions, and smart contract patterns
+---
+
+## What I do
+
+- Bridge traditional system design concepts to blockchain-specific constraints
+- Provide decision frameworks for on-chain vs off-chain placement
+- Document smart contract architecture patterns and gas optimization
+- Cover finality models, cross-chain communication, and state management
+
+## When to use me
+
+Use this skill when designing blockchain-based systems or migrating traditional
+architectures to Web3. Pair with `design-core` for foundational design
+principles and decision frameworks.
+
+## Traditional to Web3 Paradigm Translation
+
+| Traditional Concept | Web3 Equivalent | Key Difference |
+|---|---|---|
+| Database | Smart contract storage | Writes cost gas; storage is permanent and public |
+| API server | Smart contract functions | Execution is trustless but expensive and rate-limited by block space |
+| Authentication | Wallet signatures (ECDSA) | Self-sovereign identity; no password resets |
+| Authorization | On-chain access control | Enforced by consensus, not by a server you control |
+| Message queue | Events / logs | Append-only, indexed, but not readable by contracts |
+| Cron job | Keeper networks (Chainlink, Gelato) | No native scheduling; external actors trigger execution |
+| Load balancer | Multiple RPC endpoints | Decentralized but variable latency and reliability |
+| Database migration | Contract upgrade pattern | Immutable by default; upgrades require proxy patterns |
+| Caching layer | Indexer (The Graph, Subsquid) | On-chain reads are slow; indexers denormalize for query speed |
+| CI/CD pipeline | Deployment scripts + verification | Deployed code is immutable; verify source on block explorer |
+
+## On-chain / Off-chain Decision Framework
+
+```
+Does the data need trustless verification?
+  YES --> On-chain (or commit hash on-chain, data off-chain)
+  NO  |
+      v
+Does the operation need atomic composability with other contracts?
+  YES --> On-chain
+  NO  |
+      v
+Can the operation tolerate >12s latency (block time)?
+  NO  --> Off-chain with on-chain settlement
+  YES |
+      v
+Is the data larger than 1 KB per transaction?
+  YES --> Off-chain storage (IPFS, Arweave) with on-chain hash
+  NO  |
+      v
+Does the computation cost >500K gas?
+  YES --> Off-chain compute with on-chain proof (ZK or optimistic)
+  NO  --> On-chain is viable; evaluate gas cost vs trust benefit
+```
+
+## Smart Contract Architecture Patterns
+
+| Pattern | Use Case | Trade-off |
+|---|---|---|
+| Transparent proxy | Upgradeable contracts | Admin key risk; storage collision possible |
+| UUPS proxy | Upgradeable with lower gas | Upgrade logic in implementation; bricking risk |
+| Diamond (EIP-2535) | Large contracts exceeding size limit | Complexity; harder to audit and verify |
+| Minimal proxy (EIP-1167) | Deploying many identical contracts cheaply | Cannot be upgraded; fixed logic |
+| Beacon proxy | Upgrading many proxies atomically | Single point of upgrade; centralization risk |
+| Immutable | Maximum trust and simplicity | No bug fixes; must get it right the first time |
+
+**Default choice:** Immutable for simple contracts. UUPS proxy when upgrades
+are genuinely needed. Avoid Diamond unless contract size forces it.
+
+## Gas Optimization as Architectural Constraint
+
+Design-level decisions that dominate gas costs (not code-level tricks):
+
+1. **Storage layout** -- Pack variables into 32-byte slots. One SSTORE
+   costs 20K gas (cold) or 5K gas (warm). Minimize storage writes.
+2. **Batch operations** -- Amortize fixed costs across multiple operations.
+   One transaction with N transfers beats N transactions.
+3. **Off-chain computation** -- Move computation off-chain; submit only
+   results and proofs on-chain.
+4. **Event-driven reads** -- Use events for data that only needs to be
+   read off-chain. Events cost ~375 gas per topic vs 20K for storage.
+5. **Lazy evaluation** -- Defer computation until the result is needed.
+   Distribute gas cost across multiple transactions.
+
+## Finality Models
+
+| Chain Type | Finality | Time | Design Implication |
+|---|---|---|---|
+| Ethereum (PoS) | Probabilistic then finalized | ~15 min (2 epochs) | Wait for finalization for high-value operations |
+| L2 Rollups | Soft confirmation, then L1 finality | Seconds (soft), hours (hard) | Design for two-tier confirmation UX |
+| Solana | Optimistic confirmation | ~400ms | Fast but reorgs possible; confirm for value transfers |
+| Cosmos (Tendermint) | Instant finality | ~6s | No reorgs; safe to act on first confirmation |
+| Bitcoin | Probabilistic | ~60 min (6 blocks) | Wait for depth proportional to transaction value |
+
+## Cross-chain Communication Patterns
+
+| Pattern | Trust Model | Latency | Best For |
+|---|---|---|---|
+| Hash time-locked contracts (HTLC) | Trustless | Minutes-hours | Atomic swaps between chains |
+| Light client bridges | Trust chain consensus | Minutes | High-security cross-chain messaging |
+| Optimistic bridges | Trust + fraud proof window | 7+ days | L2-to-L1 withdrawals |
+| Oracle-based bridges | Trust oracle set | Seconds-minutes | Speed-critical cross-chain transfers |
+| ZK bridges | Trust math (proof verification) | Minutes | High-security with faster finality than optimistic |
+
+**Default choice:** Use canonical bridges when available. For custom bridges,
+prefer ZK or light client approaches over oracle-based for security.
+
+## State Management on Blockchains
+
+- **On-chain state** -- Minimal, critical data only (balances, ownership,
+  protocol parameters). Expensive to write, cheap to verify.
+- **Events as state** -- Emit events for historical data. Reconstruct state
+  off-chain via indexers. Cannot be read by other contracts.
+- **Off-chain indexing** -- Use The Graph or custom indexers for complex
+  queries. Treat as a read cache, not source of truth.
+- **Hybrid state** -- Merkle roots on-chain, full data off-chain (calldata,
+  IPFS, DA layers). Verify inclusion proofs on-chain.
+
+## Anti-Patterns
+
+| Anti-Pattern | Why It Fails | What To Do Instead |
+|---|---|---|
+| Storing everything on-chain | Gas costs explode; blockchain is not a database | Store hashes on-chain, data off-chain |
+| Ignoring MEV | Transactions are reordered for profit; users get worse prices | Design with MEV awareness; use private mempools or batch auctions |
+| Treating blockchain as a database | Queries are expensive; no native indexing or joins | Use indexers for reads; blockchain is for verification |
+| Single-chain lock-in | Chains evolve; users exist across ecosystems | Abstract chain-specific logic behind interfaces |
+| Unbounded loops in contracts | Gas limit exceeded; transaction reverts | Use pagination or off-chain computation with proofs |
+| Admin keys without timelock | Rug pull risk; single point of trust failure | Timelock + multi-sig for all privileged operations |
+| Ignoring upgrade path | Immutable bugs with no recovery mechanism | Decide upgrade strategy before deployment; document it |


### PR DESCRIPTION
## Summary

- Add `design-core` skill (179 lines) — system design foundations with first-principles thinking, evolution stages, architecture decision trees, and design review checklists
- Add `design-web3` skill (131 lines) — blockchain architecture, on-chain/off-chain decision framework, smart contract patterns, gas optimization, finality models
- Add `design-defi` skill (117 lines) — DeFi protocol design with composability risk matrix, invariant design, economic security analysis, MEV exposure assessment
- Add `design-arbitrage` skill (148 lines) — latency-sensitive trading with tick-to-trade pipeline, execution engine patterns, risk management as design constraint

## Structure

All skills follow the established pattern (`crypto-core`/`crypto-zkp` format):
- YAML frontmatter
- "What I do" / "When to use me" sections
- Domain-specific tables, decision trees, and frameworks
- Anti-patterns table

## Skill Hierarchy

```
design-core (foundations)
  ├── design-web3 (blockchain architecture)
  │     └── design-defi (DeFi protocols)
  └── design-arbitrage (trading systems)
```

## Files Changed

| File | Lines | Status |
|---|---|---|
| `skills/design-core/SKILL.md` | 179 | New |
| `skills/design-web3/SKILL.md` | 131 | New |
| `skills/design-defi/SKILL.md` | 117 | New |
| `skills/design-arbitrage/SKILL.md` | 148 | New |

Closes #57, closes #58, closes #59, closes #60