### PR TITLE
fix(agents): add external_directory permissions for /tmp workspaces and re-enable write/edit/patch

### DIFF
--- a/agents/devops/agent.md
+++ b/agents/devops/agent.md
@@ -9,10 +9,6 @@ description: >
 mode: subagent
 temperature: 0.1
 tools:
-  # Disable file write tools — devops writes via bash scoped to /tmp/agent-*
-  write: false
-  edit: false
-  patch: false
   # Disable tools not relevant to devops (git-ops tools handled by delegation)
   gh-issue_*: false
   gh-pr_*: false
@@ -32,6 +28,8 @@ tools:
   pilot-workspace_*: false
   pilot-run_*: false
 permission:
+  external_directory:
+    "/tmp/agent-*": allow
   skill:
     "*": deny
     devops-workflow: allow
@@ -193,17 +191,10 @@ branch must never change as a result of your work.
 
 **File Write Method**
 
-The `write`, `edit`, and `patch` tools are disabled because they enforce a
-project-root path restriction that prevents writing to `/tmp/agent-*`
-workspaces. Instead, use bash commands for all file operations in the
-workspace:
-
-- Create files: `cat > /tmp/agent-<workspace>/path/to/file.ext << 'EOF'`
-- Append to files: `cat >> /tmp/agent-<workspace>/path/to/file.ext << 'EOF'`
-- Copy files: `cp source dest` (with workdir set to workspace)
-- Move/rename: `mv old new` (with workdir set to workspace)
-- Read access: The `read` and `glob` tools work for any path. Use them
-  to read files from the main project for reference.
+Use the standard `write`, `edit`, and `patch` tools for all file operations
+in the workspace. The `external_directory` permission grants access to
+`/tmp/agent-*` paths. Bash commands (`cat >`, `cp`, `mv`) are also available
+as alternatives via the bash permission allowlist.
 
 Load the `devops-workflow` skill for branch naming conventions and the full
 issue-to-PR lifecycle reference.

--- a/agents/git-ops/agent.md
+++ b/agents/git-ops/agent.md
@@ -6,9 +6,6 @@ description: >
 mode: subagent
 temperature: 0.1
 tools:
-  write: false
-  edit: false
-  patch: false
   # Disable tools not relevant to git-ops
   scaffold_*: false
   cloudbuild_*: false
@@ -25,6 +22,8 @@ tools:
   pilot-run_*: false
   # branch-cleanup tools enabled for /cleanup workflows
 permission:
+  external_directory:
+    "/tmp/agent-*": allow
   skill:
     "*": deny
     git-pr-workflow: allow

--- a/agents/pilot/agent.md
+++ b/agents/pilot/agent.md
@@ -7,10 +7,6 @@ description: >
 mode: subagent
 temperature: 0.3
 tools:
-  # Disable file write tools — pilot writes via bash scoped to /tmp/pilot-*
-  write: false
-  edit: false
-  patch: false
   # Disable all tools not relevant to experimentation
   scaffold_*: false
   cloudbuild_*: false
@@ -37,6 +33,8 @@ tools:
   skill: false
   troubleshoot_*: false
 permission:
+  external_directory:
+    "/tmp/pilot-*": allow
   bash:
     "*": deny
     # Workspace filesystem ops (scoped to /tmp/pilot-*)
@@ -112,9 +110,9 @@ All experiments run in complete isolation from the main project:
 
 - **Workspace boundary**: All experiments run in `/tmp/pilot-*` directories.
   You have NO write access to the main project directory.
-- **File tools disabled**: The `write` and `edit` tools are disabled. You
-  write files via bash commands (`cat >`, `tee`, `echo >`) scoped to workspace
-  paths only.
+- **File tools**: The `write`, `edit`, and `patch` tools are available for
+  `/tmp/pilot-*` paths via the `external_directory` permission. Bash commands
+  (`cat >`, `tee`, `echo >`) are also available as alternatives.
 - **Read access allowed**: You CAN read the main project's files (for copying
   patterns, understanding architecture, reading configs). Use the `read` and
   `glob` tools, or read-only bash commands like `cat`, `head`, `tail`.
@@ -142,7 +140,7 @@ Use the `pilot-workspace_create` tool with:
 
 ### 3. Write Test Code
 
-Use bash to write minimal test files into the workspace. Keep it small:
+Write minimal test files into the workspace. Keep it small:
 - One file if possible
 - Minimal dependencies
 - Clear pass/fail criteria


### PR DESCRIPTION
## Summary

- Add `permission.external_directory` to devops, git-ops, and pilot agents, granting `write`/`edit`/`patch` tools access to `/tmp/agent-*` and `/tmp/pilot-*` workspace paths
- Remove `write: false`, `edit: false`, `patch: false` tool disabling from all three agents
- Update "File Write Method" documentation in devops agent and "Safety Model" in pilot agent to reflect the new approach

## Context

The project had 4 prior rounds of permission fixes (#18, #90, #104, #110) that addressed `permission.bash` allowlists but never configured OpenCode's `external_directory` permission — the native mechanism for granting built-in tools access to paths outside the project root. The workaround was to disable `write`/`edit`/`patch` entirely and force agents to use fragile bash heredocs (`cat > file << 'EOF'`). This fix uses the proper `external_directory` permission to re-enable structured file editing tools.

## Files Changed

| File | Change |
|------|--------|
| `agents/devops/agent.md` | Add `external_directory`, remove tool disabling, update docs |
| `agents/git-ops/agent.md` | Add `external_directory`, remove tool disabling |
| `agents/pilot/agent.md` | Add `external_directory`, remove tool disabling, update docs |

Closes #114