### PR TITLE
refactor: consolidate tools to reduce context bloat

### DIFF
--- a/agents/devops/README.md
+++ b/agents/devops/README.md
@@ -66,14 +66,14 @@ cicd/
 
 | Tool | Exports | Description |
 |------|---------|-------------|
-| `devops-preflight` | `check_issue`, `check_clean`, `check_branch`, `full_preflight` | Pre-flight checks |
-| `scaffold` | `makefile`, `scripts`, `container_files`, `cloudbuild`, `terraform_cicd`, `gitignore`, `full_scaffold` | Project scaffolding |
+| `devops-preflight` | `preflight`, `validate_tests` | Pre-flight checks and test validation |
+| `scaffold` | `scaffold` | Project scaffolding (with optional `components` parameter) |
 | `cloudbuild` | `submit`, `list_builds`, `log`, `triggers_list`, `triggers_run`, `cancel` | Cloud Build management |
 | `podman` | `build`, `run_container`, `ps`, `images`, `logs`, `stop`, `rm`, `inspect`, `exec` | Container management |
 | `terraform` | `init`, `validate`, `fmt`, `plan`, `apply`, `destroy`, `state_list`, `state_show`, `output`, `workspace_list`, `workspace_select` | Infrastructure as code |
 | `gcloud` | `auth_status`, `project_info`, `compute_list`, `gke_clusters`, `run_services`, `logs_read`, `iam_roles`, `config_list`, `services_list` | Google Cloud operations |
 | `troubleshoot` | `check_ports`, `check_dns`, `check_connectivity`, `system_info`, `process_list`, `disk_usage`, `container_health` | System diagnostics |
-| `branch-cleanup` | `list_stale`, `prune`, `prune_remote` | Stale branch cleanup |
+| `branch-cleanup` | `list_stale`, `prune` | Stale branch cleanup |
 
 ## Commands
 

--- a/agents/devops/agent.md
+++ b/agents/devops/agent.md
@@ -92,7 +92,7 @@ prompt.
 
 ## Pre-flight Protocol (MANDATORY)
 
-Before performing ANY work, run `full_preflight` with the issue number. This
+Before performing ANY work, run `preflight` with the issue number. This
 checks that the GitHub issue exists, the working tree is clean, and a dedicated
 branch is created. All three must pass before work begins.
 

--- a/agents/git-ops/README.md
+++ b/agents/git-ops/README.md
@@ -166,8 +166,7 @@ These load automatically when the agent needs them, or you can reference them vi
 
 | Tool | Description |
 |------|-------------|
-| `git-conflict_detect` | Detect merge conflicts |
-| `git-conflict_list_files` | List conflicted files |
+| `git-conflict_detect` | Detect merge conflicts and list conflicted files |
 | `git-conflict_show` | Show conflict markers in a file |
 | `git-conflict_abort_merge` | Abort an in-progress merge |
 

--- a/commands/cleanup.md
+++ b/commands/cleanup.md
@@ -14,5 +14,5 @@ This is a branch cleanup workflow. No pre-flight checks are needed for cleanup.
    - Local only (default)
    - Local and remote (if they confirm)
 4. Run `prune` with the user's confirmation to delete the selected branches.
-5. Run `prune_remote` to clean up stale remote-tracking references.
-6. Show a summary of what was cleaned up.
+   Use `include_remote=true` to also clean up stale remote-tracking references.
+5. Show a summary of what was cleaned up.

--- a/commands/scaffold.md
+++ b/commands/scaffold.md
@@ -15,6 +15,7 @@ This is a project scaffolding workflow.
    - **Full CI/CD** (all of the above + Cloud Build + Terraform)
 3. If CI/CD is selected, confirm the user wants Terraform executed via Cloud
    Build (plan on PR, apply on merge).
-4. Run the appropriate scaffold tool exports (or `full_scaffold` for everything).
+4. Run the `scaffold` tool with the appropriate `components` parameter
+   (or omit `components` for everything).
 5. Show a summary of all files created/skipped.
 6. Follow the standard post-work protocol.

--- a/opencode.json
+++ b/opencode.json
@@ -62,7 +62,6 @@
         "pilot-workspace_*": false,
         "pilot-run_*": false,
         "branch-cleanup_prune": false,
-        "branch-cleanup_prune_remote": false,
         "devops-preflight_*": false,
         "readme-analyze": false,
         "readme-scaffold": false,

--- a/tools/branch-cleanup.ts
+++ b/tools/branch-cleanup.ts
@@ -250,16 +250,4 @@ export const prune = tool({
   },
 })
 
-export const prune_remote = tool({
-  description:
-    "Run git fetch --prune to clean up stale remote-tracking references. " +
-    "This removes local references to remote branches that no longer exist.",
-  args: {},
-  async execute() {
-    const result = await run(["git", "fetch", "--prune"])
-    if (!result.ok) {
-      return `Error pruning remote references: ${result.out}`
-    }
-    return result.out || "Remote-tracking references are up to date."
-  },
-})
+

--- a/tools/devops-preflight.ts
+++ b/tools/devops-preflight.ts
@@ -34,265 +34,203 @@ function slugify(text: string): string {
     .slice(0, 40)
 }
 
-export const check_issue = tool({
-  description:
-    "Verify that a GitHub issue exists and is open. Returns the issue title " +
-    "and state, or an error if the issue does not exist.",
-  args: {
-    number: tool.schema.number().describe("GitHub issue number to verify"),
-  },
-  async execute(args) {
-    if (args.number <= 0) return "FAIL: Issue number must be a positive integer."
+// ─── Individual Check Helpers (private) ──────────────────────────────
 
-    const result = await run([
-      "gh",
-      "issue",
-      "view",
-      String(args.number),
-      "--json",
-      "number,title,state,labels,url",
-    ])
+type PreflightCheck = "issue" | "clean" | "branch" | "plan"
 
-    if (!result.ok) {
-      return `FAIL: Could not find issue #${args.number}. Error: ${result.out}`
+const ALL_CHECKS: PreflightCheck[] = ["issue", "clean", "branch", "plan"]
+
+async function checkIssue(issueNumber: number): Promise<{ lines: string[]; pass: boolean; title: string }> {
+  const lines: string[] = []
+
+  if (issueNumber <= 0) {
+    lines.push("   FAIL: Issue number must be a positive integer.")
+    return { lines, pass: false, title: "" }
+  }
+
+  const result = await run([
+    "gh", "issue", "view", String(issueNumber),
+    "--json", "number,title,state,labels,url",
+  ])
+
+  if (!result.ok) {
+    lines.push(`   FAIL: Could not find issue #${issueNumber}.`)
+    lines.push(`   Error: ${result.out}`)
+    return { lines, pass: false, title: "" }
+  }
+
+  try {
+    const issue = JSON.parse(result.out)
+    const labels = issue.labels?.map((l: any) => l.name).join(", ") || "none"
+    lines.push(`   PASS: Issue #${issue.number} -- ${issue.title}`)
+    lines.push(`   State: ${issue.state}  |  Labels: ${labels}`)
+    if (issue.state === "CLOSED") {
+      lines.push("   WARNING: Issue is closed. Consider reopening or creating a new one.")
     }
+    return { lines, pass: true, title: issue.title || "" }
+  } catch {
+    lines.push(`   PASS: Issue #${issueNumber} exists (could not parse details)`)
+    return { lines, pass: true, title: "" }
+  }
+}
 
-    try {
-      const issue = JSON.parse(result.out)
-      const labels =
-        issue.labels?.map((l: any) => l.name).join(", ") || "none"
-      const lines = [
-        `PASS: Issue #${issue.number} exists`,
-        `  Title  : ${issue.title}`,
-        `  State  : ${issue.state}`,
-        `  Labels : ${labels}`,
-        `  URL    : ${issue.url}`,
-      ]
+async function checkClean(): Promise<{ lines: string[]; pass: boolean }> {
+  const lines: string[] = []
+  const result = await run(["git", "status", "--porcelain"])
 
-      if (issue.state === "CLOSED") {
-        lines.push("")
-        lines.push(
-          "WARNING: This issue is closed. Consider reopening it or creating a new issue.",
-        )
-      }
+  if (!result.ok) {
+    lines.push(`   FAIL: Could not check git status. Error: ${result.out}`)
+    return { lines, pass: false }
+  }
 
-      return lines.join("\n")
-    } catch {
-      return result.out
+  if (result.out === "") {
+    lines.push("   PASS: Working tree is clean.")
+    return { lines, pass: true }
+  }
+
+  const fileLines = result.out.split("\n")
+  const staged = fileLines.filter(
+    (l) => l.startsWith("M ") || l.startsWith("A ") || l.startsWith("D "),
+  )
+  const unstaged = fileLines.filter(
+    (l) => l.startsWith(" M") || l.startsWith(" D") || l.startsWith("MM"),
+  )
+  const untracked = fileLines.filter((l) => l.startsWith("??"))
+
+  lines.push(`   FAIL: Working tree is dirty. ${fileLines.length} file(s) with changes.`)
+  if (staged.length > 0) {
+    lines.push(`   Staged (${staged.length}):`)
+    for (const f of staged) lines.push(`     ${f}`)
+  }
+  if (unstaged.length > 0) {
+    lines.push(`   Unstaged (${unstaged.length}):`)
+    for (const f of unstaged) lines.push(`     ${f}`)
+  }
+  if (untracked.length > 0) {
+    lines.push(`   Untracked (${untracked.length}):`)
+    for (const f of untracked) lines.push(`     ${f}`)
+  }
+  lines.push("   Stash or commit changes before proceeding.")
+  return { lines, pass: false }
+}
+
+async function checkBranch(
+  issueNumber: number,
+  issueTitle: string,
+  type: string,
+): Promise<{ lines: string[]; pass: boolean; branchName: string }> {
+  const lines: string[] = []
+  const slug = slugify(issueTitle)
+  const branchName = `${type}/${issueNumber}-${slug}`
+
+  const currentResult = await run(["git", "rev-parse", "--abbrev-ref", "HEAD"])
+  if (!currentResult.ok) {
+    lines.push("   FAIL: Could not determine current branch.")
+    return { lines, pass: false, branchName }
+  }
+
+  const currentBranch = currentResult.out
+  const issuePattern = `/${issueNumber}-`
+
+  if (currentBranch.includes(issuePattern)) {
+    lines.push(`   PASS: Already on branch '${currentBranch}' for issue #${issueNumber}`)
+    return { lines, pass: true, branchName: currentBranch }
+  }
+
+  const defaultBranch = await getDefaultBranch()
+
+  if (currentBranch !== defaultBranch) {
+    const switchResult = await run(["git", "checkout", defaultBranch])
+    if (!switchResult.ok) {
+      lines.push(`   FAIL: Could not switch to ${defaultBranch}.`)
+      return { lines, pass: false, branchName }
     }
-  },
-})
+  }
 
-export const check_clean = tool({
-  description:
-    "Check if the git working tree is clean (no uncommitted changes). " +
-    "Returns PASS if clean, FAIL with details if dirty.",
-  args: {},
-  async execute() {
-    const result = await run(["git", "status", "--porcelain"])
+  await run(["git", "pull", "--ff-only"]) // non-fatal
 
-    if (!result.ok) {
-      return `FAIL: Could not check git status. Error: ${result.out}`
+  const existsResult = await run(["git", "rev-parse", "--verify", branchName])
+  if (existsResult.ok) {
+    const checkoutResult = await run(["git", "checkout", branchName])
+    if (!checkoutResult.ok) {
+      lines.push(`   FAIL: Could not switch to existing branch '${branchName}'.`)
+      return { lines, pass: false, branchName }
     }
-
-    if (result.out === "") {
-      return "PASS: Working tree is clean. No uncommitted changes."
-    }
-
-    const lines = result.out.split("\n")
-    const staged = lines.filter(
-      (l) => l.startsWith("M ") || l.startsWith("A ") || l.startsWith("D "),
-    )
-    const unstaged = lines.filter(
-      (l) =>
-        l.startsWith(" M") || l.startsWith(" D") || l.startsWith("MM"),
-    )
-    const untracked = lines.filter((l) => l.startsWith("??"))
-
-    const summary = [
-      `FAIL: Working tree is dirty. ${lines.length} file(s) with changes.`,
-      "",
-    ]
-
-    if (staged.length > 0) {
-      summary.push(`Staged (${staged.length}):`)
-      for (const f of staged) summary.push(`  ${f}`)
-      summary.push("")
-    }
-    if (unstaged.length > 0) {
-      summary.push(`Unstaged (${unstaged.length}):`)
-      for (const f of unstaged) summary.push(`  ${f}`)
-      summary.push("")
-    }
-    if (untracked.length > 0) {
-      summary.push(`Untracked (${untracked.length}):`)
-      for (const f of untracked) summary.push(`  ${f}`)
-      summary.push("")
-    }
-
-    summary.push("Options:")
-    summary.push("  1. Stash changes: delegate to @git-ops to stash")
-    summary.push("  2. Commit changes: delegate to @git-ops to commit")
-    summary.push(
-      "  3. Discard changes: only with explicit user confirmation",
-    )
-
-    return summary.join("\n")
-  },
-})
-
-export const check_branch = tool({
-  description:
-    "Create or verify a dedicated branch for an issue. Uses the naming " +
-    "convention <type>/<issue>-<slug>. If already on the correct branch, " +
-    "reports success. Otherwise creates and switches to the new branch.",
-  args: {
-    issue_number: tool.schema.number().describe("GitHub issue number"),
-    issue_title: tool.schema
-      .string()
-      .describe("Issue title (used to generate the branch slug)"),
-    type: tool.schema
-      .enum(["feature", "fix", "chore", "docs", "refactor", "test"])
-      .optional()
-      .describe("Branch type prefix (default: feature)"),
-  },
-  async execute(args) {
-    const type = args.type || "feature"
-    const slug = slugify(args.issue_title)
-    const branchName = `${type}/${args.issue_number}-${slug}`
-
-    // Check current branch
-    const currentResult = await run(["git", "rev-parse", "--abbrev-ref", "HEAD"])
-    if (!currentResult.ok) {
-      return `FAIL: Could not determine current branch. Error: ${currentResult.out}`
-    }
-
-    const currentBranch = currentResult.out
-
-    // Check if already on a branch for this issue
-    const issuePattern = `/${args.issue_number}-`
-    if (currentBranch.includes(issuePattern)) {
-      return [
-        `PASS: Already on branch for issue #${args.issue_number}`,
-        `  Branch: ${currentBranch}`,
-      ].join("\n")
-    }
-
-    // Get default branch to branch from
-    const defaultBranch = await getDefaultBranch()
-
-    // Switch to default branch first if not already on it
-    if (currentBranch !== defaultBranch) {
-      const switchResult = await run(["git", "checkout", defaultBranch])
-      if (!switchResult.ok) {
-        return `FAIL: Could not switch to ${defaultBranch}. Error: ${switchResult.out}`
-      }
-    }
-
-    // Pull latest
-    const pullResult = await run(["git", "pull", "--ff-only"])
-    if (!pullResult.ok) {
-      // Non-fatal: might not have upstream set or be offline
-    }
-
-    // Check if branch already exists locally
-    const existsResult = await run(["git", "rev-parse", "--verify", branchName])
-    if (existsResult.ok) {
-      // Branch exists, just switch to it
-      const checkoutResult = await run(["git", "checkout", branchName])
-      if (!checkoutResult.ok) {
-        return `FAIL: Branch '${branchName}' exists but could not switch to it. Error: ${checkoutResult.out}`
-      }
-      return [
-        `PASS: Switched to existing branch for issue #${args.issue_number}`,
-        `  Branch: ${branchName}`,
-      ].join("\n")
-    }
-
-    // Create new branch
+    lines.push(`   PASS: Switched to existing branch '${branchName}'`)
+  } else {
     const createResult = await run(["git", "checkout", "-b", branchName])
     if (!createResult.ok) {
-      return `FAIL: Could not create branch '${branchName}'. Error: ${createResult.out}`
+      lines.push(`   FAIL: Could not create branch '${branchName}'.`)
+      lines.push(`   Error: ${createResult.out}`)
+      return { lines, pass: false, branchName }
     }
+    lines.push(`   PASS: Created branch '${branchName}' from '${defaultBranch}'`)
+  }
 
-    return [
-      `PASS: Created and switched to new branch for issue #${args.issue_number}`,
-      `  Branch : ${branchName}`,
-      `  Base   : ${defaultBranch}`,
-    ].join("\n")
-  },
-})
+  return { lines, pass: true, branchName }
+}
 
-export const check_plan = tool({
-  description:
-    "Check if an implementation plan has been posted as a comment on the " +
-    "GitHub issue. Looks for a comment containing '## Implementation Plan'. " +
-    "Returns PASS if found, WARN if not found.",
-  args: {
-    number: tool.schema.number().describe("GitHub issue number to check"),
-  },
-  async execute(args) {
-    if (args.number <= 0) return "FAIL: Issue number must be a positive integer."
+async function checkPlan(issueNumber: number): Promise<{ lines: string[]; pass: boolean }> {
+  const lines: string[] = []
 
-    const result = await run([
-      "gh",
-      "issue",
-      "view",
-      String(args.number),
-      "--json",
-      "comments",
-    ])
+  if (issueNumber <= 0) {
+    lines.push("   FAIL: Issue number must be a positive integer.")
+    return { lines, pass: false }
+  }
 
-    if (!result.ok) {
-      return `FAIL: Could not fetch comments for issue #${args.number}. Error: ${result.out}`
-    }
+  const result = await run([
+    "gh", "issue", "view", String(issueNumber),
+    "--json", "comments",
+  ])
 
-    try {
-      const data = JSON.parse(result.out)
-      const comments: Array<{
-        body: string
-        author: { login: string }
-        createdAt: string
-      }> = data.comments || []
+  if (!result.ok) {
+    lines.push(`   FAIL: Could not fetch comments for issue #${issueNumber}. Error: ${result.out}`)
+    return { lines, pass: false }
+  }
 
-      for (const comment of comments) {
-        if (comment.body.includes("## Implementation Plan")) {
-          const date = comment.createdAt
-            ? new Date(comment.createdAt).toISOString().slice(0, 10)
-            : "unknown"
-          return [
-            `PASS: Implementation plan found on issue #${args.number}`,
-            `  Author : ${comment.author?.login || "unknown"}`,
-            `  Date   : ${date}`,
-          ].join("\n")
-        }
+  try {
+    const data = JSON.parse(result.out)
+    const comments: Array<{ body: string; author: { login: string }; createdAt: string }> =
+      data.comments || []
+
+    for (const comment of comments) {
+      if (comment.body.includes("## Implementation Plan")) {
+        const date = comment.createdAt
+          ? new Date(comment.createdAt).toISOString().slice(0, 10)
+          : "unknown"
+        lines.push(`   PASS: Implementation plan found on issue #${issueNumber}`)
+        lines.push(`   Author: ${comment.author?.login || "unknown"}  |  Date: ${date}`)
+        return { lines, pass: true }
       }
-
-      return [
-        `WARN: No implementation plan found on issue #${args.number}`,
-        "",
-        `Searched ${comments.length} comment(s) for a comment containing "## Implementation Plan".`,
-        "",
-        "Options:",
-        "  1. Create and post a plan now (research codebase, draft plan, post as comment)",
-        "  2. Skip plan check (requires explicit user confirmation)",
-        "",
-        "The user MUST explicitly confirm before proceeding without a plan.",
-      ].join("\n")
-    } catch {
-      return `FAIL: Could not parse comments for issue #${args.number}. Raw: ${result.out}`
     }
-  },
-})
 
-export const full_preflight = tool({
+    lines.push(`   WARN: No implementation plan found on issue #${issueNumber}`)
+    lines.push("   Post a plan comment with '## Implementation Plan' header before starting work,")
+    lines.push("   or confirm to proceed without one.")
+    return { lines, pass: true } // WARN is not a failure
+  } catch {
+    lines.push(`   FAIL: Could not parse comments for issue #${issueNumber}. Raw: ${result.out}`)
+    return { lines, pass: false }
+  }
+}
+
+// ─── Tool Exports ────────────────────────────────────────────────────
+
+export const preflight = tool({
   description:
-    "Run all pre-flight checks in sequence: verify issue exists, check for " +
-    "clean working tree, create/verify dedicated branch, and check for an " +
-    "implementation plan on the issue. Returns a consolidated report. " +
-    "This is the preferred way to run pre-flight checks.",
+    "Run pre-flight checks for issue-driven development. Checks: issue exists, " +
+    "working tree is clean, dedicated branch exists/created, and implementation " +
+    "plan posted on the issue. Use the 'checks' parameter to run specific checks, " +
+    "or omit it to run all checks in sequence. This is the standard pre-flight tool.",
   args: {
     issue_number: tool.schema.number().describe("GitHub issue number"),
+    checks: tool.schema
+      .array(tool.schema.enum(["issue", "clean", "branch", "plan"]))
+      .optional()
+      .describe(
+        "Which checks to run. Options: issue, clean, branch, plan. " +
+        "Omit to run all checks in sequence.",
+      ),
     type: tool.schema
       .enum(["feature", "fix", "chore", "docs", "refactor", "test"])
       .optional()
@@ -306,232 +244,102 @@ export const full_preflight = tool({
       ),
   },
   async execute(args) {
+    const checksToRun: PreflightCheck[] =
+      args.checks && args.checks.length > 0
+        ? args.checks as PreflightCheck[]
+        : ALL_CHECKS
+
+    const type = args.type || "feature"
     const lines: string[] = [
       "DevOps Pre-flight Check",
       "=======================",
       "",
     ]
 
-    // 1. Check issue
-    lines.push("1. Issue Check")
-    lines.push("   -----------")
-
-    const issueResult = await run([
-      "gh",
-      "issue",
-      "view",
-      String(args.issue_number),
-      "--json",
-      "number,title,state,labels,url",
-    ])
-
-    if (!issueResult.ok) {
-      lines.push(`   FAIL: Could not find issue #${args.issue_number}.`)
-      lines.push(`   Error: ${issueResult.out}`)
-      lines.push("")
-      lines.push("Pre-flight FAILED. Cannot proceed without a valid issue.")
-      return lines.join("\n")
-    }
-
     let issueTitle = ""
-    try {
-      const issue = JSON.parse(issueResult.out)
-      issueTitle = issue.title || ""
-      const labels =
-        issue.labels?.map((l: any) => l.name).join(", ") || "none"
-      lines.push(`   PASS: Issue #${issue.number} -- ${issue.title}`)
-      lines.push(`   State: ${issue.state}  |  Labels: ${labels}`)
+    let branchName = ""
+    let anyFailed = false
 
-      if (issue.state === "CLOSED") {
-        lines.push(
-          "   WARNING: Issue is closed. Consider reopening or creating a new one.",
-        )
-      }
-    } catch {
-      lines.push(`   PASS: Issue #${args.issue_number} exists (could not parse details)`)
-    }
-    lines.push("")
-
-    // 2. Check clean tree
-    lines.push("2. Clean Tree Check")
-    lines.push("   ----------------")
-
-    const statusResult = await run(["git", "status", "--porcelain"])
-    if (!statusResult.ok) {
-      lines.push(`   FAIL: Could not check git status. Error: ${statusResult.out}`)
-      lines.push("")
-      lines.push("Pre-flight FAILED.")
-      return lines.join("\n")
-    }
-
-    if (statusResult.out !== "") {
-      const fileCount = statusResult.out.split("\n").length
-      lines.push(
-        `   FAIL: Working tree is dirty. ${fileCount} file(s) with changes.`,
-      )
-      lines.push("   Stash or commit changes before proceeding.")
-      lines.push("")
-      lines.push("Pre-flight FAILED. Clean the working tree first.")
-      return lines.join("\n")
-    }
-
-    lines.push("   PASS: Working tree is clean.")
-    lines.push("")
-
-    // 3. Check/create branch
-    lines.push("3. Branch Check")
-    lines.push("   ------------")
-
-    const type = args.type || "feature"
-    const slug = slugify(issueTitle)
-    const branchName = `${type}/${args.issue_number}-${slug}`
-
-    const currentResult = await run([
-      "git",
-      "rev-parse",
-      "--abbrev-ref",
-      "HEAD",
-    ])
-
-    if (!currentResult.ok) {
-      lines.push(`   FAIL: Could not determine current branch.`)
-      lines.push("")
-      lines.push("Pre-flight FAILED.")
-      return lines.join("\n")
-    }
-
-    const currentBranch = currentResult.out
-    const issuePattern = `/${args.issue_number}-`
-
-    if (currentBranch.includes(issuePattern)) {
-      lines.push(
-        `   PASS: Already on branch '${currentBranch}' for issue #${args.issue_number}`,
-      )
-    } else {
-      // Get default branch
-      const defaultBranch = await getDefaultBranch()
-
-      // Switch to default branch if needed
-      if (currentBranch !== defaultBranch) {
-        const switchResult = await run(["git", "checkout", defaultBranch])
-        if (!switchResult.ok) {
-          lines.push(`   FAIL: Could not switch to ${defaultBranch}.`)
-          lines.push("")
-          lines.push("Pre-flight FAILED.")
-          return lines.join("\n")
-        }
-      }
-
-      // Pull latest (non-fatal)
-      await run(["git", "pull", "--ff-only"])
-
-      // Check if branch exists
-      const existsResult = await run([
-        "git",
-        "rev-parse",
-        "--verify",
-        branchName,
-      ])
-
-      if (existsResult.ok) {
-        const checkoutResult = await run(["git", "checkout", branchName])
-        if (!checkoutResult.ok) {
-          lines.push(`   FAIL: Could not switch to existing branch '${branchName}'.`)
-          lines.push("")
-          lines.push("Pre-flight FAILED.")
-          return lines.join("\n")
-        }
-        lines.push(`   PASS: Switched to existing branch '${branchName}'`)
-      } else {
-        const createResult = await run(["git", "checkout", "-b", branchName])
-        if (!createResult.ok) {
-          lines.push(`   FAIL: Could not create branch '${branchName}'.`)
-          lines.push(`   Error: ${createResult.out}`)
-          lines.push("")
-          lines.push("Pre-flight FAILED.")
-          return lines.join("\n")
-        }
-        lines.push(`   PASS: Created branch '${branchName}' from '${defaultBranch}'`)
-      }
-    }
-
-    lines.push("")
-
-    // 4. Check for implementation plan
-    lines.push("4. Plan Check")
-    lines.push("   ----------")
-
-    if (args.skip_plan_check) {
-      lines.push("   SKIP: Plan check skipped by user.")
-      lines.push("")
-    } else {
-      const commentsResult = await run([
-        "gh",
-        "issue",
-        "view",
-        String(args.issue_number),
-        "--json",
-        "comments",
-      ])
-
-      let hasPlan = false
-      let planAuthor = ""
-      let planDate = ""
-
-      if (commentsResult.ok) {
-        try {
-          const data = JSON.parse(commentsResult.out)
-          const comments: Array<{
-            body: string
-            author: { login: string }
-            createdAt: string
-          }> = data.comments || []
-
-          for (const comment of comments) {
-            if (comment.body.includes("## Implementation Plan")) {
-              hasPlan = true
-              planAuthor = comment.author?.login || "unknown"
-              planDate = comment.createdAt
-                ? new Date(comment.createdAt).toISOString().slice(0, 10)
-                : "unknown"
-              break
-            }
+    // Run checks in order
+    let step = 1
+    for (const check of checksToRun) {
+      switch (check) {
+        case "issue": {
+          lines.push(`${step}. Issue Check`)
+          lines.push("   -----------")
+          const issueResult = await checkIssue(args.issue_number)
+          lines.push(...issueResult.lines)
+          issueTitle = issueResult.title
+          if (!issueResult.pass) {
+            anyFailed = true
+            lines.push("")
+            lines.push("Pre-flight FAILED. Cannot proceed without a valid issue.")
+            return lines.join("\n")
           }
-        } catch {
-          // If we can't parse comments, treat as no plan found
+          lines.push("")
+          break
+        }
+
+        case "clean": {
+          lines.push(`${step}. Clean Tree Check`)
+          lines.push("   ----------------")
+          const cleanResult = await checkClean()
+          lines.push(...cleanResult.lines)
+          if (!cleanResult.pass) {
+            anyFailed = true
+            lines.push("")
+            lines.push("Pre-flight FAILED. Clean the working tree first.")
+            return lines.join("\n")
+          }
+          lines.push("")
+          break
+        }
+
+        case "branch": {
+          lines.push(`${step}. Branch Check`)
+          lines.push("   ------------")
+          const branchResult = await checkBranch(args.issue_number, issueTitle, type)
+          lines.push(...branchResult.lines)
+          branchName = branchResult.branchName
+          if (!branchResult.pass) {
+            anyFailed = true
+            lines.push("")
+            lines.push("Pre-flight FAILED.")
+            return lines.join("\n")
+          }
+          lines.push("")
+          break
+        }
+
+        case "plan": {
+          lines.push(`${step}. Plan Check`)
+          lines.push("   ----------")
+          if (args.skip_plan_check) {
+            lines.push("   SKIP: Plan check skipped by user.")
+          } else {
+            const planResult = await checkPlan(args.issue_number)
+            lines.push(...planResult.lines)
+          }
+          lines.push("")
+          break
         }
       }
-
-      if (hasPlan) {
-        lines.push(
-          `   PASS: Implementation plan found on issue #${args.issue_number}`,
-        )
-        lines.push(`   Author: ${planAuthor}  |  Date: ${planDate}`)
-      } else {
-        lines.push(
-          `   WARN: No implementation plan found on issue #${args.issue_number}`,
-        )
-        lines.push(
-          "   Post a plan comment with '## Implementation Plan' header before starting work,",
-        )
-        lines.push(
-          "   or confirm to proceed without one.",
-        )
-      }
-      lines.push("")
+      step++
     }
 
     // Determine overall result
     const hasWarning = lines.some((l) => l.includes("WARN:"))
-    const overallResult = hasWarning
-      ? "Pre-flight PASSED with warnings. Review warnings before proceeding."
-      : "Pre-flight PASSED. Ready to proceed."
+    const overallResult = anyFailed
+      ? "Pre-flight FAILED."
+      : hasWarning
+        ? "Pre-flight PASSED with warnings. Review warnings before proceeding."
+        : "Pre-flight PASSED. Ready to proceed."
 
     lines.push("=======================")
     lines.push(overallResult)
     lines.push("")
     lines.push(`Issue  : #${args.issue_number} -- ${issueTitle}`)
-    lines.push(`Branch : ${branchName || currentBranch}`)
+    if (branchName) lines.push(`Branch : ${branchName}`)
 
     return lines.join("\n")
   },

--- a/tools/git-conflict.ts
+++ b/tools/git-conflict.ts
@@ -16,8 +16,8 @@ async function gitRun(args: string[]): Promise<string> {
 
 export const detect = tool({
   description:
-    "Detect if there are any merge conflicts in the working tree. " +
-    "Returns a summary of conflict status.",
+    "Detect merge conflicts in the working tree and list all conflicted files. " +
+    "Returns conflict status and the list of files with conflicts.",
   args: {},
   async execute() {
     // Check for unmerged paths
@@ -30,27 +30,12 @@ export const detect = tool({
     if (result.startsWith("Error:")) return result
 
     const files = result.split("\n").filter(Boolean)
-    return `Found ${files.length} file(s) with merge conflicts:\n${files.map((f) => `  - ${f}`).join("\n")}`
-  },
-})
-
-export const list_files = tool({
-  description:
-    "List all files that currently have merge conflicts.",
-  args: {},
-  async execute() {
-    const result = await gitRun(["diff", "--name-only", "--diff-filter=U"])
-
-    if (!result || result === "") {
-      return "No files with merge conflicts."
-    }
-
-    if (result.startsWith("Error:")) return result
-
-    const files = result.split("\n").filter(Boolean)
-    const lines = [`${files.length} file(s) with conflicts:`, ""]
+    const lines = [
+      `Found ${files.length} file(s) with merge conflicts:`,
+      "",
+    ]
     for (const f of files) {
-      lines.push(`  ${f}`)
+      lines.push(`  - ${f}`)
     }
     return lines.join("\n")
   },


### PR DESCRIPTION
## Summary

Consolidates redundant and granular tools to reduce context window bloat. This is the P1 tranche of the performance audit findings.

### Changes

| Issue | Change | Tools Removed | Token Savings |
|-------|--------|---------------|---------------|
| #82 | 7 scaffold tools → 1 `scaffold` tool with `components` parameter | 6 | ~2,100 |
| #84 | 5 preflight check tools → 1 `preflight` tool with `checks` parameter | 4 | ~1,400 |
| #85 | Merged duplicate `git-conflict_detect` and `git-conflict_list_files` | 1 | ~350 |
| #87 | Removed redundant `branch-cleanup_prune_remote` (covered by `prune` with `include_remote=true`) | 1 | ~350 |

**Net reduction: 12 tool definitions, ~4,200 tokens saved per agent invocation**

### Files Changed (10)

- `tools/scaffold.ts` — Replaced 7 exports with single `scaffold` export using `components` array parameter
- `tools/devops-preflight.ts` — Replaced 5 check exports with single `preflight` export using `checks` array parameter; kept `validate_tests` separate
- `tools/git-conflict.ts` — Removed `list_files` export, enhanced `detect` to return both status and file list
- `tools/branch-cleanup.ts` — Removed `prune_remote` export (functionality already in `prune` with `include_remote=true`)
- `commands/scaffold.md` — Updated to reference consolidated `scaffold` tool
- `commands/cleanup.md` — Removed reference to `prune_remote`, updated step to use `prune` with `include_remote=true`
- `agents/devops/agent.md` — Updated `full_preflight` → `preflight` reference
- `agents/devops/README.md` — Updated tools table
- `agents/git-ops/README.md` — Removed `list_files` from conflict tools table
- `opencode.json` — Removed `branch-cleanup_prune_remote` from plan agent disable list

### Backward Compatibility

- `scaffold` with no `components` parameter generates everything (same as old `full_scaffold`)
- `preflight` with no `checks` parameter runs all checks (same as old `full_preflight`)
- All wildcard disable patterns (`scaffold_*`, `devops-preflight_*`, `git-conflict_*`, `branch-cleanup_*`) continue to work correctly

Closes #82, closes #84, closes #85, closes #87