### PR TITLE
feat(devops): enforce branch protection and add self-review-merge loop

### DIFF
--- a/agents/devops/agent.md
+++ b/agents/devops/agent.md
@@ -109,6 +109,9 @@ Before performing ANY work, run `preflight` with the issue number. This:
 4. Creates or checks out a dedicated branch in the workspace
 5. Checks for an implementation plan on the issue
 
+**The branch step is mandatory and non-negotiable.** After preflight, you
+MUST be on a non-default branch. If the branch check fails, do NOT proceed.
+
 All checks must pass before work begins.
 
 - If the user provides an issue number, use it directly.
@@ -159,6 +162,8 @@ You MUST delegate to the appropriate agent for:
 - Creating and merging pull requests
 - Code reviews and releases
 - Stashing and unstashing changes
+- Self-reviewing PR diffs (get diff, analyze against review checklist, report findings)
+- Merging PRs after successful review (squash merge, delete branch)
 
 **When delegating to @git-ops, always include the workspace path** so it
 can operate in the correct isolated clone.
@@ -202,17 +207,43 @@ After completing the requested work:
    - Links back to the issue using `Closes #<number>` in the body
    - Uses `delete_branch: true` so the remote branch is cleaned up on merge
    - **Include the workspace path.**
-5. **Clean up workspace** -- Run `agent_workspace_destroy` to remove the
-   isolated clone from `/tmp/agent-*`.
-6. **Report back** -- Summarize what was done, the PR URL, and the linked issue.
+5. **Self-review the PR** (mandatory) -- Delegate to `@git-ops` to:
+   - Get the full PR diff
+   - Analyze the diff against the review checklist: code quality, correctness,
+     security (no hardcoded secrets), performance, error handling, documentation
+   - Return a list of findings or confirm the review is clean
+6. **Fix remediations** (max 2 iterations) -- If the self-review found issues:
+   - Fix the issues in the workspace (which is still alive)
+   - Stage, commit, and push the fixes (delegate to `@git-ops`)
+   - Re-request a review from `@git-ops` on the updated PR
+   - If issues remain after 2 remediation rounds, leave the PR open and add
+     a review comment listing the remaining issues for manual review
+   - If clean after any round, proceed to merge
+7. **Merge the PR** -- If the self-review is clean (or after successful
+   remediation), delegate to `@git-ops` to:
+   - Squash merge the PR
+   - Set `delete_branch: true` to clean up the remote branch
+   - If merge fails (e.g., conflicts, branch protection rules), report the
+     failure and leave the PR open
+8. **Clean up workspace** -- Run `agent_workspace_destroy` to remove the
+   isolated clone from `/tmp/agent-*`. Do NOT destroy the workspace until
+   the PR is merged or the review loop is complete.
+9. **Report back** -- Summarize what was done, the PR URL, the linked issue,
+   the review outcome, and the merge status.
 
 ## Safety Rules
 
+- **NEVER** commit or push to the default branch (main/master) directly.
+  All work MUST happen on a dedicated branch created during pre-flight.
+  If you find yourself on the default branch, STOP immediately.
 - **NEVER** skip the pre-flight protocol. It exists to prevent mistakes.
 - **NEVER** skip test validation silently. If tests fail or no test
   infrastructure exists, the user must explicitly confirm before proceeding.
 - **NEVER** operate on the main working tree. All work happens in the
   isolated workspace returned by preflight.
+- **NEVER** destroy the workspace until the PR is merged or the review
+  loop is complete (max 2 iterations). The workspace must remain alive
+  for remediation fixes.
 - **NEVER** run destructive commands (`rm -rf`, `podman system prune`, etc.)
   without explicit user approval.
 - **ALWAYS** show what will change before executing destructive operations.

--- a/commands/implement.md
+++ b/commands/implement.md
@@ -1,5 +1,5 @@
 ---
-description: Implement an issue from its plan, commit, create PR, and optionally merge
+description: Implement an issue from its plan, commit, create PR, review, and merge
 agent: devops
 ---
 
@@ -16,10 +16,16 @@ ask the user to re-state context that already exists in the conversation.
 3. If no plan exists, stop and tell the user to add a plan first
 4. Execute each step in the plan sequentially
 5. After all steps are complete, follow the post-work protocol:
+   - Validate documentation (delegate to @docs for readme-validate)
    - Run test validation
    - Stage and commit with conventional commit message referencing the issue
    - Create a PR that closes the issue
-6. Report the PR URL and a summary of changes made
-7. Ask the user: "PR #N is ready to merge. Merge? [yes/no]"
-   - If yes, squash merge the PR and delete the branch
-   - If no, leave the PR open for manual review
+6. Self-review the PR:
+   - Delegate to @git-ops to get the PR diff and review against the
+     code quality checklist (correctness, security, performance, docs)
+   - If issues are found, fix them in the workspace, commit, push,
+     and re-review (max 2 iterations)
+   - If issues persist after 2 rounds, leave the PR open with a comment
+     listing remaining issues for manual review
+7. If the review is clean, squash merge the PR and delete the branch
+8. Report the PR URL, review outcome, and merge status

--- a/skills/devops-workflow/SKILL.md
+++ b/skills/devops-workflow/SKILL.md
@@ -28,6 +28,10 @@ Every task follows this sequence before work begins:
 5. Plan Check      ->  Implementation plan posted on the issue
 ```
 
+**CRITICAL**: After pre-flight, verify you are NOT on the default branch.
+The agent must never commit directly to main/master. If somehow on the
+default branch, STOP and re-run preflight.
+
 All checks must PASS before any work begins. If any check fails, stop and
 resolve the issue before proceeding.
 
@@ -74,30 +78,38 @@ Rules:
 
 ```
 Issue Created
-  |
+  │
   v
 Pre-flight Checks (issue, clean tree, workspace + branch, plan)
-  |
+  │
   v
 Work Execution (in isolated workspace — containers, infra, troubleshooting)
-  |
+  │
   v
 Test Validation (mandatory — PASS / FAIL / WARN — run in workspace)
-  |
+  │
   v
 Stage & Commit (via @git-ops with workspace path, conventional commit format)
-  |
+  │
   v
 Create PR (via @git-ops with workspace path, with "Closes #N" in body)
-  |         - Always set delete_branch: true
+  │         - Always set delete_branch: true
   v
-Destroy Workspace (agent_workspace_destroy)
-  |
+Self-Review PR (via @git-ops — diff analysis against review checklist)
+  │
+  ├── Clean ──────────────────────────┐
+  │                                   v
+  ├── Issues Found ──> Fix ──> Re-review (max 2 iterations)
+  │                               │
+  │                     ├── Clean ─┤
+  │                     │          v
+  │                     └── Still issues ──> Leave PR open with comment
+  │                                          │
+  v                                          v
+Merge PR (squash, delete branch)      Destroy Workspace & Report
+  │
   v
-Review & Merge
-  |
-  v
-Post-merge Cleanup
+Destroy Workspace & Report
 ```
 
 ## Test Validation
@@ -133,6 +145,44 @@ The tool searches for test infrastructure in this order:
   found. Do you want to proceed without test validation?"
 - Skipping should be the exception, not the norm.
 
+## Self-Review Protocol
+
+After creating the PR, the agent MUST self-review before merging. This is
+delegated to `@git-ops` and is never skipped.
+
+### Process
+
+1. Delegate to `@git-ops` to get the full PR diff
+2. `@git-ops` analyzes the diff against the review checklist
+3. If issues are found:
+   - Fix them in the workspace (which must still be alive)
+   - Stage, commit, and push fixes via `@git-ops`
+   - Re-request a review from `@git-ops` on the updated PR
+   - Maximum **2 remediation iterations**
+4. If clean (or after successful remediation): merge via `@git-ops`
+   using squash merge with `delete_branch: true`
+5. If issues persist after 2 rounds: leave PR open with a review
+   comment listing remaining issues for manual review
+
+### Review Checklist
+
+The self-review checks for:
+
+- Code follows project conventions and style
+- No hardcoded secrets or credentials
+- Error handling is appropriate
+- No unnecessary complexity or duplication
+- Logic is correct and handles edge cases
+- Public APIs are documented
+- README updated if needed
+
+### Remediation Rules
+
+- The workspace MUST remain alive until the review loop completes
+- Each fix iteration requires a new commit (do not amend)
+- After 2 failed iterations, the agent MUST stop and leave the PR open
+- The agent MUST NOT skip the review or auto-approve without analysis
+
 ## Commit Message Convention
 
 Use conventional commits: `type(scope): description`
@@ -144,12 +194,13 @@ Use conventional commits: `type(scope): description`
 
 ## Post-merge Cleanup
 
-After a PR is merged, clean up to prevent branch accumulation:
+After a PR is merged (either via the self-review-merge loop or manually),
+clean up to prevent branch accumulation:
 
-1. Destroy workspace: `agent_workspace_destroy` (if not already destroyed)
+1. Destroy workspace: `agent_workspace_destroy` (if not already destroyed).
+   The workspace is kept alive during the review loop for remediation fixes,
+   and destroyed only after the PR is merged or the loop completes.
 2. Delete local branch: `git branch -d <branch>` (in the main repo)
 3. Prune remote refs: `git fetch --prune`
 
 Use the `/cleanup` command to list and prune stale merged branches.
-This is a separate step from the post-work protocol. Do NOT run cleanup
-immediately after PR creation -- wait until the PR is merged.


### PR DESCRIPTION
## Summary

- Add explicit branch protection rules preventing direct commits to main/master, with mandatory verification after preflight
- Extend the post-work protocol with a self-review → fix → merge loop: PR diffs are analyzed against a code quality checklist, with up to 2 remediation iterations before auto-merging clean PRs
- Update the implement command to include self-review, remediation, and merge steps

## Files Changed

| File | Changes |
|------|---------|
| `agents/devops/agent.md` | Branch protection emphasis in pre-flight, self-review/merge delegation to @git-ops, expanded post-work protocol (steps 5-9), new safety rules |
| `skills/devops-workflow/SKILL.md` | Branch verification after preflight, updated lifecycle diagram with review-merge loop, new Self-Review Protocol section with checklist and remediation rules |
| `commands/implement.md` | Added self-review, remediation loop (max 2 iterations), and merge steps |

## Review Checklist

- [x] All changes are markdown/documentation only — no TypeScript tool code changes
- [x] No permission changes needed — review stays delegated to @git-ops
- [x] Existing formatting style preserved (double-dash em dashes, backticks, bold emphasis)
- [x] All unmodified content preserved (Context Awareness, Core Responsibilities, Response Format sections)

Closes #92