### PR TITLE
feat: add logs-analyse tool, command, skill, and scaffold log capture

### DIFF
--- a/agents/devops/agent.md
+++ b/agents/devops/agent.md
@@ -35,6 +35,7 @@ permission:
     container-ops: allow
     cloudbuild-ops: allow
     gcloud-ops: allow
+    log-analysis: allow
   bash:
     "*": deny
     # Git operations scoped to workspaces — prevent branch switching in main tree
@@ -83,6 +84,7 @@ permission:
     "tail *": allow
     "chmod *": allow
     "mkdir *": allow
+    "journalctl *": allow
 ---
 
 You are a DevOps operations assistant that enforces disciplined, issue-driven

--- a/commands/logs-analyse.md
+++ b/commands/logs-analyse.md
@@ -1,0 +1,52 @@
+---
+description: Analyse logs from containers, builds, services, or files to diagnose issues
+agent: devops
+---
+
+$ARGUMENTS
+
+This is a log analysis and diagnostics workflow.
+
+**Step 1: Determine scope from arguments**
+
+If $ARGUMENTS specifies a file path (contains `/` or ends in `.log`):
+- Use `read_logs` with the file path as target (source auto-detection will resolve to "file")
+- Then use `extract_errors` on the same target to find issues
+- Skip discovery — go straight to analysis
+
+If $ARGUMENTS specifies a container name, build ID, or systemd unit:
+- Use `read_logs` with the target (source auto-detection will resolve the type)
+- Then use `extract_errors` on the same target
+- Skip discovery — go straight to analysis
+
+If $ARGUMENTS mentions "compare" or "diff" with two targets:
+- Use `compare_logs` with the two targets as `good` and `bad`
+- Analyse the differences and identify likely root cause
+
+If $ARGUMENTS is empty or says "everything" / "what's broken":
+- Run `discover_sources` to find all available log sources
+- For each discovered source, run `extract_errors` to find issues
+- Use `since: "1h"` as default time window
+
+**Step 2: Analyse and report**
+
+Load the `log-analysis` skill for domain-specific diagnostic knowledge.
+
+For each source with findings, present a structured diagnostic summary:
+
+1. **Source** — what was checked (file path, container name, build ID)
+2. **Severity** — count of critical/error/warning messages found
+3. **Key findings** — the most significant errors with context
+4. **Likely cause** — your assessment based on the error patterns and the
+   log-analysis skill's decision trees
+5. **Suggested action** — what to try next to resolve the issue
+
+Number each finding for drill-down reference.
+
+**Step 3: Offer next steps**
+
+After presenting the summary, offer:
+- "Want me to dig deeper into finding #N?"
+- "Should I check system health with the troubleshoot tools?"
+- "Want me to compare against a previous successful run?"
+- "Should I create a GitHub issue for this error?"

--- a/skills/log-analysis/SKILL.md
+++ b/skills/log-analysis/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: log-analysis
+description: Systematic log analysis and incident diagnosis patterns
+---
+
+## What I do
+
+- Guide systematic log investigation across multiple sources
+- Provide error pattern recognition for common tools and languages
+- Document diagnostic decision trees for common failure modes
+- Help correlate errors across services and time windows
+
+## When to use me
+
+Use this skill when analysing logs, diagnosing failures, or investigating
+incidents across containers, CI/CD pipelines, infrastructure, or applications.
+
+## Diagnostic Decision Trees
+
+### Container won't start
+1. Check `podman logs <container>` for startup errors
+2. Look for: port conflicts, missing env vars, permission denied, OOM
+3. Check `podman inspect` for exit code:
+   - **137** → OOMKilled (container exceeded memory limit)
+   - **1** → Application error (check app logs for stack trace)
+   - **126** → Permission denied (check file permissions, USER directive)
+   - **127** → Command not found (check CMD/ENTRYPOINT in Dockerfile)
+   - **143** → SIGTERM (graceful shutdown, check orchestrator)
+4. Cross-reference with `container_health` and `check_ports` troubleshoot tools
+
+### Cloud Build failure
+1. Check `gcloud builds log <id>` for the failing step
+2. Common patterns:
+   - **"DEADLINE_EXCEEDED"** → Build timeout, increase `timeout` in cloudbuild.yaml
+   - **"permission denied"** → Service account missing IAM roles
+   - **"not found"** → Image or artifact reference is wrong
+   - **"FETCHSOURCE" error** → Can't access source repo, check permissions
+   - **Step N "failed"** → Read step N logs for the actual error
+3. Check substitution variables match expectations
+4. Verify the Cloud Build service account has required permissions
+
+### Terraform apply failure
+1. Check for state lock ("Error acquiring the state lock") → Wait or force-unlock
+2. Check for resource conflicts ("Resource already exists") → Import or taint
+3. Check for quota/permission errors → Request quota increase or fix IAM
+4. Check for dependency errors → Run `terraform plan` first to preview
+5. Run `terraform state list` to verify current state
+
+### Application crash loop
+1. Check container restart count with `podman ps`
+2. Read last 100 lines of logs before each crash
+3. Look for: unhandled exceptions, segfaults, OOM, connection refused
+4. Check if the crash correlates with a recent deployment
+5. Check resource limits (memory, CPU) against actual usage
+
+### CI/CD pipeline stuck
+1. Check for pending approvals or manual gates
+2. Check for resource quotas (concurrent build limits)
+3. Check network connectivity to artifact registries
+4. Look for deadlocked dependencies between build steps
+
+## Common Error Patterns by Tool
+
+### Podman
+| Error | Likely Cause | Fix |
+|-------|-------------|-----|
+| `port already in use` | Another container/process on same port | Use `check_ports` tool, then stop conflicting process |
+| `OOMKilled` (exit 137) | Container exceeded memory limit | Increase `--memory` flag or fix memory leak |
+| `no such image` | Image not built or wrong tag | Check with `podman images`, rebuild if needed |
+| `permission denied` | File ownership mismatch | Check USER in Dockerfile, fix COPY --chown |
+| `network not found` | Pod network doesn't exist | Create network with `podman network create` |
+
+### Cloud Build
+| Error | Likely Cause | Fix |
+|-------|-------------|-----|
+| `TIMEOUT` | Build exceeded deadline | Increase `timeout` in cloudbuild config |
+| `FETCHSOURCE` | Can't access source repo | Check repo permissions and triggers |
+| `Step N failed` | Build step returned non-zero | Read step N output for details |
+| `INTERNAL` | Cloud Build service issue | Retry, check GCP status dashboard |
+
+### Terraform
+| Error | Likely Cause | Fix |
+|-------|-------------|-----|
+| `state lock` | Another process holds the lock | Wait or `terraform force-unlock <ID>` |
+| `already exists` | Resource created outside TF | `terraform import` or `terraform taint` |
+| `quota exceeded` | GCP quota limit hit | Request quota increase in Cloud Console |
+| `provider produced inconsistent result` | Provider bug or state drift | `terraform refresh` then retry |
+
+### GCP / gcloud
+| Error | Likely Cause | Fix |
+|-------|-------------|-----|
+| `PERMISSION_DENIED` | Missing IAM role | Grant required role to service account |
+| `NOT_FOUND` | Resource doesn't exist | Check resource name, project, region |
+| `RESOURCE_EXHAUSTED` | Quota limit reached | Request quota increase |
+| `UNAVAILABLE` | Service temporarily down | Retry with exponential backoff |
+
+## Log Severity Patterns by Language
+
+Use these patterns to detect error severity in application logs:
+
+### Python
+- **Error**: `Traceback (most recent call last)`, `raise \w+Error`, `logging.error`, `logging.critical`
+- **Warning**: `logging.warning`, `DeprecationWarning`, `UserWarning`
+- Stack traces span multiple lines — capture from `Traceback` to the final exception line
+
+### Go
+- **Error**: `level=error`, `level=fatal`, `panic:`, `fatal error:`, `goroutine \d+`
+- **Warning**: `level=warn`, `level=warning`
+- Panic traces include goroutine dumps — capture the full goroutine block
+
+### Node.js / TypeScript
+- **Error**: `Error:`, `TypeError:`, `ReferenceError:`, `UnhandledPromiseRejection`, `ECONNREFUSED`, `ENOENT`
+- **Warning**: `DeprecationWarning`, `ExperimentalWarning`
+- Stack traces start with `Error:` followed by indented `at` lines
+
+### Rust
+- **Error**: `thread .* panicked at`, `RUST_BACKTRACE`, `fatal runtime error`
+- **Warning**: `warning:` from compiler output
+- Panic traces include file:line:column references
+
+### Java
+- **Error**: `Exception in thread`, `at .*\(.*\.java:\d+\)`, `Caused by:`, `java.lang.\w+Exception`
+- **Warning**: `WARN`, `WARNING`
+- Stack traces are multi-line with `at` prefixed lines and `Caused by:` chains
+
+### Structured JSON Logs
+- Look for `"level"`, `"severity"`, `"lvl"` fields
+- Common values: `"error"`, `"fatal"`, `"warn"`, `"info"`, `"debug"`
+- Parse the JSON to extract structured fields when possible
+
+### Syslog / systemd
+- **Error**: `<*.err>`, `<*.crit>`, `<*.alert>`, `<*.emerg>`
+- **Warning**: `<*.warning>`
+- Use `journalctl -p err` to filter by priority
+
+## Analysis Best Practices
+
+1. **Start with errors, then expand to warnings** — Don't get lost in noise
+2. **Check timestamps** — Are errors clustered at a specific time?
+3. **Correlate across sources** — Did the container crash at the same time as a deploy?
+4. **Look for the first error** — Later errors are often cascading failures
+5. **Check resource metrics alongside logs** — OOM, CPU throttling, disk full
+6. **Compare against a known good run** — Use `compare_logs` when available

--- a/skills/makefile-ops/SKILL.md
+++ b/skills/makefile-ops/SKILL.md
@@ -25,6 +25,7 @@ project's development workflow.
 | **Local dev** | `local-init` | `local-clean` | `local-build` | `local-run` | `local-test` | `local-lint` |
 | **Container dev** | `container-init` | `container-clean` | `container-build` | `container-run` | — | — |
 | **Cloud runtime** | `cloud-init` | `cloud-clean` | `cloud-build` | `cloud-deploy` | — | — |
+| **Logs** | — | `logs-clean` | — | — | — | `logs-list` / `logs-last` |
 
 ### Thin-wrapper Pattern
 
@@ -124,6 +125,28 @@ Must exclude:
 - `.env`, `.env.*` (secrets must not be baked into images)
 - `cicd/terraform/`, `cicd/cloudbuild*.yaml` (not needed in the image)
 - Language-specific artifacts (`node_modules/`, `__pycache__/`, `target/`, etc.)
+
+### Log Management Targets
+
+The scaffolded Makefile includes targets for managing per-run log files:
+
+| Target | Description |
+|--------|-------------|
+| `logs-list` | List recent log files (newest first, max 20) |
+| `logs-last` | Display contents of the most recent log file |
+| `logs-clean` | Remove all log files from `logs/` directory |
+
+Log files are created automatically by the scaffolded scripts. Each `make`
+target execution generates a timestamped log file in `logs/`:
+
+```
+logs/20260307-143022-local-build.log
+logs/20260307-143155-container-run.log
+logs/20260307-150000-cloud-deploy.log
+```
+
+These log files capture all stdout and stderr output from the command,
+making it easy to review past runs and diagnose failures.
 
 ## Per-language Patterns
 

--- a/tools/logs-analyse.ts
+++ b/tools/logs-analyse.ts
@@ -1,0 +1,548 @@
+import { tool } from "@opencode-ai/plugin"
+import { existsSync, readdirSync, readFileSync, statSync } from "fs"
+import { join, basename } from "path"
+
+// ─── Helpers ────────────────────────────────────────────────────────
+
+async function run(cmd: string[]): Promise<{ ok: boolean; out: string }> {
+  try {
+    const result = await Bun.$`${cmd}`.text()
+    return { ok: true, out: result.trim() }
+  } catch (e: any) {
+    return {
+      ok: false,
+      out: e?.stderr?.toString?.()?.trim() || e.message || "unknown error",
+    }
+  }
+}
+
+type SourceType = "file" | "container" | "cloudbuild" | "journald" | "gcloud"
+
+function inferSource(target: string): SourceType {
+  if (target.includes("/") || target.endsWith(".log") || target.endsWith(".txt")) return "file"
+  if (/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/.test(target)) return "cloudbuild"
+  if (target.endsWith(".service")) return "journald"
+  return "container"
+}
+
+const SEVERITY_PATTERNS: Record<string, RegExp> = {
+  error: /\b(ERROR|FATAL|CRIT(?:ICAL)?|PANIC|EXCEPTION|FAIL(?:ED|URE)?|Traceback|panic:|fatal error:|UnhandledPromiseRejection|ECONNREFUSED|OOMKilled|segfault|SIGSEGV|SIGKILL)\b/i,
+  warning: /\b(WARN(?:ING)?|DEPRECAT(?:ED|ION)|TIMEOUT|RETRY|retry|timeout)\b/i,
+  info: /\b(INFO|DEBUG|TRACE|NOTICE)\b/i,
+}
+
+function matchesSeverity(line: string, minSeverity: string): boolean {
+  if (minSeverity === "all") return true
+  if (minSeverity === "info") return true
+  if (minSeverity === "warning") {
+    return SEVERITY_PATTERNS.error.test(line) || SEVERITY_PATTERNS.warning.test(line)
+  }
+  if (minSeverity === "error") {
+    return SEVERITY_PATTERNS.error.test(line)
+  }
+  return true
+}
+
+function extractWithContext(lines: string[], pattern: RegExp, contextLines: number = 5): string[] {
+  const result: string[] = []
+  const matched = new Set<number>()
+
+  for (let i = 0; i < lines.length; i++) {
+    if (pattern.test(lines[i])) {
+      matched.add(i)
+    }
+  }
+
+  for (const idx of matched) {
+    const start = Math.max(0, idx - contextLines)
+    const end = Math.min(lines.length - 1, idx + contextLines)
+    if (result.length > 0) result.push("---")
+    for (let i = start; i <= end; i++) {
+      const marker = matched.has(i) ? ">>> " : "    "
+      result.push(`${marker}${i + 1}: ${lines[i]}`)
+    }
+  }
+
+  return result
+}
+
+// ─── Tool: discover_sources ─────────────────────────────────────────
+
+export const discover_sources = tool({
+  description:
+    "Auto-detect available log sources in the current project. " +
+    "Checks for local log files in logs/, running containers, " +
+    "recent Cloud Build builds, and common log file patterns.",
+  args: {},
+  async execute(_args, context) {
+    const root = context.directory || "."
+    const sources: string[] = ["Log Source Discovery", "====================", ""]
+
+    // 1. Check logs/ directory (scaffolded per-run logs)
+    const logsDir = join(root, "logs")
+    if (existsSync(logsDir)) {
+      try {
+        const files = readdirSync(logsDir)
+          .filter((f) => f.endsWith(".log"))
+          .sort()
+          .reverse()
+          .slice(0, 10)
+        if (files.length > 0) {
+          sources.push("── Local Log Files (logs/) ──")
+          for (const f of files) {
+            const stat = statSync(join(logsDir, f))
+            const age = Math.round((Date.now() - stat.mtimeMs) / 60000)
+            const size = stat.size > 1024 ? `${(stat.size / 1024).toFixed(1)}KB` : `${stat.size}B`
+            sources.push(`  ${f}  (${age}m ago, ${size})`)
+          }
+          sources.push("")
+        }
+      } catch { /* non-fatal */ }
+    }
+
+    // 2. Check for *.log files in project root
+    try {
+      const rootFiles = readdirSync(root).filter(
+        (f) => f.endsWith(".log") && statSync(join(root, f)).isFile(),
+      )
+      if (rootFiles.length > 0) {
+        sources.push("── Log Files (project root) ──")
+        for (const f of rootFiles) {
+          const stat = statSync(join(root, f))
+          const size = stat.size > 1024 ? `${(stat.size / 1024).toFixed(1)}KB` : `${stat.size}B`
+          sources.push(`  ${f}  (${size})`)
+        }
+        sources.push("")
+      }
+    } catch { /* non-fatal */ }
+
+    // 3. Check running containers
+    const podmanCheck = await run(["podman", "ps", "--format", "{{.Names}}\t{{.Image}}\t{{.Status}}"])
+    if (podmanCheck.ok && podmanCheck.out) {
+      sources.push("── Containers (Podman) ──")
+      for (const line of podmanCheck.out.split("\n")) {
+        if (line.trim()) sources.push(`  ${line}`)
+      }
+      sources.push("")
+    }
+
+    // Also check stopped containers
+    const podmanAll = await run(["podman", "ps", "-a", "--filter", "status=exited", "--format", "{{.Names}}\t{{.Image}}\t{{.Status}}"])
+    if (podmanAll.ok && podmanAll.out) {
+      sources.push("── Stopped Containers ──")
+      for (const line of podmanAll.out.split("\n")) {
+        if (line.trim()) sources.push(`  ${line}`)
+      }
+      sources.push("")
+    }
+
+    // 4. Check recent Cloud Build builds
+    const gcloudCheck = await run(["gcloud", "builds", "list", "--limit=5", "--format=table(id,status,createTime,duration)"])
+    if (gcloudCheck.ok && gcloudCheck.out) {
+      sources.push("── Cloud Build (recent) ──")
+      sources.push(gcloudCheck.out)
+      sources.push("")
+    }
+
+    // 5. Check for common log directories
+    const commonDirs = ["/var/log", "var/log", "log"]
+    for (const dir of commonDirs) {
+      const fullPath = dir.startsWith("/") ? dir : join(root, dir)
+      if (existsSync(fullPath)) {
+        try {
+          const files = readdirSync(fullPath)
+            .filter((f) => f.endsWith(".log"))
+            .slice(0, 5)
+          if (files.length > 0) {
+            sources.push(`── ${fullPath} ──`)
+            for (const f of files) sources.push(`  ${f}`)
+            sources.push("")
+          }
+        } catch { /* permission denied is common */ }
+      }
+    }
+
+    if (sources.length <= 3) {
+      sources.push("No log sources found. Run a build or deployment to generate logs.")
+      sources.push("")
+      sources.push("Tip: If this project was scaffolded with lib-agents, logs are")
+      sources.push("captured automatically in the logs/ directory.")
+    }
+
+    return sources.join("\n")
+  },
+})
+
+// ─── Tool: read_logs ────────────────────────────────────────────────
+
+export const read_logs = tool({
+  description:
+    "Read and filter logs from various sources (file, container, Cloud Build, " +
+    "journald, Cloud Logging). Supports severity filtering, time windowing, " +
+    "search patterns, and smart truncation. Source type is auto-detected " +
+    "from the target if not specified.",
+  args: {
+    source: tool.schema
+      .enum(["auto", "file", "container", "cloudbuild", "journald", "gcloud"])
+      .optional()
+      .describe("Log source type (default: auto-detect from target)"),
+    target: tool.schema
+      .string()
+      .describe(
+        "Source identifier: file path, container name/ID, Cloud Build ID, " +
+        "systemd unit name, or Cloud Logging filter",
+      ),
+    severity: tool.schema
+      .enum(["all", "info", "warning", "error"])
+      .optional()
+      .describe("Minimum severity to include (default: all)"),
+    since: tool.schema
+      .string()
+      .optional()
+      .describe("Time window: '10m', '1h', '1d' (default: 1h)"),
+    tail: tool.schema
+      .number()
+      .optional()
+      .describe("Number of lines from end (default: 500)"),
+    search: tool.schema
+      .string()
+      .optional()
+      .describe("Search pattern to filter lines (regex supported)"),
+  },
+  async execute(args) {
+    const sourceType = args.source === "auto" || !args.source
+      ? inferSource(args.target)
+      : args.source as SourceType
+    const severity = args.severity || "all"
+    const tail = args.tail || 500
+    const since = args.since || "1h"
+
+    let rawLines: string[] = []
+
+    switch (sourceType) {
+      case "file": {
+        if (!existsSync(args.target)) {
+          return `Error: File not found: ${args.target}`
+        }
+        try {
+          const content = readFileSync(args.target, "utf-8")
+          rawLines = content.split("\n")
+        } catch (e: any) {
+          return `Error reading file: ${e.message}`
+        }
+        break
+      }
+
+      case "container": {
+        const flags = ["logs", "--tail", String(tail)]
+        if (since) flags.push("--since", since)
+        flags.push(args.target)
+        const result = await run(["podman", ...flags])
+        if (!result.ok) return `Error reading container logs: ${result.out}`
+        rawLines = result.out.split("\n")
+        break
+      }
+
+      case "cloudbuild": {
+        const result = await run(["gcloud", "builds", "log", args.target])
+        if (!result.ok) return `Error reading Cloud Build logs: ${result.out}`
+        rawLines = result.out.split("\n")
+        break
+      }
+
+      case "journald": {
+        const flags = ["journalctl", "-u", args.target, "--no-pager", "-n", String(tail)]
+        if (since) flags.push("--since", since)
+        const result = await run(flags)
+        if (!result.ok) return `Error reading journald logs: ${result.out}`
+        rawLines = result.out.split("\n")
+        break
+      }
+
+      case "gcloud": {
+        const flags = ["gcloud", "logging", "read", args.target, "--limit", String(tail), "--format=value(textPayload)"]
+        const result = await run(flags)
+        if (!result.ok) return `Error reading Cloud Logging: ${result.out}`
+        rawLines = result.out.split("\n")
+        break
+      }
+    }
+
+    // Apply severity filter
+    let filtered = severity === "all"
+      ? rawLines
+      : rawLines.filter((line) => matchesSeverity(line, severity))
+
+    // Apply search pattern
+    if (args.search) {
+      try {
+        const regex = new RegExp(args.search, "i")
+        filtered = filtered.filter((line) => regex.test(line))
+      } catch {
+        return `Error: Invalid search pattern: ${args.search}`
+      }
+    }
+
+    // Apply tail limit
+    if (filtered.length > tail) {
+      filtered = filtered.slice(-tail)
+    }
+
+    const header = [
+      `Log: ${args.target} (${sourceType})`,
+      `Lines: ${filtered.length} (of ${rawLines.length} total)`,
+      `Severity: ${severity} | Since: ${since} | Tail: ${tail}`,
+      args.search ? `Search: ${args.search}` : null,
+      "─".repeat(60),
+    ]
+      .filter(Boolean)
+      .join("\n")
+
+    return `${header}\n${filtered.join("\n")}`
+  },
+})
+
+// ─── Tool: extract_errors ───────────────────────────────────────────
+
+export const extract_errors = tool({
+  description:
+    "Extract errors and warnings from logs with surrounding context. " +
+    "Detects stack traces, ERROR/FATAL/WARN messages, exit codes, panics, " +
+    "and other common error patterns. Returns only relevant sections.",
+  args: {
+    source: tool.schema
+      .enum(["auto", "file", "container", "cloudbuild", "journald", "gcloud"])
+      .optional()
+      .describe("Log source type (default: auto-detect from target)"),
+    target: tool.schema
+      .string()
+      .describe("Source identifier: file path, container name, build ID, etc."),
+    context_lines: tool.schema
+      .number()
+      .optional()
+      .describe("Lines of context around each error (default: 5)"),
+    severity: tool.schema
+      .enum(["error", "warning"])
+      .optional()
+      .describe("Minimum severity to extract (default: error)"),
+  },
+  async execute(args) {
+    const sourceType = args.source === "auto" || !args.source
+      ? inferSource(args.target)
+      : args.source as SourceType
+    const contextLines = args.context_lines || 5
+    const severity = args.severity || "error"
+
+    // Read the log content
+    let rawContent: string
+
+    switch (sourceType) {
+      case "file": {
+        if (!existsSync(args.target)) {
+          return `Error: File not found: ${args.target}`
+        }
+        try {
+          rawContent = readFileSync(args.target, "utf-8")
+        } catch (e: any) {
+          return `Error reading file: ${e.message}`
+        }
+        break
+      }
+
+      case "container": {
+        const result = await run(["podman", "logs", "--tail", "2000", args.target])
+        if (!result.ok) return `Error reading container logs: ${result.out}`
+        rawContent = result.out
+        break
+      }
+
+      case "cloudbuild": {
+        const result = await run(["gcloud", "builds", "log", args.target])
+        if (!result.ok) return `Error reading Cloud Build logs: ${result.out}`
+        rawContent = result.out
+        break
+      }
+
+      case "journald": {
+        const result = await run(["journalctl", "-u", args.target, "--no-pager", "-n", "2000"])
+        if (!result.ok) return `Error reading journald logs: ${result.out}`
+        rawContent = result.out
+        break
+      }
+
+      case "gcloud": {
+        const result = await run(["gcloud", "logging", "read", args.target, "--limit=2000", "--format=value(textPayload)"])
+        if (!result.ok) return `Error reading Cloud Logging: ${result.out}`
+        rawContent = result.out
+        break
+      }
+
+      default:
+        return `Error: Unknown source type: ${sourceType}`
+    }
+
+    const lines = rawContent.split("\n")
+    const pattern = severity === "warning"
+      ? new RegExp(`${SEVERITY_PATTERNS.error.source}|${SEVERITY_PATTERNS.warning.source}`, "i")
+      : SEVERITY_PATTERNS.error
+
+    const extracted = extractWithContext(lines, pattern, contextLines)
+
+    if (extracted.length === 0) {
+      return `No ${severity}-level messages found in ${args.target} (${sourceType}).`
+    }
+
+    const errorCount = extracted.filter((l) => l.startsWith(">>>")).length
+    const header = [
+      `Error Extraction: ${args.target} (${sourceType})`,
+      `Found: ${errorCount} ${severity}-level messages`,
+      `Context: ±${contextLines} lines`,
+      "─".repeat(60),
+    ].join("\n")
+
+    return `${header}\n${extracted.join("\n")}`
+  },
+})
+
+// ─── Tool: compare_logs ─────────────────────────────────────────────
+
+export const compare_logs = tool({
+  description:
+    "Compare logs between two runs to identify what changed. " +
+    "Useful for diagnosing regressions: compare a working build/run " +
+    "against a failing one. Highlights lines present in the failing " +
+    "run but absent from the working run.",
+  args: {
+    source: tool.schema
+      .enum(["auto", "file", "container", "cloudbuild"])
+      .optional()
+      .describe("Log source type (default: auto-detect from target)"),
+    good: tool.schema
+      .string()
+      .describe("Identifier for the working/good run (file path, container, build ID)"),
+    bad: tool.schema
+      .string()
+      .describe("Identifier for the failing/bad run (file path, container, build ID)"),
+    context_lines: tool.schema
+      .number()
+      .optional()
+      .describe("Lines of context around differences (default: 3)"),
+  },
+  async execute(args) {
+    const contextLines = args.context_lines || 3
+
+    async function fetchContent(target: string): Promise<string> {
+      const sourceType = args.source === "auto" || !args.source
+        ? inferSource(target)
+        : args.source as SourceType
+
+      switch (sourceType) {
+        case "file": {
+          if (!existsSync(target)) throw new Error(`File not found: ${target}`)
+          return readFileSync(target, "utf-8")
+        }
+        case "container": {
+          const result = await run(["podman", "logs", "--tail", "2000", target])
+          if (!result.ok) throw new Error(`Container logs error: ${result.out}`)
+          return result.out
+        }
+        case "cloudbuild": {
+          const result = await run(["gcloud", "builds", "log", target])
+          if (!result.ok) throw new Error(`Cloud Build logs error: ${result.out}`)
+          return result.out
+        }
+        default:
+          throw new Error(`Compare not supported for source type: ${sourceType}`)
+      }
+    }
+
+    let goodContent: string
+    let badContent: string
+
+    try {
+      goodContent = await fetchContent(args.good)
+    } catch (e: any) {
+      return `Error reading good run: ${e.message}`
+    }
+
+    try {
+      badContent = await fetchContent(args.bad)
+    } catch (e: any) {
+      return `Error reading bad run: ${e.message}`
+    }
+
+    // Normalize lines: strip leading timestamps for comparison
+    const timestampRegex = /^\d{4}[-/]\d{2}[-/]\d{2}[T ]\d{2}:\d{2}:\d{2}[.\d]*\s*/
+    const normalize = (line: string) => line.replace(timestampRegex, "").trim()
+
+    const goodLines = goodContent.split("\n")
+    const badLines = badContent.split("\n")
+
+    const goodSet = new Set(goodLines.map(normalize))
+    const badSet = new Set(badLines.map(normalize))
+
+    // Find lines unique to bad (potential issues)
+    const onlyInBad: { idx: number; line: string }[] = []
+    for (let i = 0; i < badLines.length; i++) {
+      if (!goodSet.has(normalize(badLines[i])) && badLines[i].trim()) {
+        onlyInBad.push({ idx: i, line: badLines[i] })
+      }
+    }
+
+    // Find lines unique to good (things that stopped happening)
+    const onlyInGood: { idx: number; line: string }[] = []
+    for (let i = 0; i < goodLines.length; i++) {
+      if (!badSet.has(normalize(goodLines[i])) && goodLines[i].trim()) {
+        onlyInGood.push({ idx: i, line: goodLines[i] })
+      }
+    }
+
+    const result: string[] = [
+      "Log Comparison",
+      "==============",
+      `Good: ${args.good} (${goodLines.length} lines)`,
+      `Bad:  ${args.bad} (${badLines.length} lines)`,
+      "─".repeat(60),
+      "",
+    ]
+
+    if (onlyInBad.length > 0) {
+      result.push(`── Lines ONLY in failing run (${onlyInBad.length}) ──`)
+      result.push("These appeared in the bad run but not the good run:")
+      result.push("")
+      for (const entry of onlyInBad.slice(0, 50)) {
+        // Add context from bad run
+        const start = Math.max(0, entry.idx - contextLines)
+        const end = Math.min(badLines.length - 1, entry.idx + contextLines)
+        for (let i = start; i <= end; i++) {
+          const marker = i === entry.idx ? "+ " : "  "
+          result.push(`${marker}${i + 1}: ${badLines[i]}`)
+        }
+        result.push("")
+      }
+      if (onlyInBad.length > 50) {
+        result.push(`  ... and ${onlyInBad.length - 50} more unique lines`)
+      }
+    }
+
+    if (onlyInGood.length > 0) {
+      result.push("")
+      result.push(`── Lines ONLY in working run (${onlyInGood.length}) ──`)
+      result.push("These were present in the good run but missing from the bad run:")
+      result.push("")
+      for (const entry of onlyInGood.slice(0, 20)) {
+        result.push(`- ${entry.idx + 1}: ${entry.line}`)
+      }
+      if (onlyInGood.length > 20) {
+        result.push(`  ... and ${onlyInGood.length - 20} more`)
+      }
+    }
+
+    if (onlyInBad.length === 0 && onlyInGood.length === 0) {
+      result.push("No significant differences found between the two runs.")
+      result.push("The logs appear identical (after timestamp normalization).")
+    }
+
+    return result.join("\n")
+  },
+})

--- a/tools/scaffold.ts
+++ b/tools/scaffold.ts
@@ -60,7 +60,8 @@ function generateMakefile(_pt: ProjectType): string {
   return `.PHONY: help \\
   local-init local-clean local-build local-run local-test local-lint \\
   container-init container-clean container-build container-run \\
-  cloud-init cloud-build cloud-deploy cloud-clean
+  cloud-init cloud-build cloud-deploy cloud-clean \\
+  logs-list logs-last logs-clean
 
 help: ## Show this help
 \t@grep -E '^[a-zA-Z_-]+:.*?## ' $(MAKEFILE_LIST) | \\
@@ -113,6 +114,17 @@ cloud-deploy: ## Deploy to cloud runtime (via Cloud Build)
 
 cloud-clean: ## Tear down cloud resources (via Cloud Build)
 \t@bash scripts/cloud.sh clean
+
+# ─── Logs ─────────────────────────────────────────────────────────────
+
+logs-list: ## List recent log files
+\t@ls -lt logs/*.log 2>/dev/null | head -20 || echo "No log files found"
+
+logs-last: ## Show the most recent log file
+\t@ls -t logs/*.log 2>/dev/null | head -1 | xargs cat 2>/dev/null || echo "No log files found"
+
+logs-clean: ## Remove all log files
+\t@rm -rf logs/*.log && echo "Cleaned log files" || true
 `
 }
 
@@ -168,6 +180,20 @@ confirm() {
   local prompt="\${1:-Are you sure?} [y/N] "
   read -r -p "\${prompt}" response
   [[ "\${response}" =~ ^[Yy]$ ]]
+}
+
+# ─── Log Capture ─────────────────────────────────────────────────────
+
+LOG_DIR="\${PROJECT_ROOT}/logs"
+mkdir -p "\${LOG_DIR}"
+
+# Start capturing all stdout/stderr to a per-run log file.
+# Usage: start_log <action-name>
+start_log() {
+  local action="\${1:-unknown}"
+  LOG_FILE="\${LOG_DIR}/$(date +%Y%m%d-%H%M%S)-\${action}.log"
+  exec > >(tee -a "\${LOG_FILE}") 2>&1
+  log_info "Logging to \${LOG_FILE}"
 }
 `
 }
@@ -234,6 +260,7 @@ function generateLocalSh(pt: ProjectType): string {
 SCRIPT_DIR="$(cd "$(dirname "\${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck disable=SC1091
 source "\${SCRIPT_DIR}/common.sh"
+start_log "local-\${1:-unknown}"
 
 init() {
   log_info "Initializing local dev environment..."
@@ -298,6 +325,7 @@ function generateContainerSh(pt: ProjectType): string {
 SCRIPT_DIR="$(cd "$(dirname "\${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck disable=SC1091
 source "\${SCRIPT_DIR}/common.sh"
+start_log "container-\${1:-unknown}"
 
 CONTAINER_PORT="\${CONTAINER_PORT:-${port}}"
 HOST_PORT="\${HOST_PORT:-\${CONTAINER_PORT}}"
@@ -357,6 +385,7 @@ function generateCloudSh(): string {
 SCRIPT_DIR="$(cd "$(dirname "\${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck disable=SC1091
 source "\${SCRIPT_DIR}/common.sh"
+start_log "cloud-\${1:-unknown}"
 
 AR_LOCATION="\${GCP_REGION}"
 AR_IMAGE="\${AR_LOCATION}-docker.pkg.dev/\${GCP_PROJECT}/\${AR_REPO}/\${IMAGE_NAME}:\${IMAGE_TAG}"
@@ -850,6 +879,7 @@ function gitignoreEntries(pt: ProjectType): string[] {
     "tmp/",
     ".cache/",
     "*.log",
+    "logs/",
   ]
 
   const perLang: Record<ProjectType, string[]> = {


### PR DESCRIPTION
## Summary

Adds a comprehensive log analysis capability to lib-agents with three layers:

- **Scaffold enhancement** — Per-run log capture in scaffolded scripts (`common.sh` gets `start_log()`, each script auto-captures stdout/stderr to `logs/YYYYMMDD-HHMMSS-<action>.log`). New Makefile targets: `logs-list`, `logs-last`, `logs-clean`.
- **New tool** — `tools/logs-analyse.ts` with 4 functions: `discover_sources` (auto-detect available log sources), `read_logs` (fetch + filter with source auto-detection from target), `extract_errors` (error extraction with context), `compare_logs` (diff good vs bad runs).
- **New command + skill** — `/logs-analyse` slash command with 3 usage modes (auto-discover, explicit file/target, compare). `skills/log-analysis/SKILL.md` with diagnostic decision trees, error patterns per tool, and severity patterns per language.

## Changes

| File | Change |
|------|--------|
| `tools/scaffold.ts` | Added `start_log()` to common.sh, log capture to all scripts, `logs-*` Makefile targets, `logs/` to .gitignore |
| `tools/logs-analyse.ts` | **New** — `discover_sources`, `read_logs`, `extract_errors`, `compare_logs` |
| `commands/logs-analyse.md` | **New** — `/logs-analyse` slash command |
| `skills/log-analysis/SKILL.md` | **New** — Diagnostic knowledge base |
| `agents/devops/agent.md` | Added `log-analysis` skill permission, `journalctl *` bash permission |
| `skills/makefile-ops/SKILL.md` | Documented `logs-*` Makefile targets |

Closes #97, #98, #99