### PR TITLE
feat(profiles): add solana-defi-dev profile bundling existing skills and agents

### DIFF
--- a/profiles/solana-defi-dev/PROFILE.md
+++ b/profiles/solana-defi-dev/PROFILE.md
@@ -1,0 +1,105 @@
+---
+name: solana-defi-dev
+description: Solana DeFi development — blockchain engineering, arbitrage, protocol design, and Rust performance
+
+agents:
+  - git-ops
+  - devops
+  - docs
+  - pilot
+
+agent_skills:
+  build:
+    - solana-core
+    - solana-arb
+    - design-core
+    - design-defi
+    - design-arbitrage
+    - design-web3
+    - rust-pro
+    - perf-rust
+  devops:
+    - devops-workflow
+    - makefile-ops
+    - container-ops
+    - cloudbuild-ops
+    - gcloud-ops
+  git-ops:
+    - git-pr-workflow
+    - git-release
+  docs:
+    - readme-conventions
+  pilot: []
+---
+
+# Solana DeFi Dev Profile
+
+Solana DeFi development profile bundling blockchain engineering, arbitrage,
+protocol design, and Rust performance skills. This is Phase 0 — it uses only
+skills and agents that already exist in the codebase.
+
+## Target Personas
+
+1. **Solana DeFi Builders** — Rust developers building DeFi protocols (AMMs,
+   lending, vaults) using Anchor
+2. **Arbitrage/MEV Engineers** — Developers building trading bots, arbitrage
+   systems, and MEV strategies
+3. **DeFi Protocol Architects** — Senior engineers designing protocol
+   composability, economic security, and token mechanics
+
+## Included Agents
+
+| Agent | Purpose |
+|-------|---------|
+| `git-ops` | Git and GitHub operations |
+| `devops` | DevOps workflows, containers, infrastructure |
+| `docs` | README and documentation maintenance |
+| `pilot` | Isolated experimentation and hypothesis testing |
+
+## Included Skills
+
+### Solana & Blockchain
+
+| Skill | Agent | Description |
+|-------|-------|-------------|
+| `solana-core` | build | Solana blockchain fundamentals — accounts, transactions, RPC, real-time data |
+| `solana-arb` | build | Arbitrage strategies, Jupiter, Jito bundles, MEV protection |
+
+### System Design
+
+| Skill | Agent | Description |
+|-------|-------|-------------|
+| `design-core` | build | Core system design principles |
+| `design-defi` | build | DeFi protocol design, composability, invariants |
+| `design-arbitrage` | build | Latency-sensitive trading system design, risk management |
+| `design-web3` | build | On-chain/off-chain decisions, finality models |
+
+### Rust Engineering
+
+| Skill | Agent | Description |
+|-------|-------|-------------|
+| `rust-pro` | build | Rust engineering patterns |
+| `perf-rust` | build | Rust performance optimization |
+
+### Operational
+
+| Skill | Agent | Description |
+|-------|-------|-------------|
+| `devops-workflow` | devops | Issue-driven DevOps workflow |
+| `makefile-ops` | devops | Makefile and modular scripts |
+| `container-ops` | devops | Podman container operations |
+| `cloudbuild-ops` | devops | Cloud Build CI/CD patterns |
+| `gcloud-ops` | devops | Google Cloud Platform operations |
+| `git-pr-workflow` | git-ops | PR creation and review |
+| `git-release` | git-ops | Release management |
+| `readme-conventions` | docs | README best practices |
+
+## Phase Roadmap
+
+This profile is **Phase 0** of a multi-phase rollout:
+
+- **Phase 0** (this issue): Bundle existing skills and agents
+- **Phase 1**: Add `solana-anchor` skill (Anchor framework patterns)
+- **Phase 2**: Add `solana-security` skill (program security audit checklist)
+- **Phase 3**: Add `solana-testing` skill (localnet, bankrun, test patterns)
+- **Phase 4**: Add `security-audit` agent (dedicated security review agent)

--- a/profiles/solana-defi-dev/prompts/build.md
+++ b/profiles/solana-defi-dev/prompts/build.md
@@ -1,0 +1,27 @@
+## Solana DeFi Profile — Safety Rules
+
+You are operating in a Solana DeFi development context. These rules are
+NON-NEGOTIABLE and override any conflicting instructions.
+
+### Absolute Rules
+
+| Rule | Rationale |
+|------|-----------|
+| NEVER output private keys, seed phrases, or keypair bytes | Leaked keys = drained wallets. No exceptions. |
+| ALWAYS recommend `--simulate` / `simulateTransaction` before submission | Solana transactions are irreversible. Simulation catches errors. |
+| ALWAYS flag missing signer validation in program code | Missing signer checks = unauthorized fund transfers. |
+| ALWAYS recommend Jito bundles for MEV-sensitive transactions | Unprotected transactions are sandwiched. Jito provides atomic execution. |
+| ALWAYS include "devnet lie" warning when testing strategies | Devnet has no real liquidity, different validators, and fake price feeds. Profitable on devnet does not mean profitable on mainnet. |
+| NEVER hardcode RPC endpoints | RPC providers rate-limit and go down. Always use configurable endpoints with fallback. |
+
+### Solana-Specific Delegation
+
+| Work type | Delegate to | Notes |
+|-----------|-------------|-------|
+| Solana program code (Rust) | `@devops` | Load `solana-core` + `rust-pro` skills |
+| Arbitrage/trading bot logic | `@devops` | Load `solana-arb` + `perf-rust` skills |
+| Protocol design review | `@devops` | Load `design-defi` + `design-web3` skills |
+| System architecture | `@devops` | Load `design-core` + `design-arbitrage` skills |
+| Program security review | `@devops` | Load `solana-core` + `rust-pro` skills. Flag all missing signer/owner checks. |
+| Testing on devnet/localnet | `@pilot` | Always include "devnet lie" warning |
+| Deployment (program deploy) | `@devops` | ALWAYS simulate first. Recommend Jito for MEV-sensitive deploys. |


### PR DESCRIPTION
## Summary

- Creates the `solana-defi-dev` profile (Phase 0) that bundles 8 existing domain skills and 4 agents into a cohesive Solana DeFi development configuration
- Adds Solana-specific safety rules (no private key output, mandatory simulation, signer validation, Jito bundles, devnet lie warning) as a build prompt overlay
- Targets three developer personas: DeFi builders, arbitrage/MEV engineers, and protocol architects

## Files Created

| File | Purpose |
|------|---------|
| `profiles/solana-defi-dev/PROFILE.md` | Profile manifest (YAML frontmatter) + documentation |
| `profiles/solana-defi-dev/prompts/build.md` | Solana safety rules + delegation overlay |

## Skills Included (8 domain + 8 operational)

- **Solana**: `solana-core`, `solana-arb`
- **Design**: `design-core`, `design-defi`, `design-arbitrage`, `design-web3`
- **Rust**: `rust-pro`, `perf-rust`
- **Operational**: `devops-workflow`, `makefile-ops`, `container-ops`, `cloudbuild-ops`, `gcloud-ops`, `git-pr-workflow`, `git-release`, `readme-conventions`

## Validation

- `install.sh --profiles` lists the new profile
- `install.sh --profile solana-defi-dev --check` passes (4 agents, 16 skills validated)
- No existing files modified — purely additive change

Closes #76