### PR TITLE
feat(pilot): add isolated experimentation agent for hypothesis testing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,7 @@ Task tool instead of handling these tasks directly.
 | Scaffolding, containers, Terraform, CI/CD, GCP, deployment | `@devops` | Issue-driven DevOps workflows with pre-flight checks |
 | README, documentation | `@docs` | Minimalist README maintenance and validation |
 | Brainstorming, ideation, feature exploration | `@ideate` | Audience-first creative ideation with structured evaluation |
+| Testing hypotheses, experiments, prototyping, reproducing bugs | `@pilot` | Isolated experimentation in ephemeral workspaces |
 
 ## Rules
 
@@ -47,3 +48,6 @@ Task tool instead of handling these tasks directly.
 - "validate documentation" / "check the README" → `@docs`
 - "brainstorm ideas" / "explore features" → `@ideate`
 - "what should we build?" / "creative session" → `@ideate`
+- "test this hypothesis" / "try this out" / "experiment" → `@pilot`
+- "reproduce this bug" / "prototype this" / "does X work?" → `@pilot`
+- "clean up workspaces" / "pilot clean" → `@pilot`

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Each agent is a self-contained package with custom tools, slash commands, skills
 | [docs](agents/docs/) | Minimalist README.md maintenance -- analyze, generate, validate, and update project documentation | git-ops |
 | [devops](agents/devops/) | Issue-driven DevOps workflows -- Makefile scaffolding, Podman containers, Terraform IaC, Cloud Build CI/CD, GCP operations | git-ops, docs |
 | [ideate](agents/ideate/) | Audience-centered creative brainstorming -- diverge-evaluate-converge ideation with multiple perspective lenses | git-ops, docs |
+| [pilot](agents/pilot/) | Isolated experimentation -- test hypotheses, reproduce bugs, and prototype in ephemeral `/tmp/pilot-*` workspaces | git-ops |
 
 ## Quick Start
 

--- a/agents/pilot/DEPENDS
+++ b/agents/pilot/DEPENDS
@@ -1,0 +1,3 @@
+# Dependencies for the pilot agent
+# Each line is an agent name that must be installed first
+git-ops

--- a/agents/pilot/agent.md
+++ b/agents/pilot/agent.md
@@ -1,0 +1,198 @@
+---
+description: >
+  Isolated experimentation agent for hypothesis testing, bug reproduction, and
+  prototyping. Creates ephemeral /tmp/pilot-* workspaces with zero ceremony.
+  Cannot write to the main project — all experiments run in throwaway sandboxes.
+  Delegates significant findings to git-ops as issues.
+mode: subagent
+temperature: 0.3
+tools:
+  # Disable file write tools — pilot writes via bash scoped to /tmp/pilot-*
+  write: false
+  edit: false
+  patch: false
+  # Disable all tools not relevant to experimentation
+  scaffold_*: false
+  cloudbuild_*: false
+  podman_*: false
+  gcloud_*: false
+  terraform_*: false
+  devops-preflight_*: false
+  branch-cleanup_*: false
+  gh-issue_*: false
+  gh-pr_*: false
+  gh-release_*: false
+  gh-review_*: false
+  git-branch_*: false
+  git-commit_*: false
+  git-conflict_*: false
+  git-ops-init: false
+  git-ops-init_*: false
+  git-status_*: false
+  readme-analyze: false
+  readme-scaffold: false
+  readme-validate: false
+  skill: false
+  troubleshoot_*: false
+permission:
+  bash:
+    "*": deny
+    # Workspace filesystem ops (scoped to /tmp/pilot-*)
+    "mkdir /tmp/pilot-*": allow
+    "rm -rf /tmp/pilot-*": allow
+    "rm -r /tmp/pilot-*": allow
+    "rm /tmp/pilot-*": allow
+    "cp *": allow
+    "ls *": allow
+    "find *": allow
+    "tree *": allow
+    "cat *": allow
+    "head *": allow
+    "tail *": allow
+    "diff *": allow
+    "tar *": allow
+    "wc *": allow
+    "grep *": allow
+    "rg *": allow
+    # Language runtimes (for running experiments)
+    "npm *": allow
+    "npx *": allow
+    "bun *": allow
+    "node *": allow
+    "go *": allow
+    "cargo *": allow
+    "python3 *": allow
+    "pip *": allow
+    "pip3 *": allow
+    "make *": allow
+    # Read-only git (inspect main project, never modify)
+    "git log*": allow
+    "git diff*": allow
+    "git show*": allow
+    "git ls-files*": allow
+    "git rev-parse*": allow
+    # Read-only GitHub (view issues for context)
+    "gh issue view*": allow
+    "gh issue list*": allow
+---
+
+You are an experimentation assistant that helps developers test hypotheses,
+reproduce bugs, and prototype ideas in isolated throwaway workspaces. You
+prioritize fast feedback and zero ceremony over process and discipline.
+
+## Context Awareness
+
+You are a subagent. You receive ONLY the Task tool prompt -- you have NO
+access to the parent conversation's history. If the prompt contains ambiguous
+references (e.g., "the ideas above", "what we discussed"), STOP immediately
+and return a clear message explaining what context is missing. Do NOT guess
+-- the parent agent must re-invoke you with a fully self-contained prompt.
+
+## Zero-Ceremony Philosophy
+
+No pre-flight checks. No issue requirements. No branch management. The
+workflow is simple and fast:
+
+1. Interpret the hypothesis or question
+2. Create a workspace
+3. Write test code
+4. Run the experiment
+5. Report the result
+6. Offer next steps
+7. Clean up (or keep for further exploration)
+
+Every experiment should be as small as possible. The goal is to answer a
+question, not build a project. Prefer 5-line scripts over 50-line programs.
+
+## Safety Model
+
+All experiments run in complete isolation from the main project:
+
+- **Workspace boundary**: All experiments run in `/tmp/pilot-*` directories.
+  You have NO write access to the main project directory.
+- **File tools disabled**: The `write` and `edit` tools are disabled. You
+  write files via bash commands (`cat >`, `tee`, `echo >`) scoped to workspace
+  paths only.
+- **Read access allowed**: You CAN read the main project's files (for copying
+  patterns, understanding architecture, reading configs). Use the `read` and
+  `glob` tools, or read-only bash commands like `cat`, `head`, `tail`.
+- **Git is read-only**: You can inspect the main project's git history
+  (`git log`, `git diff`, `git show`) but cannot modify it.
+
+Never attempt to write files outside of `/tmp/pilot-*` directories.
+
+## Experiment Protocol
+
+Follow this protocol for every experiment:
+
+### 1. Interpret
+
+Understand what the user wants to test. Restate the hypothesis clearly:
+- What is being tested?
+- What does CONFIRMED look like?
+- What does REFUTED look like?
+
+### 2. Create Workspace
+
+Use the `pilot-workspace_create` tool with:
+- A short, descriptive name derived from the hypothesis
+- The appropriate project type (node/go/python/rust/generic)
+
+### 3. Write Test Code
+
+Use bash to write minimal test files into the workspace. Keep it small:
+- One file if possible
+- Minimal dependencies
+- Clear pass/fail criteria
+
+### 4. Run
+
+Use the `pilot-run_execute` tool to run commands in the workspace. This
+ensures proper scoping and timeout enforcement.
+
+### 5. Report
+
+Present a structured result:
+
+```
+## Experiment Result: <hypothesis>
+
+**Verdict**: CONFIRMED | REFUTED | INCONCLUSIVE
+
+**Workspace**: /tmp/pilot-<name>-<hash>
+
+**Evidence**:
+- <key observation 1>
+- <key observation 2>
+
+**Next Steps**: <suggestions>
+```
+
+### 6. Next Steps
+
+Offer the user options:
+- Run a follow-up experiment
+- Create a GitHub issue for significant findings (delegate to `@git-ops`)
+- Clean up the workspace
+- Keep the workspace for further exploration
+
+## Delegation Rules
+
+You MUST delegate to the appropriate agent for:
+
+### `@git-ops` -- Actionable findings
+- **Bug reports** discovered during reproduction -> create issue with `bug` label
+- **Feature insights** from experiments -> create issue with `feature` label
+- **Viewing issues** for context when reproducing bugs
+
+When delegating, provide full context: the experiment, the evidence, and why
+it matters.
+
+## Response Format
+
+- Keep responses concise and focused on the experiment
+- Always show the test code you're writing (so the user can verify the approach)
+- Always show the full output from running the experiment
+- Use the structured result format for every experiment verdict
+- When an experiment fails to run (syntax errors, missing deps), fix and retry
+  before reporting -- don't report INCONCLUSIVE for fixable errors

--- a/agents/pilot/package.json
+++ b/agents/pilot/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "opencode-pilot",
+  "version": "0.1.0",
+  "description": "Isolated experimentation agent for OpenCode TUI - hypothesis testing in ephemeral workspaces",
+  "dependencies": {}
+}

--- a/commands/pilot-clean.md
+++ b/commands/pilot-clean.md
@@ -1,0 +1,24 @@
+---
+description: List and clean up pilot experiment workspaces
+agent: pilot
+---
+
+$ARGUMENTS
+
+This is a workspace cleanup workflow.
+
+1. Use `pilot-workspace_list` to show all active workspaces with their age
+   and disk usage.
+
+2. If $ARGUMENTS contains "all" or "--all":
+   - Confirm with the user, then use `pilot-workspace_destroy_all`.
+
+3. If $ARGUMENTS contains a specific workspace name:
+   - Use `pilot-workspace_destroy` to remove that specific workspace.
+
+4. If $ARGUMENTS contains "--stale" or no arguments:
+   - Identify workspaces older than 24 hours.
+   - List them and ask the user which to clean up.
+   - Destroy confirmed workspaces one by one.
+
+5. Show a summary of what was cleaned up (count, total space freed).

--- a/commands/pilot-try.md
+++ b/commands/pilot-try.md
@@ -1,0 +1,38 @@
+---
+description: Test a hypothesis in an isolated throwaway workspace
+agent: pilot
+---
+
+$ARGUMENTS
+
+The user wants to test a hypothesis or answer a question through experimentation.
+
+1. **Interpret the hypothesis** — Parse $ARGUMENTS to understand what the user
+   wants to test. If the hypothesis is unclear, ask for clarification.
+
+2. **Plan the experiment** — Briefly state:
+   - What you'll test
+   - What language/runtime you'll use
+   - What a CONFIRMED vs REFUTED result looks like
+
+3. **Create a workspace** — Use `pilot-workspace_create` with an appropriate
+   name derived from the hypothesis and the correct project type.
+
+4. **Write test code** — Use bash to write minimal test files into the workspace.
+   Keep experiments as small as possible — the goal is to answer the question,
+   not build a project.
+
+5. **Run the experiment** — Use `pilot-run_execute` to run the test code.
+
+6. **Report the result** — Present a structured verdict:
+   - **CONFIRMED** — The hypothesis is true, with evidence
+   - **REFUTED** — The hypothesis is false, with evidence
+   - **INCONCLUSIVE** — Could not determine, explain why
+
+7. **Offer next steps**:
+   - Run a follow-up experiment
+   - Create a GitHub issue for significant findings (delegate to @git-ops)
+   - Clean up the workspace
+   - Keep the workspace for further exploration
+
+If no arguments are provided, ask the user what they want to test.

--- a/profiles/default/PROFILE.md
+++ b/profiles/default/PROFILE.md
@@ -1,12 +1,13 @@
 ---
 name: default
-description: Standard operational setup — DevOps, Git, docs, and ideation agents with core operational skills
+description: Standard operational setup — DevOps, Git, docs, ideation, and pilot agents with core operational skills
 
 agents:
   - git-ops
   - devops
   - docs
   - ideate
+  - pilot
 
 agent_skills:
   build: []
@@ -21,11 +22,12 @@ agent_skills:
     - git-release
   docs:
     - readme-conventions
+  pilot: []
 ---
 
 # Default Profile
 
-Standard operational setup with 4 agents and 8 operational skills. This is the
+Standard operational setup with 5 agents and 8 operational skills. This is the
 baseline configuration suitable for any project that uses the lib-agents DevOps
 workflow.
 
@@ -37,6 +39,7 @@ workflow.
 | `devops` | DevOps workflows, containers, infrastructure |
 | `docs` | README and documentation maintenance |
 | `ideate` | Brainstorming and creative ideation |
+| `pilot` | Isolated experimentation and hypothesis testing |
 
 ## Included Skills
 

--- a/tools/pilot-run.ts
+++ b/tools/pilot-run.ts
@@ -1,0 +1,163 @@
+import { tool } from "@opencode-ai/plugin"
+import { existsSync, readFileSync } from "fs"
+import { join } from "path"
+import { homedir } from "os"
+
+// ─── Types ───────────────────────────────────────────────────────────
+
+interface Workspace {
+  name: string
+  path: string
+  projectType: string
+  createdAt: string
+  sourceProject?: string
+}
+
+interface Manifest {
+  workspaces: Workspace[]
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────
+
+function getManifestPath(): string {
+  return join(homedir(), ".pilot-workspaces.json")
+}
+
+function readManifest(): Manifest {
+  const path = getManifestPath()
+  if (!existsSync(path)) {
+    return { workspaces: [] }
+  }
+  try {
+    return JSON.parse(readFileSync(path, "utf-8"))
+  } catch {
+    return { workspaces: [] }
+  }
+}
+
+function findWorkspace(name: string): Workspace | undefined {
+  const manifest = readManifest()
+  return manifest.workspaces.find(
+    (w) => w.name === name || w.path.includes(name),
+  )
+}
+
+const MAX_OUTPUT_BYTES = 10240 // 10KB
+
+function truncate(text: string, label: string): string {
+  if (text.length <= MAX_OUTPUT_BYTES) return text
+  return (
+    text.slice(0, MAX_OUTPUT_BYTES) +
+    `\n\n... [${label} truncated at ${MAX_OUTPUT_BYTES} bytes, total ${text.length} bytes]`
+  )
+}
+
+// ─── Tool Exports ────────────────────────────────────────────────────
+
+export const execute = tool({
+  description:
+    "Execute a command inside a pilot workspace. The command runs with the " +
+    "workspace directory as its working directory. Enforces timeout and returns " +
+    "structured output with exit code, stdout, stderr, and duration.",
+  args: {
+    workspace: tool.schema
+      .string()
+      .describe("Name of the workspace to run the command in"),
+    command: tool.schema
+      .string()
+      .describe("The shell command to execute"),
+    timeout: tool.schema
+      .number()
+      .optional()
+      .describe("Timeout in milliseconds (default: 60000)"),
+  },
+  async execute(args) {
+    const timeout = args.timeout || 60000
+
+    // Resolve workspace
+    const ws = findWorkspace(args.workspace)
+    if (!ws) {
+      return `Workspace '${args.workspace}' not found. Use pilot-workspace_list to see active workspaces.`
+    }
+
+    // Safety: validate path
+    if (!ws.path.startsWith("/tmp/pilot-")) {
+      return `SAFETY ERROR: Workspace path '${ws.path}' is not under /tmp/pilot-*. Refusing to execute.`
+    }
+
+    // Validate workspace exists
+    if (!existsSync(ws.path)) {
+      return `Workspace directory '${ws.path}' does not exist. It may have been cleaned up.`
+    }
+
+    const startTime = performance.now()
+    let timedOut = false
+
+    try {
+      const proc = Bun.spawn(["bash", "-c", args.command], {
+        cwd: ws.path,
+        stdout: "pipe",
+        stderr: "pipe",
+      })
+
+      // Set up timeout
+      const timeoutId = setTimeout(() => {
+        timedOut = true
+        proc.kill()
+      }, timeout)
+
+      // Wait for completion
+      const exitCode = await proc.exited
+      clearTimeout(timeoutId)
+
+      const duration = Math.round(performance.now() - startTime)
+
+      const stdout = await new Response(proc.stdout).text()
+      const stderr = await new Response(proc.stderr).text()
+
+      const lines: string[] = [
+        "Execution Result",
+        "================",
+        `  Workspace: ${ws.name} (${ws.path})`,
+        `  Command:   ${args.command}`,
+        `  Exit Code: ${exitCode}`,
+        `  Duration:  ${duration}ms`,
+        `  Timed Out: ${timedOut}`,
+      ]
+
+      if (stdout.trim()) {
+        lines.push("")
+        lines.push("stdout:")
+        lines.push("-------")
+        lines.push(truncate(stdout.trim(), "stdout"))
+      }
+
+      if (stderr.trim()) {
+        lines.push("")
+        lines.push("stderr:")
+        lines.push("-------")
+        lines.push(truncate(stderr.trim(), "stderr"))
+      }
+
+      if (!stdout.trim() && !stderr.trim()) {
+        lines.push("")
+        lines.push("(no output)")
+      }
+
+      return lines.join("\n")
+    } catch (e: any) {
+      const duration = Math.round(performance.now() - startTime)
+
+      return [
+        "Execution Error",
+        "===============",
+        `  Workspace: ${ws.name} (${ws.path})`,
+        `  Command:   ${args.command}`,
+        `  Duration:  ${duration}ms`,
+        `  Timed Out: ${timedOut}`,
+        "",
+        `Error: ${e.message || "unknown error"}`,
+      ].join("\n")
+    }
+  },
+})

--- a/tools/pilot-workspace.ts
+++ b/tools/pilot-workspace.ts
@@ -1,0 +1,399 @@
+import { tool } from "@opencode-ai/plugin"
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from "fs"
+import { join } from "path"
+import { homedir } from "os"
+import { randomBytes } from "crypto"
+
+// ─── Types ───────────────────────────────────────────────────────────
+
+interface Workspace {
+  name: string
+  path: string
+  projectType: "node" | "go" | "python" | "rust" | "generic"
+  createdAt: string
+  sourceProject?: string
+}
+
+interface Manifest {
+  workspaces: Workspace[]
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────
+
+function getManifestPath(): string {
+  return join(homedir(), ".pilot-workspaces.json")
+}
+
+function readManifest(): Manifest {
+  const path = getManifestPath()
+  if (!existsSync(path)) {
+    return { workspaces: [] }
+  }
+  try {
+    return JSON.parse(readFileSync(path, "utf-8"))
+  } catch {
+    return { workspaces: [] }
+  }
+}
+
+function writeManifest(manifest: Manifest): void {
+  writeFileSync(getManifestPath(), JSON.stringify(manifest, null, 2) + "\n")
+}
+
+function generateHash(): string {
+  return randomBytes(4).toString("hex")
+}
+
+async function run(cmd: string[]): Promise<{ ok: boolean; out: string }> {
+  try {
+    const result = await Bun.$`${cmd}`.text()
+    return { ok: true, out: result.trim() }
+  } catch (e: any) {
+    return {
+      ok: false,
+      out: e?.stderr?.toString?.()?.trim() || e.message || "unknown error",
+    }
+  }
+}
+
+function formatAge(createdAt: string): string {
+  const ms = Date.now() - new Date(createdAt).getTime()
+  const minutes = Math.floor(ms / 60000)
+  if (minutes < 60) return `${minutes}m ago`
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) return `${hours}h ago`
+  const days = Math.floor(hours / 24)
+  return `${days}d ago`
+}
+
+// ─── Tool Exports ────────────────────────────────────────────────────
+
+export const create = tool({
+  description:
+    "Create a new isolated pilot workspace in /tmp/pilot-*. " +
+    "Optionally scaffold for a specific project type and copy files from the main project.",
+  args: {
+    name: tool.schema
+      .string()
+      .describe("Short descriptive name for the workspace (kebab-case)"),
+    project_type: tool.schema
+      .enum(["node", "go", "python", "rust", "generic"])
+      .optional()
+      .describe("Project type for scaffolding (default: generic)"),
+    copy_files: tool.schema
+      .string()
+      .optional()
+      .describe("Glob pattern of files to copy from the main project (e.g. 'src/**/*.ts')"),
+  },
+  async execute(args, context) {
+    const projectType = args.project_type || "generic"
+    const hash = generateHash()
+    const wsName = args.name.replace(/[^a-z0-9-]/gi, "-").toLowerCase()
+    const wsPath = `/tmp/pilot-${wsName}-${hash}`
+
+    // Create workspace directory
+    mkdirSync(wsPath, { recursive: true })
+
+    const lines: string[] = [
+      `Workspace created: ${wsPath}`,
+      `  Name: ${wsName}`,
+      `  Type: ${projectType}`,
+    ]
+
+    // Scaffold based on project type
+    if (projectType === "node") {
+      const result = await run(["npm", "init", "-y"])
+      if (result.ok) {
+        // Move package.json into workspace (npm init runs in cwd)
+        try {
+          await Bun.$`npm init -y`.cwd(wsPath).text()
+        } catch { /* non-fatal */ }
+      }
+      lines.push("  Scaffolded: package.json (npm init -y)")
+    } else if (projectType === "go") {
+      const modName = `experiment/${wsName}`
+      try {
+        await Bun.$`go mod init ${modName}`.cwd(wsPath).text()
+        lines.push(`  Scaffolded: go.mod (module ${modName})`)
+      } catch (e: any) {
+        lines.push(`  Warning: could not init go.mod: ${e.message}`)
+      }
+    } else if (projectType === "python") {
+      try {
+        await Bun.$`touch ${join(wsPath, "main.py")}`.text()
+        lines.push("  Scaffolded: main.py (empty)")
+      } catch { /* non-fatal */ }
+    } else if (projectType === "rust") {
+      try {
+        await Bun.$`cargo init ${wsPath}`.text()
+        lines.push("  Scaffolded: Cargo.toml + src/main.rs (cargo init)")
+      } catch (e: any) {
+        lines.push(`  Warning: could not cargo init: ${e.message}`)
+      }
+    }
+
+    // Copy files from main project if requested
+    if (args.copy_files) {
+      const sourceDir = context.directory || "."
+      try {
+        // Use rsync or cp with glob
+        const result = await run([
+          "bash",
+          "-c",
+          `cd "${sourceDir}" && cp --parents ${args.copy_files} "${wsPath}/" 2>/dev/null || true`,
+        ])
+        if (result.ok) {
+          lines.push(`  Copied files matching: ${args.copy_files}`)
+        }
+      } catch {
+        lines.push(`  Warning: could not copy files matching ${args.copy_files}`)
+      }
+    }
+
+    // Record in manifest
+    const manifest = readManifest()
+    manifest.workspaces.push({
+      name: wsName,
+      path: wsPath,
+      projectType,
+      createdAt: new Date().toISOString(),
+      sourceProject: context.directory || undefined,
+    })
+    writeManifest(manifest)
+
+    lines.push("")
+    lines.push("Workspace is ready. Use pilot-run_execute to run commands inside it.")
+
+    return lines.join("\n")
+  },
+})
+
+export const list = tool({
+  description:
+    "List all active pilot workspaces with their age, size, and project type.",
+  args: {},
+  async execute() {
+    const manifest = readManifest()
+
+    if (manifest.workspaces.length === 0) {
+      return "No active pilot workspaces."
+    }
+
+    // Prune workspaces that no longer exist on disk
+    const alive: Workspace[] = []
+    const pruned: string[] = []
+
+    for (const ws of manifest.workspaces) {
+      if (existsSync(ws.path)) {
+        alive.push(ws)
+      } else {
+        pruned.push(ws.name)
+      }
+    }
+
+    if (pruned.length > 0) {
+      manifest.workspaces = alive
+      writeManifest(manifest)
+    }
+
+    if (alive.length === 0) {
+      return "No active pilot workspaces (pruned stale manifest entries)."
+    }
+
+    const lines: string[] = [
+      "Active Pilot Workspaces",
+      "=======================",
+      "",
+    ]
+
+    for (const ws of alive) {
+      // Get disk size
+      const sizeResult = await run(["du", "-sh", ws.path])
+      const size = sizeResult.ok
+        ? sizeResult.out.split("\t")[0]
+        : "unknown"
+
+      lines.push(`  ${ws.name}`)
+      lines.push(`    Path: ${ws.path}`)
+      lines.push(`    Type: ${ws.projectType}`)
+      lines.push(`    Age:  ${formatAge(ws.createdAt)}`)
+      lines.push(`    Size: ${size}`)
+      lines.push("")
+    }
+
+    if (pruned.length > 0) {
+      lines.push(`(Pruned ${pruned.length} stale entries: ${pruned.join(", ")})`)
+    }
+
+    lines.push(`Total: ${alive.length} workspace(s)`)
+
+    return lines.join("\n")
+  },
+})
+
+export const inspect = tool({
+  description:
+    "Show details of a specific pilot workspace including file tree and status.",
+  args: {
+    name: tool.schema
+      .string()
+      .describe("Name of the workspace to inspect"),
+  },
+  async execute(args) {
+    const manifest = readManifest()
+    const ws = manifest.workspaces.find(
+      (w) => w.name === args.name || w.path.includes(args.name),
+    )
+
+    if (!ws) {
+      return `Workspace '${args.name}' not found. Use pilot-workspace_list to see active workspaces.`
+    }
+
+    if (!existsSync(ws.path)) {
+      return `Workspace '${args.name}' directory no longer exists at ${ws.path}. It may have been cleaned up externally.`
+    }
+
+    const lines: string[] = [
+      `Workspace: ${ws.name}`,
+      `=======================`,
+      `  Path:    ${ws.path}`,
+      `  Type:    ${ws.projectType}`,
+      `  Created: ${ws.createdAt}`,
+      `  Age:     ${formatAge(ws.createdAt)}`,
+    ]
+
+    if (ws.sourceProject) {
+      lines.push(`  Source:  ${ws.sourceProject}`)
+    }
+
+    // Disk size
+    const sizeResult = await run(["du", "-sh", ws.path])
+    if (sizeResult.ok) {
+      lines.push(`  Size:    ${sizeResult.out.split("\t")[0]}`)
+    }
+
+    lines.push("")
+    lines.push("File Tree:")
+    lines.push("----------")
+
+    // File tree (prefer tree, fallback to find)
+    const treeResult = await run(["tree", "-L", "3", "--noreport", ws.path])
+    if (treeResult.ok) {
+      lines.push(treeResult.out)
+    } else {
+      const findResult = await run([
+        "find",
+        ws.path,
+        "-maxdepth",
+        "3",
+        "-not",
+        "-path",
+        "*/node_modules/*",
+        "-not",
+        "-path",
+        "*/.git/*",
+        "-not",
+        "-path",
+        "*/target/*",
+      ])
+      if (findResult.ok) {
+        lines.push(findResult.out)
+      } else {
+        lines.push("  (could not list files)")
+      }
+    }
+
+    return lines.join("\n")
+  },
+})
+
+export const destroy = tool({
+  description:
+    "Remove a pilot workspace by name. Validates the path is scoped to /tmp/pilot-* for safety.",
+  args: {
+    name: tool.schema
+      .string()
+      .describe("Name of the workspace to destroy"),
+  },
+  async execute(args) {
+    const manifest = readManifest()
+    const wsIndex = manifest.workspaces.findIndex(
+      (w) => w.name === args.name || w.path.includes(args.name),
+    )
+
+    if (wsIndex === -1) {
+      return `Workspace '${args.name}' not found in manifest. Use pilot-workspace_list to see active workspaces.`
+    }
+
+    const ws = manifest.workspaces[wsIndex]
+
+    // Safety check: ensure path is scoped to /tmp/pilot-*
+    if (!ws.path.startsWith("/tmp/pilot-")) {
+      return `SAFETY ERROR: Workspace path '${ws.path}' is not under /tmp/pilot-*. Refusing to delete.`
+    }
+
+    // Remove from disk
+    if (existsSync(ws.path)) {
+      const result = await run(["rm", "-rf", ws.path])
+      if (!result.ok) {
+        return `Error removing workspace directory: ${result.out}`
+      }
+    }
+
+    // Remove from manifest
+    manifest.workspaces.splice(wsIndex, 1)
+    writeManifest(manifest)
+
+    return `Workspace '${ws.name}' destroyed.\n  Removed: ${ws.path}`
+  },
+})
+
+export const destroy_all = tool({
+  description:
+    "Remove all pilot workspaces. Cleans up all /tmp/pilot-* directories tracked in the manifest.",
+  args: {},
+  async execute() {
+    const manifest = readManifest()
+
+    if (manifest.workspaces.length === 0) {
+      return "No pilot workspaces to destroy."
+    }
+
+    const results: string[] = []
+    let count = 0
+
+    for (const ws of manifest.workspaces) {
+      // Safety check
+      if (!ws.path.startsWith("/tmp/pilot-")) {
+        results.push(`  SKIPPED: ${ws.name} (path not under /tmp/pilot-*)`)
+        continue
+      }
+
+      if (existsSync(ws.path)) {
+        const result = await run(["rm", "-rf", ws.path])
+        if (result.ok) {
+          results.push(`  DESTROYED: ${ws.name} (${ws.path})`)
+          count++
+        } else {
+          results.push(`  ERROR: ${ws.name} — ${result.out}`)
+        }
+      } else {
+        results.push(`  PRUNED: ${ws.name} (already gone)`)
+        count++
+      }
+    }
+
+    // Clear manifest
+    manifest.workspaces = []
+    writeManifest(manifest)
+
+    return [
+      "Destroy All Workspaces",
+      "======================",
+      "",
+      ...results,
+      "",
+      `${count} workspace(s) destroyed. Manifest cleared.`,
+    ].join("\n")
+  },
+})


### PR DESCRIPTION
## Summary

Implements the pilot agent — a zero-ceremony experimentation assistant that creates ephemeral `/tmp/pilot-*` workspaces for hypothesis testing, bug reproduction, and prototyping.

### Key Design Decisions

- **Architectural safety**: The agent has NO write access to the main project. File write tools (`write`, `edit`, `patch`) are disabled. All writes happen via bash commands scoped to `/tmp/pilot-*` paths.
- **Zero ceremony**: No pre-flight checks, no issue requirements, no branch management. Create workspace → experiment → report → clean up.
- **Structured results**: Every experiment produces a CONFIRMED / REFUTED / INCONCLUSIVE verdict with evidence.

### New Files (7)

| File | Purpose |
|------|---------|
| `agents/pilot/agent.md` | Agent definition with isolation-first permissions, temperature 0.3 |
| `agents/pilot/DEPENDS` | git-ops dependency |
| `agents/pilot/package.json` | Package metadata |
| `tools/pilot-workspace.ts` | Workspace lifecycle: create, list, inspect, destroy, destroy_all |
| `tools/pilot-run.ts` | Scoped command execution with timeout and structured output |
| `commands/pilot-try.md` | `/pilot try "hypothesis"` — zero-ceremony hypothesis testing |
| `commands/pilot-clean.md` | `/pilot clean` — workspace garbage collection |

### Modified Files (3)

| File | Change |
|------|--------|
| `AGENTS.md` | Added pilot to delegation table and quick reference |
| `README.md` | Added pilot to Available Agents table |
| `profiles/default/PROFILE.md` | Added pilot to default profile (5 agents) |

Closes #72