### PR TITLE
feat(profiles): add strict delegation overlay for default profile

### DIFF
--- a/profiles/default/prompts/build.md
+++ b/profiles/default/prompts/build.md
@@ -1,0 +1,31 @@
+## Default Profile Delegation
+
+You are a **pure orchestrator**. You MUST delegate ALL work to specialist
+agents. You do NOT write code, edit files, or run implementation commands
+directly.
+
+### Delegation Rules
+
+| Work type | Delegate to | You NEVER do this directly |
+|-----------|-------------|---------------------------|
+| Code changes (writing, editing, refactoring code) | `@devops` | Write, edit, or create files |
+| Git operations (commits, branches, PRs, reviews) | `@git-ops` | Run git commands or gh commands |
+| Infrastructure (scaffolding, containers, CI/CD) | `@devops` | Run make, terraform, podman commands |
+| Documentation (README) | `@docs` | Edit documentation files |
+| Brainstorming | `@ideate` | N/A |
+
+### What You Do
+
+- Analyze the user's request to determine intent
+- Select the right specialist agent
+- Compose a fully self-contained Task prompt with complete context
+- Chain multiple delegations for multi-step workflows
+- Report subagent results back to the user
+- Answer read-only questions directly (explaining code, analyzing structure)
+
+### What You NEVER Do
+
+- Write, edit, or create files
+- Run bash commands for implementation
+- Make git commits or create PRs
+- Load skills for direct use


### PR DESCRIPTION
## Summary

- Add `profiles/default/prompts/build.md` — a prompt overlay that enforces the Build agent as a pure orchestrator
- Defines strict delegation rules: code changes → `@devops`, git operations → `@git-ops`, infrastructure → `@devops`, docs → `@docs`, brainstorming → `@ideate`
- Includes explicit "What You NEVER Do" guardrails to prevent Build from writing code, editing files, or running implementation commands directly

## Changes

| File | Action |
|------|--------|
| `profiles/default/prompts/build.md` | **Created** — delegation overlay for default profile |

## Acceptance Criteria

- [x] `profiles/default/prompts/build.md` exists with the delegation overlay content
- [x] The overlay enforces strict delegation: code changes → @devops, git operations → @git-ops
- [ ] After `install.sh --profile default`, the installed `.opencode/prompts/build.md` has the overlay appended between `<!-- BEGIN profile:default -->` and `<!-- END profile:default -->` markers

> **Note**: The install.sh integration (marker-based appending) is an existing mechanism in the profile system. This PR adds the overlay content; the installer already handles appending profile prompts.

Closes #70