### PR TITLE
feat(profiles): add composable profile system for domain-specific agent configurations

### DIFF
--- a/profiles/default/PROFILE.md
+++ b/profiles/default/PROFILE.md
@@ -1,0 +1,52 @@
+---
+name: default
+description: Standard operational setup — DevOps, Git, docs, and ideation agents with core operational skills
+
+agents:
+  - git-ops
+  - devops
+  - docs
+  - ideate
+
+agent_skills:
+  build: []
+  devops:
+    - devops-workflow
+    - makefile-ops
+    - container-ops
+    - cloudbuild-ops
+    - gcloud-ops
+  git-ops:
+    - git-pr-workflow
+    - git-release
+  docs:
+    - readme-conventions
+---
+
+# Default Profile
+
+Standard operational setup with 4 agents and 8 operational skills. This is the
+baseline configuration suitable for any project that uses the lib-agents DevOps
+workflow.
+
+## Included Agents
+
+| Agent | Purpose |
+|-------|---------|
+| `git-ops` | Git and GitHub operations |
+| `devops` | DevOps workflows, containers, infrastructure |
+| `docs` | README and documentation maintenance |
+| `ideate` | Brainstorming and creative ideation |
+
+## Included Skills
+
+| Skill | Agent | Description |
+|-------|-------|-------------|
+| `devops-workflow` | devops | Issue-driven DevOps workflow |
+| `makefile-ops` | devops | Makefile and modular scripts |
+| `container-ops` | devops | Podman container operations |
+| `cloudbuild-ops` | devops | Cloud Build CI/CD patterns |
+| `gcloud-ops` | devops | Google Cloud Platform operations |
+| `git-pr-workflow` | git-ops | PR creation and review |
+| `git-release` | git-ops | Release management |
+| `readme-conventions` | docs | README best practices |


### PR DESCRIPTION
## Summary

Implements the profiles system from issue #67 — composable agent configurations for domain-specific setups.

- **Profile format**: `profiles/<name>/PROFILE.md` with YAML frontmatter defining agents, per-agent skill mappings, and optional prompt overlays
- **Selective skill installation**: Only skills from `UNION(all agent_skills values)` are installed (8 of 22 for default profile)
- **CLI interface**: `--profile <name>`, `--profiles`, `--profile <name> --update` for switching
- **`--all` is now shorthand** for `--profile default`
- **Validation**: Catches nonexistent skills/agents referenced in profiles
- **Manifest**: Records `profile=<name>` in lockfile; `--status` shows active profile
- **Profile Skills section**: Auto-generated from SKILL.md frontmatter, appended to agent.md with markers
- **Prompt overlays**: Applied between `<!-- BEGIN/END profile -->` markers (infrastructure ready, no overlays for default profile)
- **Idempotent**: Profile switching cleans old artifacts before applying new profile

### Files Created
- `profiles/default/PROFILE.md` — Standard operational setup (4 agents, 8 skills)

### Files Modified
- `install.sh` — Profile parsing, selective skill install, permission injection, prompt overlays, CLI flags, manifest updates

### Testing
- `--profile default` installs exactly 8 skills ✓
- `--all` produces identical output to `--profile default` ✓
- `--profiles` lists available profiles ✓
- `--status` shows active profile ✓
- `--profile <name> --update` switches profiles ✓
- Validation catches nonexistent skills/agents ✓
- Manifest records `profile=default` ✓

> **Out of scope**: Domain-specific profiles (sol-dev, rust-dev, etc.) and their prompt overlays — tracked as separate issues.

Closes #67