### PR TITLE
fix(agents): route write git-ops through devops, mandatory docs validation, slash command context

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,4 @@
+<!-- lib-agents managed file. Add customizations to AGENTS.local.md -->
 # Project Agent Delegation
 
 This project uses specialized agents for different domains. The primary agents
@@ -8,7 +9,8 @@ Task tool instead of handling these tasks directly.
 
 | When the user asks about... | Delegate to | The agent handles... |
 |---|---|---|
-| Issues, PRs, commits, branches, reviews, releases | `@git-ops` | All Git and GitHub operations with safety rails and conventional commits |
+| Read-only GitHub queries (view issues, list PRs, check status, diffs) | `@git-ops` | Git/GitHub read operations with safety rails |
+| Write GitHub operations (create issues, commits, PRs, reviews, releases, merges) | `@devops` | Issue-driven Git/GitHub writes with pre-flight checks, docs validation, and test validation |
 | Scaffolding, containers, Terraform, CI/CD, GCP, deployment | `@devops` | Issue-driven DevOps workflows with pre-flight checks |
 | README, documentation | `@docs` | Minimalist README maintenance and validation |
 | Brainstorming, ideation, feature exploration | `@ideate` | Audience-first creative ideation with structured evaluation |
@@ -34,9 +36,10 @@ Task tool instead of handling these tasks directly.
 
 ## Quick Reference
 
-- "create an issue" / "file a bug" / "track this" → `@git-ops`
-- "commit these changes" / "open a PR" / "merge" → `@git-ops`
-- "review this PR" / "create a release" → `@git-ops`
+- "view this issue" / "list PRs" / "check git status" / "show diff" → `@git-ops`
+- "create an issue" / "file a bug" / "track this" → `@devops`
+- "commit these changes" / "open a PR" / "merge" → `@devops`
+- "review this PR" / "create a release" → `@devops`
 - "scaffold a Makefile" / "set up CI/CD" → `@devops`
 - "deploy this" / "run terraform plan" → `@devops`
 - "build the container" / "manage pods" → `@devops`

--- a/agents/devops/agent.md
+++ b/agents/devops/agent.md
@@ -141,13 +141,13 @@ When delegating, provide the agent with complete context about what to do.
 
 After completing the requested work:
 
-1. **Validate documentation** (conditional) -- If files were created or modified
-   during this task, ask the user if they want to validate documentation before
-   committing. Skip this step for read-only operations (e.g., `terraform plan`,
-   status checks, troubleshooting).
-   - If yes, delegate to `@docs` to run `readme-validate` on the project.
-   - Fix small related issues inline; create tracking issues for larger ones.
-   - If the user skips, proceed immediately.
+1. **Validate documentation** (mandatory) -- Automatically delegate to `@docs`
+   to run `readme-validate` on the project. Do NOT ask the user — just run it.
+   Skip this step only for read-only operations that don't result in a commit
+   (e.g., `terraform plan`, status checks, troubleshooting).
+   - If validation passes with no issues, proceed silently to test validation.
+   - If issues are found, fix small related issues inline; create tracking
+     issues for larger ones.
 2. **Run test validation** (mandatory) -- Run `validate_tests` to detect and
    execute available tests before committing. This step is NEVER silently skipped.
    - **PASS**: Tests passed. Proceed to commit.

--- a/prompts/build.md
+++ b/prompts/build.md
@@ -8,7 +8,8 @@ to them instead of handling their domains directly. See the AGENTS.md file
 for the full delegation table.
 
 Key delegations:
-- Git/GitHub operations (issues, PRs, commits, reviews, releases) → delegate to `@git-ops`
+- Read-only GitHub queries (view issue, list PRs, check status, diff) → delegate to `@git-ops`
+- Write GitHub operations (create issues, commits, PRs, reviews, releases, merges) → delegate to `@devops`
 - DevOps/infrastructure (scaffolding, containers, Terraform, CI/CD) → delegate to `@devops`
 - Documentation (README maintenance) → delegate to `@docs`
 - Brainstorming/ideation → delegate to `@ideate`
@@ -34,3 +35,13 @@ Every Task tool prompt must be a **fully self-contained brief**:
 If the user's request is a short reference to earlier conversation (e.g.,
 "create issues for those two skills"), YOU must expand it into a complete,
 self-contained specification before passing it to the subagent.
+
+### Slash Command Delegation
+
+When you need to invoke a slash command (e.g., `/create-and-plan`, `/implement`)
+on behalf of the user based on conversational context, you MUST inline the full
+expanded description as the `$ARGUMENTS`. Never pass empty arguments, and never
+use vague references like "the above feature" or "for the three issues we
+discussed". The slash command handler receives ONLY the argument string — it
+has no access to this conversation. Expand all context into a self-contained
+specification before invoking the command.


### PR DESCRIPTION
## Summary

- **Split Build agent Git/GitHub delegation**: Read-only queries (view issue, list PRs, check status, diff) route to `@git-ops`; write operations (create issues, commits, PRs, reviews, releases, merges) route through `@devops` for disciplined workflow enforcement (pre-flight checks, docs validation, test validation)
- **Make docs validation mandatory**: Devops agent Post-work Protocol step 1 changed from conditional/user-prompted to mandatory — automatically runs `readme-validate` via `@docs` before every commit without asking the user
- **Add slash command delegation rule**: New subsection in Build agent's Subagent Context Isolation requiring full context expansion when invoking slash commands on behalf of the user

## Changes

| File | Change |
|------|--------|
| `prompts/build.md` | Split delegation (read→@git-ops, write→@devops), add Slash Command Delegation subsection |
| `AGENTS.md` | Split delegation table row, update Quick Reference routing |
| `agents/devops/agent.md` | Post-work step 1: conditional → mandatory docs validation |
| `.opencode/prompts/build.md` | Mirror of prompts/build.md (gitignored, updated for local dev) |
| `.opencode/agents/devops.md` | Mirror of agents/devops/agent.md (gitignored, updated for local dev) |
| `.opencode/skills/devops-workflow/SKILL.md` | Add Doc Validation step to Full Lifecycle diagram (gitignored, updated for local dev) |

Closes #65