### PR TITLE
feat(prompts): add structured handoff pipeline for Plan→Build→DevOps context passing

### DIFF
--- a/agents/devops/agent.md
+++ b/agents/devops/agent.md
@@ -123,6 +123,30 @@ is missing. Do NOT guess, do NOT ask clarifying questions that cannot be
 answered -- the parent agent must re-invoke you with a fully self-contained
 prompt.
 
+### Structured Briefs
+
+The orchestrator (Build agent) may provide a structured brief with labeled
+markdown sections: `## Task`, `## Issue`, `## Context`, `## Implementation
+Plan`, `## Files to Create/Modify`, and `## Acceptance Criteria`. This
+format is used when the Plan agent has analyzed a request and the Build
+agent has synthesized that analysis into an actionable brief.
+
+When receiving a structured brief:
+
+- **Extract the issue number** from the `## Issue` section and use it for
+  pre-flight. The issue number is typically formatted as `#<number>`.
+- **If no issue number exists** but the brief describes trackable work,
+  delegate to `@git-ops` to create a GitHub issue using the brief's Task
+  section as the title and the Context section as the body. Then run
+  pre-flight with the returned issue number.
+- **Use the `## Implementation Plan` section** as the execution guide
+  instead of relying solely on the issue's implementation plan comment.
+  The structured brief's plan is typically more detailed because it
+  incorporates the Plan agent's full analysis.
+- **After completing work**, verify against the `## Acceptance Criteria`
+  section if provided. Check each criterion before proceeding to the
+  post-work protocol.
+
 ## Pre-flight Protocol (MANDATORY)
 
 Before performing ANY work, run `preflight` with the issue number. This:

--- a/commands/devops.md
+++ b/commands/devops.md
@@ -8,5 +8,23 @@ $ARGUMENTS
 If $ARGUMENTS is empty, report back that the orchestrator must provide a
 specific task description. Do NOT ask the user to re-state context.
 
+## Context Handling
+
+$ARGUMENTS may contain a structured brief from the orchestrator with labeled
+sections: Task, Issue, Context, Implementation Plan, Files to Create/Modify,
+and Acceptance Criteria. When a structured brief is provided:
+
+1. **Issue number present** — Extract the issue number from the `## Issue`
+   section and use it for pre-flight checks.
+2. **No issue number** — If the brief describes work that should be tracked
+   but no issue number is included, create an issue first (delegate to
+   `@git-ops` with the Task and Context sections as the issue body), then
+   run pre-flight with the newly created issue number.
+3. **Implementation Plan** — Use the `## Implementation Plan` section, if
+   present, as the execution guide. This plan was produced by the Plan agent
+   and contains specific file paths, changes, and steps.
+4. **Acceptance Criteria** — Use the `## Acceptance Criteria` section, if
+   present, to verify the work after completion.
+
 Execute the requested DevOps task. The agent's pre-flight and post-work
 protocols apply automatically.

--- a/prompts/build.md
+++ b/prompts/build.md
@@ -63,3 +63,56 @@ Rules:
    only ask the user if the conversation genuinely has no relevant context
 4. NEVER use vague references — "the above feature" or "what we discussed"
    mean nothing to the receiving agent; inline the full details
+
+### Plan Agent Handoff
+
+When the conversation contains analysis or plans from the Plan agent (visible
+as earlier messages in the same conversation), and the user asks to implement,
+execute, or act on that analysis, you MUST extract and forward that context to
+the specialist agent. The Plan agent's output is read-only analysis — it
+cannot execute. Your job is to bridge the gap.
+
+Follow these steps:
+
+1. **Extract structured context** from the Plan agent's output. Look for:
+   issue numbers, file paths, architectural decisions, step-by-step plans,
+   acceptance criteria, technology choices, rationale, and constraints. The
+   Plan agent may have used labeled sections (Issue, Task, Context,
+   Implementation Plan, Files to Create/Modify, Acceptance Criteria) — if
+   so, preserve that structure.
+
+2. **Format as a self-contained brief** for the specialist agent using this
+   template:
+
+   ```
+   ## Task
+   <one-sentence summary of what needs to be done>
+
+   ## Issue
+   <#number if referenced by the Plan agent, or "No issue exists yet">
+
+   ## Context
+   <key decisions, rationale, constraints, and background from the Plan
+   agent's analysis>
+
+   ## Implementation Plan
+   <step-by-step plan from the Plan agent, with file paths and specific
+   changes>
+
+   ## Files to Create/Modify
+   <bulleted list of file paths identified by the Plan agent>
+
+   ## Acceptance Criteria
+   <verification criteria from the Plan agent's analysis>
+   ```
+
+3. **Never lose plan context** — if the Plan agent produced a detailed
+   analysis, ALL of it must flow to the specialist agent. Summarize for
+   brevity but never omit actionable details such as file paths, specific
+   changes, patterns to follow, or architectural decisions. When in doubt,
+   include more rather than less.
+
+4. **If no issue exists yet**, include a note in the brief telling the
+   specialist agent to create one first (delegate to `@git-ops`) before
+   starting work. For example: "No issue exists yet. Create a GitHub issue
+   from the Task and Context sections before running pre-flight."

--- a/prompts/plan.md
+++ b/prompts/plan.md
@@ -1,5 +1,29 @@
 You are the Plan agent. You analyze code and create plans without making changes.
 
+## Output Format for Implementation Plans
+
+When creating implementation plans that will be handed off to another agent
+for execution, structure your analysis output with the following clearly
+labeled markdown sections:
+
+- **Issue**: Reference existing issue numbers if applicable (e.g., `#42`).
+  If no issue exists yet, note that one should be created.
+- **Task**: One-sentence summary of what needs to be done.
+- **Context**: Key decisions, rationale, and constraints that informed the
+  plan. Include technology choices, trade-offs considered, and any relevant
+  background the implementer needs.
+- **Implementation Plan**: Numbered steps with specific file paths and
+  changes. Each step should be actionable and unambiguous.
+- **Files to Create/Modify**: Bulleted list of file paths that will be
+  touched, so the implementer can quickly scope the work.
+- **Acceptance Criteria**: How to verify the work is complete. Include
+  specific checks, expected behaviors, or test conditions.
+
+This structure ensures the Build agent can extract and forward your analysis
+to specialist agents (such as `@devops`) without losing context. When the
+Build agent synthesizes your output into a Task tool prompt, these labeled
+sections map directly to the brief format that specialist agents expect.
+
 ## Delegation
 
 This project has specialist agents. When the user's request falls into a


### PR DESCRIPTION
## Summary

- Adds a structured brief format across the Plan → Build → DevOps agent pipeline so that analysis context flows through without loss
- Plan agent now outputs labeled markdown sections (Issue, Task, Context, Implementation Plan, Files, Acceptance Criteria) when creating implementation plans
- Build agent now extracts Plan agent output and formats it as a self-contained brief for specialist agents
- `/devops` command now parses structured briefs for issue extraction, plan-guided execution, and criteria verification
- DevOps agent now handles structured briefs with issue creation fallback and plan-based execution guidance

## Changes

| File | Change |
|------|--------|
| `prompts/plan.md` | Added "Output Format for Implementation Plans" section with labeled markdown sections |
| `prompts/build.md` | Added "Plan Agent Handoff" section with extraction, formatting, and forwarding instructions |
| `commands/devops.md` | Added "Context Handling" section for parsing structured briefs |
| `agents/devops/agent.md` | Added "Structured Briefs" subsection under Context Awareness |

## Acceptance Criteria

- [x] Plan agent prompt includes structured output format guidance
- [x] Build agent prompt includes Plan Agent Handoff section
- [x] `/devops` command includes context handling for structured briefs
- [x] DevOps agent includes Structured Briefs subsection
- [x] All changes are prompt/markdown content only (no code changes)

Closes #106