### PR TITLE
fix(devops): add missing bash permission entries for git, runtimes, and file ops

### DIFF
--- a/agents/devops/agent.md
+++ b/agents/devops/agent.md
@@ -46,12 +46,26 @@ permission:
     "git diff*": allow
     "git show*": allow
     "git ls-files*": allow
+    "git status*": allow
+    "git fetch*": allow
+    "git branch*": allow
+    "git stash*": allow
     # GitHub CLI
     "gh *": allow
     # Build & infrastructure tools
     "make *": allow
     "bash *": allow
     "sh *": allow
+    # Language runtimes (builds and tests in workspace)
+    "npm *": allow
+    "npx *": allow
+    "bun *": allow
+    "node *": allow
+    "go *": allow
+    "cargo *": allow
+    "python3 *": allow
+    "pip *": allow
+    "pip3 *": allow
     "podman *": allow
     "buildah *": allow
     "skopeo *": allow
@@ -84,6 +98,14 @@ permission:
     "tail *": allow
     "chmod *": allow
     "mkdir *": allow
+    "cp *": allow
+    "mv *": allow
+    "rm *": allow
+    "touch *": allow
+    "tree *": allow
+    "diff *": allow
+    "tar *": allow
+    "rg *": allow
     "journalctl *": allow
 ---
 


### PR DESCRIPTION
## Summary

- Add missing git commands (`git status*`, `git fetch*`, `git branch*`, `git stash*`) to the devops agent's bash permission allowlist — these are needed when the bash tool runs with `workdir` instead of `git -C`
- Add language runtime commands (`npm`, `npx`, `bun`, `node`, `go`, `cargo`, `python3`, `pip`, `pip3`) required for the mandatory post-work test validation step
- Add common file operations (`cp`, `mv`, `rm`, `touch`, `tree`, `diff`, `tar`, `rg`) needed for workspace file management — consistent with the pilot agent's allowlist

## Problem

The devops agent's default-deny bash permission policy had gaps for commands routinely needed in `/tmp/agent-*` workspaces. Any unlisted command triggered OpenCode's permission prompt, requiring manual user approval for safe, routine operations.

## Changes

**File:** `agents/devops/agent.md` (YAML frontmatter `permission.bash` section only)

All existing entries are preserved unchanged. Three groups of entries added:

| Group | Commands Added | Rationale |
|-------|---------------|-----------|
| Git (workdir) | `git status*`, `git fetch*`, `git branch*`, `git stash*` | git-ops agent already has these; needed when bash uses `workdir` param |
| Language runtimes | `npm *`, `npx *`, `bun *`, `node *`, `go *`, `cargo *`, `python3 *`, `pip *`, `pip3 *` | Required for mandatory test validation; pilot agent already has these |
| File operations | `cp *`, `mv *`, `rm *`, `touch *`, `tree *`, `diff *`, `tar *`, `rg *` | Common workspace ops; pilot agent already has most of these |

Closes #104