### PR TITLE
perf: disable unnecessary tools for plan agent and pilot tool leaking

### DIFF
--- a/agents/devops/agent.md
+++ b/agents/devops/agent.md
@@ -24,6 +24,9 @@ tools:
   readme-analyze: false
   readme-scaffold: false
   readme-validate: false
+  # Disable pilot tools (handled by delegation to @pilot)
+  pilot-workspace_*: false
+  pilot-run_*: false
 permission:
   skill:
     "*": deny

--- a/agents/docs/agent.md
+++ b/agents/docs/agent.md
@@ -26,6 +26,9 @@ tools:
   git-ops-init: false
   git-ops-init_*: false
   git-status_*: false
+  # Disable pilot tools (handled by delegation to @pilot)
+  pilot-workspace_*: false
+  pilot-run_*: false
 permission:
   skill:
     "*": deny

--- a/agents/git-ops/agent.md
+++ b/agents/git-ops/agent.md
@@ -20,6 +20,9 @@ tools:
   readme-analyze: false
   readme-scaffold: false
   readme-validate: false
+  # Disable pilot tools (handled by delegation to @pilot)
+  pilot-workspace_*: false
+  pilot-run_*: false
   # branch-cleanup tools enabled for /cleanup workflows
 permission:
   skill:

--- a/opencode.json
+++ b/opencode.json
@@ -24,11 +24,54 @@
         "branch-cleanup_*": false,
         "readme-analyze": false,
         "readme-scaffold": false,
-        "readme-validate": false
+        "readme-validate": false,
+        "pilot-workspace_*": false,
+        "pilot-run_*": false
       }
     },
     "plan": {
-      "prompt": "{file:.opencode/prompts/plan.md}"
+      "prompt": "{file:.opencode/prompts/plan.md}",
+      "tools": {
+        "write": false,
+        "edit": false,
+        "scaffold_*": false,
+        "terraform_*": false,
+        "podman_*": false,
+        "cloudbuild_*": false,
+        "gcloud_*": false,
+        "troubleshoot_*": false,
+        "git-commit_*": false,
+        "git-conflict_*": false,
+        "git-branch_create": false,
+        "git-branch_delete_branch": false,
+        "git-branch_rename": false,
+        "git-branch_switch_branch": false,
+        "gh-issue_create": false,
+        "gh-issue_update": false,
+        "gh-issue_close": false,
+        "gh-issue_reopen": false,
+        "gh-issue_comment": false,
+        "gh-pr_create": false,
+        "gh-pr_merge": false,
+        "gh-pr_close": false,
+        "gh-pr_checkout": false,
+        "gh-release_*": false,
+        "gh-review_approve": false,
+        "gh-review_request_changes": false,
+        "gh-review_comment_on_pr": false,
+        "pilot-workspace_*": false,
+        "pilot-run_*": false,
+        "branch-cleanup_prune": false,
+        "branch-cleanup_prune_remote": false,
+        "devops-preflight_*": false,
+        "readme-analyze": false,
+        "readme-scaffold": false,
+        "readme-validate": false,
+        "git-ops-init_setup": false,
+        "git-ops-init_clearCache": false,
+        "git-ops-init_ensureEnvironment": false,
+        "git-ops-init_getEnvironmentReport": false
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

- **Issue #86**: Add comprehensive tool restrictions to the `plan` agent (39 disable rules), reducing visible tools from ~124 to ~21 (~83% reduction, saving ~20K-24.5K tokens per request)
- **Issue #83**: Disable `pilot-workspace_*` and `pilot-run_*` for `build`, `devops`, `git-ops`, and `docs` agents (saving ~8.4K tokens across all non-pilot invocations)

## Changes

### `opencode.json`
- **build agent**: Added `pilot-workspace_*: false` and `pilot-run_*: false` (2 new rules)
- **plan agent**: Added `tools` section with 39 disable rules covering all write, infrastructure, and deployment tools. Only read-only tools remain enabled (git-status, branch read, issue/PR view, review read, branch-cleanup list, built-in read/glob/grep/webfetch/task/skill)

### `agents/devops/agent.md`
- Added `pilot-workspace_*: false` and `pilot-run_*: false` to YAML frontmatter tools section

### `agents/git-ops/agent.md`
- Added `pilot-workspace_*: false` and `pilot-run_*: false` to YAML frontmatter tools section

### `agents/docs/agent.md`
- Added `pilot-workspace_*: false` and `pilot-run_*: false` to YAML frontmatter tools section

## Impact

| Agent | Tools Before | Tools After | Tokens Saved |
|-------|-------------|-------------|-------------|
| plan | ~124 | ~21 | ~20,000-24,500 |
| build | ~87 | ~81 | ~2,100 |
| devops | ~99 | ~93 | ~2,100 |
| git-ops | ~99 | ~93 | ~2,100 |
| docs | ~96 | ~90 | ~2,100 |

**Total estimated savings: ~28,400-32,900 tokens per combined agent invocation cycle**

## Risk

**None** — purely additive disable rules. No tool behavior changes. No agent prompt changes. The pilot tools were never intentionally used by these agents, and the plan agent's prompt already declares it read-only.

Closes #86
Closes #83