### PR TITLE
fix(agents): Build delegation bypass, devops /tmp write permissions, and #106 source sync

### DIFF
--- a/agents/devops/agent.md
+++ b/agents/devops/agent.md
@@ -9,6 +9,10 @@ description: >
 mode: subagent
 temperature: 0.1
 tools:
+  # Disable file write tools — devops writes via bash scoped to /tmp/agent-*
+  write: false
+  edit: false
+  patch: false
   # Disable tools not relevant to devops (git-ops tools handled by delegation)
   gh-issue_*: false
   gh-pr_*: false
@@ -35,7 +39,7 @@ permission:
     container-ops: allow
     cloudbuild-ops: allow
     gcloud-ops: allow
-    troubleshooting: allow
+    log-analysis: allow
   bash:
     "*": deny
     # Git operations scoped to workspaces — prevent branch switching in main tree
@@ -52,6 +56,11 @@ permission:
     "git stash*": allow
     # GitHub CLI
     "gh *": allow
+    # Workspace filesystem write ops (scoped to /tmp/agent-*)
+    "mkdir /tmp/agent-*": allow
+    "rm -rf /tmp/agent-*": allow
+    "rm -r /tmp/agent-*": allow
+    "rm /tmp/agent-*": allow
     # Build & infrastructure tools
     "make *": allow
     "bash *": allow
@@ -182,6 +191,20 @@ subsequent operations MUST target this workspace:
 **NEVER operate on the main project directory.** The main working tree's
 branch must never change as a result of your work.
 
+**File Write Method**
+
+The `write`, `edit`, and `patch` tools are disabled because they enforce a
+project-root path restriction that prevents writing to `/tmp/agent-*`
+workspaces. Instead, use bash commands for all file operations in the
+workspace:
+
+- Create files: `cat > /tmp/agent-<workspace>/path/to/file.ext << 'EOF'`
+- Append to files: `cat >> /tmp/agent-<workspace>/path/to/file.ext << 'EOF'`
+- Copy files: `cp source dest` (with workdir set to workspace)
+- Move/rename: `mv old new` (with workdir set to workspace)
+- Read access: The `read` and `glob` tools work for any path. Use them
+  to read files from the main project for reference.
+
 Load the `devops-workflow` skill for branch naming conventions and the full
 issue-to-PR lifecycle reference.
 
@@ -198,7 +221,7 @@ domain -- it contains conventions, patterns, and safety rules.
 | Infrastructure as Code | `cloudbuild-ops` | Terraform via Cloud Build |
 | CI/CD pipelines | `cloudbuild-ops` | Pipeline configs, triggers |
 | Google Cloud operations | `gcloud-ops` | GCP resources, IAM, logging |
-| System troubleshooting | `troubleshooting` | Logs, Prometheus metrics, system diagnostics |
+| System troubleshooting | -- | Use troubleshoot tools directly |
 
 ## Delegation Rules
 

--- a/profiles/default/prompts/build.md
+++ b/profiles/default/prompts/build.md
@@ -29,3 +29,4 @@ directly.
 - Run bash commands for implementation
 - Make git commits or create PRs
 - Load skills for direct use
+- Fall back to direct implementation when a subagent rejects your delegation

--- a/prompts/build.md
+++ b/prompts/build.md
@@ -116,3 +116,24 @@ Follow these steps:
    specialist agent to create one first (delegate to `@git-ops`) before
    starting work. For example: "No issue exists yet. Create a GitHub issue
    from the Task and Context sections before running pre-flight."
+
+### Delegation Failure Protocol
+
+When a subagent rejects your task — returns an error, reports missing context,
+or asks for more information — follow these rules strictly:
+
+1. **NEVER fall back to direct implementation.** A subagent rejection is NOT
+   permission to bypass delegation. You are a pure orchestrator — this constraint
+   does not change when a delegation fails. You MUST NOT write files, run
+   implementation commands, create issues, or make commits directly.
+2. **Analyze the rejection.** Read the subagent's response to understand what
+   context was missing or what went wrong.
+3. **Re-invoke with better context.** Compose a new, improved Task prompt that
+   addresses the missing information. Scan the conversation history to synthesize
+   the needed context — issue numbers, file paths, implementation plans,
+   acceptance criteria, and any decisions made during the conversation.
+4. **If context is genuinely unavailable**, ask the user for the specific
+   information the subagent needs. Do NOT attempt the work yourself.
+5. **Maximum 2 retries.** If the subagent rejects after 2 re-invocations with
+   improved context, report the failure to the user and explain specifically
+   what context the subagent requires. NEVER attempt the work directly.


### PR DESCRIPTION
## Summary

Fixes three related issues with the agent delegation and workspace system:

- **Delegation Failure Protocol**: Adds explicit rules to `prompts/build.md` preventing the Build agent from falling back to direct implementation when a subagent rejects a delegation. Includes max 2 retries with improved context before reporting failure.
- **Devops workspace write permissions**: Disables `write`, `edit`, and `patch` tools in the devops agent (following the pilot agent pattern) and adds workspace-scoped bash write permissions for `/tmp/agent-*` paths. Adds "File Write Method" documentation section.
- **#106 source sync**: The workspace-scoped bash permissions, Structured Briefs, and other #106 changes were already in source. This PR adds the remaining missing pieces (write/edit/patch disabling, workspace write ops, File Write Method section) and fixes the `troubleshooting` → `log-analysis` skill name discrepancy.

## Changes

- `agents/devops/agent.md`: Disable write/edit/patch tools, add `/tmp/agent-*` scoped write permissions, add "File Write Method" section, fix skill name
- `prompts/build.md`: Add "Delegation Failure Protocol" section
- `profiles/default/prompts/build.md`: Add anti-fallback rule to "What You NEVER Do" list

Closes #110