### PR TITLE
feat(scaffold): port DNS + external HTTPS LB + multi-env promotion

### DIFF
--- a/commands/scaffold.md
+++ b/commands/scaffold.md
@@ -13,9 +13,71 @@ This is a project scaffolding workflow.
    - **Local dev only** (Makefile + scripts + .gitignore)
    - **Container dev** (Makefile + scripts + container files + .gitignore)
    - **Full CI/CD** (all of the above + Cloud Build + Terraform)
+   - **Cloud Build + Terraform only** (no local/container scripts)
+   - **Full CI/CD with external HTTPS LB + DNS + multi-env promotion**
+     (everything; Terraform includes `lb.tf` + `dns.tf`, scripts include
+     `config.py` + `config.toml.example` + the multi-verb cloud
+     workflow `init / init-prod / infra / app-deploy / app-promote /
+     app-undeploy / clean`).
 3. If CI/CD is selected, confirm the user wants Terraform executed via Cloud
    Build (plan on PR, apply on merge).
 4. Run the `scaffold` tool with the appropriate `components` parameter
    (or omit `components` for everything).
 5. Show a summary of all files created/skipped.
-6. Follow the standard post-work protocol.
+6. If the user picked the LB + DNS + multi-env option, show the post-scaffold
+   checklist below.
+7. Follow the standard post-work protocol.
+
+## Post-scaffold checklist (LB + DNS + multi-env)
+
+When the user picked the full CI/CD with LB + DNS + multi-env option, walk
+them through:
+
+1. **Copy the example config:**
+   ```bash
+   cp config.toml.example config.toml
+   ```
+   `config.toml` is gitignored — never commit it.
+
+2. **Fill in the staging / Cloud Build project (`[gcp.default]`):**
+   - `project_id` — the GCP project that owns the deployer SA, the AR repo,
+     and the Terraform state bucket (this is your Cloud Build project).
+   - `[gcp.default.terraform].state_bucket` — pre-existing or to-be-created
+     GCS bucket name for Terraform state.
+   - DNS trio (only if you want the external HTTPS LB + custom domain):
+     - `dns_project_id` — GCP project hosting the Cloud DNS managed zone
+       (typically a SEPARATE project, owned by the DNS / platform team).
+     - `dns_managed_zone` — GCP RESOURCE NAME of the existing managed zone
+       (not the DNS name; e.g. `kunall-demo-altostrat-com`).
+     - `dns_record_name` — FQDN with trailing dot, e.g. `app.example.com.`.
+   - `domain` — same FQDN without the trailing dot, e.g. `app.example.com`.
+
+3. **Fill in `[gcp.production].project_id`** with a SEPARATE GCP project ID
+   (a different project from staging/CB). Optionally override `domain` and
+   the DNS trio for the prod-specific record.
+
+4. **Run the two-environment workflow:**
+   ```bash
+   # Bootstrap staging / Cloud Build project (TF state bucket, deployer SA,
+   # bootstrap IAM, optional cross-project DNS grant). Run as the staging
+   # project owner.
+   make cloud-init
+
+   # One-time prod bootstrap: grants projectIamAdmin on the prod project
+   # to the staging-resident deployer SA, so Terraform can self-escalate
+   # on subsequent cloud-infra runs. Run as the PROD project owner.
+   ENVIRONMENT=production make cloud-init-prod
+
+   # Provision prod infrastructure (Cloud Run, AR, IAM, optional LB+DNS).
+   ENVIRONMENT=production make cloud-infra
+
+   # Deploy the app to staging (build + push + Cloud Run update).
+   make cloud-app-deploy
+
+   # Promote a specific staging image to production with a semver tag.
+   # IMAGE = full URI of the staging image you want to promote (use the
+   #         :sha-<short_sha> tag printed by cloud-app-deploy).
+   ENVIRONMENT=production VERSION=v1.0.0 \\
+     IMAGE=us-central1-docker.pkg.dev/<cb-project>/<service>/<service>:sha-abc123f \\
+     make cloud-app-promote
+   ```

--- a/tools/scaffold.ts
+++ b/tools/scaffold.ts
@@ -484,6 +484,12 @@ init() {
 
   # Step 3: Create deployer SA (if not exists)
   log_info "Step 3/6: Creating deployer service account..."
+  # NOTE: This block assumes CB_PROJECT == GCP_PROJECT (enforced by the
+  # refusal guard above). The \`describe\` call uses the full SA email
+  # (CB_SERVICE_ACCOUNT) which is only valid in CB_PROJECT, while \`create\`
+  # uses the short DEPLOYER_SA_NAME. If the refusal guard is ever relaxed
+  # to allow init on a different project, this detection logic will break
+  # silently — switch to using the short name with --project=CB_PROJECT.
   if ! gcloud iam service-accounts describe "\${CB_SERVICE_ACCOUNT}" --project="\${GCP_PROJECT}" &>/dev/null; then
     gcloud iam service-accounts create "\${DEPLOYER_SA_NAME}" \\
       --display-name="\${PROJECT_NAME} Deployer" \\

--- a/tools/scaffold.ts
+++ b/tools/scaffold.ts
@@ -779,12 +779,16 @@ app_undeploy() {
   [[ -z "\${GCP_PROJECT}" ]] && die "GCP_PROJECT is not set. Add to config.toml or .env"
   [[ -z "\${TF_STATE_BUCKET}" ]] && die "TF_STATE_BUCKET is not set. Add to config.toml or .env"
 
-  # Set image to empty string — Terraform will use the placeholder
+  # Pass the \`__placeholder__\` sentinel — Terraform's main.tf substitutes
+  # the Cloud Run hello-world image when it sees this value. We use a
+  # sentinel rather than an empty \`_IMAGE=\` because some Cloud Build
+  # invocations reject empty substitution values, and \`cloudbuild-apply.yaml\`'s
+  # default of \`_IMAGE: ''\` is not guaranteed to work everywhere.
   gcloud builds submit "\${PROJECT_ROOT}" \\
     --project="\${CB_PROJECT}" \\
     --service-account="projects/\${CB_PROJECT}/serviceAccounts/\${CB_SERVICE_ACCOUNT}" \\
     --config="\${PROJECT_ROOT}/cicd/cloudbuild-apply.yaml" \\
-    --substitutions="_TF_ACTION=apply,$(_tf_substitutions),_IMAGE=" \\
+    --substitutions="_TF_ACTION=apply,$(_tf_substitutions),_IMAGE=__placeholder__" \\
     --quiet
 
   log_ok "Application undeployed (Cloud Run reverted to placeholder)"
@@ -1495,7 +1499,11 @@ resource "google_cloud_run_v2_service" "app" {
     labels          = { app = var.service_name }
 
     containers {
-      image = var.image != "" ? var.image : "us-docker.pkg.dev/cloudrun/container/hello:latest"
+      # The \`__placeholder__\` sentinel is passed by \`cloud.sh app-undeploy\`
+      # to revert the service to the upstream hello-world image without
+      # tearing down the Cloud Run resource. We treat it (and the empty
+      # string, for safety) the same as "no image specified".
+      image = (var.image == "" || var.image == "__placeholder__") ? "us-docker.pkg.dev/cloudrun/container/hello:latest" : var.image
 
       resources {
         limits = {

--- a/tools/scaffold.ts
+++ b/tools/scaffold.ts
@@ -749,6 +749,14 @@ app_promote() {
   [[ -z "\${VERSION:-}" ]] && die "VERSION is required (e.g., VERSION=v1.0.0)"
   [[ -z "\${IMAGE:-}" ]] && die "IMAGE is required (full URI of staging image to promote, e.g., IMAGE=us-central1-docker.pkg.dev/<cb-project>/\${PROJECT_NAME}/\${PROJECT_NAME}:sha-abc123f)"
 
+  # Validate IMAGE belongs to the CB project's AR (where promote is rooted).
+  # Cross-project promotion is not supported — the source image must live in
+  # \${CB_PROJECT}'s AR for the runtime SA cross-project read binding to work.
+  local expected_prefix="\${GCP_REGION}-docker.pkg.dev/\${CB_PROJECT}/\${PROJECT_NAME}/"
+  if [[ "\${IMAGE}" != "\${expected_prefix}"* ]]; then
+    die "IMAGE must start with '\${expected_prefix}' (got: \${IMAGE}). Source images must live in CB_PROJECT's Artifact Registry."
+  fi
+
   # Step 1: Tag the source image with the semver version
   log_info "Step 1/2: Tagging image as \${VERSION}..."
   gcloud artifacts docker tags add \\

--- a/tools/scaffold.ts
+++ b/tools/scaffold.ts
@@ -1286,13 +1286,41 @@ variable "ingress" {
 
 function generateTfMain(): string {
   return `# ─── GCP API Enablement ──────────────────────────────────────────────
+#
+# APIs are enabled in two phases to break a chicken-and-egg cycle:
+#
+#   1. \`bootstrap_apis\` — enables the meta-APIs (serviceusage, iam,
+#      cloudresourcemanager) that all subsequent gcloud/TF calls need.
+#      No \`depends_on\` — these MUST come first. Without serviceusage
+#      enabled, the project_iam_member bindings below would 403.
+#
+#   2. \`apis\` — enables the runtime APIs (run, artifactregistry,
+#      cloudbuild, compute). Depends on \`time_sleep.wait_for_iam\` so
+#      the deployer SA's IAM has propagated before TF tries to operate
+#      on those APIs through it.
+#
+# This split is what makes a brand-new-project apply work without any
+# prior gcloud bootstrap. Previously the whole \`apis\` set depended on
+# IAM bindings whose grants needed serviceusage already on, so the only
+# reason apply succeeded was that cloud-init Steps 1–4 had already
+# enabled serviceusage via gcloud.
+
+resource "google_project_service" "bootstrap_apis" {
+  for_each = toset([
+    "serviceusage.googleapis.com",
+    "iam.googleapis.com",
+    "cloudresourcemanager.googleapis.com",
+  ])
+  project            = var.project_id
+  service            = each.value
+  disable_on_destroy = false
+}
 
 resource "google_project_service" "apis" {
   for_each = toset([
     "run.googleapis.com",
     "artifactregistry.googleapis.com",
     "cloudbuild.googleapis.com",
-    "iam.googleapis.com",
     "compute.googleapis.com",
   ])
   service            = each.value
@@ -1302,23 +1330,34 @@ resource "google_project_service" "apis" {
 }
 
 # ─── Deployer SA: Functional roles (self-granted via projectIamAdmin) ──
+#
+# All deployer IAM bindings depend on \`bootstrap_apis\` so the
+# serviceusage / iam / cloudresourcemanager APIs are guaranteed to be on
+# before the IAM API tries to write the binding (which would otherwise
+# 403 on a brand-new project).
 
 resource "google_project_iam_member" "deployer_run_admin" {
   project = var.project_id
   role    = "roles/run.admin"
   member  = "serviceAccount:\${var.cb_service_account}"
+
+  depends_on = [google_project_service.bootstrap_apis]
 }
 
 resource "google_project_iam_member" "deployer_ar_admin" {
   project = var.project_id
   role    = "roles/artifactregistry.admin"
   member  = "serviceAccount:\${var.cb_service_account}"
+
+  depends_on = [google_project_service.bootstrap_apis]
 }
 
 resource "google_project_iam_member" "deployer_sa_user" {
   project = var.project_id
   role    = "roles/iam.serviceAccountUser"
   member  = "serviceAccount:\${var.cb_service_account}"
+
+  depends_on = [google_project_service.bootstrap_apis]
 }
 
 # Self-escalation chain extenders. With these two grants, the deployer SA
@@ -1333,12 +1372,16 @@ resource "google_project_iam_member" "deployer_serviceusage_admin" {
   project = var.project_id
   role    = "roles/serviceusage.serviceUsageAdmin"
   member  = "serviceAccount:\${var.cb_service_account}"
+
+  depends_on = [google_project_service.bootstrap_apis]
 }
 
 resource "google_project_iam_member" "deployer_sa_creator" {
   project = var.project_id
   role    = "roles/iam.serviceAccountCreator"
   member  = "serviceAccount:\${var.cb_service_account}"
+
+  depends_on = [google_project_service.bootstrap_apis]
 }
 
 # Compute network admin: required by the LB stack (global address, NEG,
@@ -1349,6 +1392,8 @@ resource "google_project_iam_member" "deployer_network_admin" {
   project = var.project_id
   role    = "roles/compute.networkAdmin"
   member  = "serviceAccount:\${var.cb_service_account}"
+
+  depends_on = [google_project_service.bootstrap_apis]
 }
 
 # Compute LB admin: required by the LB stack (backend services, URL maps,
@@ -1359,6 +1404,8 @@ resource "google_project_iam_member" "deployer_lb_admin" {
   project = var.project_id
   role    = "roles/compute.loadBalancerAdmin"
   member  = "serviceAccount:\${var.cb_service_account}"
+
+  depends_on = [google_project_service.bootstrap_apis]
 }
 
 # ─── Wait for IAM propagation ───────────────────────────────

--- a/tools/scaffold.ts
+++ b/tools/scaffold.ts
@@ -60,12 +60,13 @@ function generateMakefile(_pt: ProjectType): string {
   return `.PHONY: help \\
   local-init local-clean local-build local-run local-test local-lint \\
   container-init container-clean container-build container-run \\
-  cloud-init cloud-build cloud-deploy cloud-clean \\
+  cloud-init cloud-init-prod cloud-infra cloud-app-deploy \\
+  cloud-app-promote cloud-app-undeploy cloud-clean \\
   logs-list logs-last logs-clean
 
 help: ## Show this help
 \t@grep -E '^[a-zA-Z_-]+:.*?## ' $(MAKEFILE_LIST) | \\
-\t  awk 'BEGIN {FS = ":.*?## "}; {printf "  \\033[36m%-20s\\033[0m %s\\n", $$1, $$2}'
+\t  awk 'BEGIN {FS = ":.*?## "}; {printf "  \\033[36m%-22s\\033[0m %s\\n", $$1, $$2}'
 
 # ─── Local Development ───────────────────────────────────────────────
 
@@ -103,16 +104,25 @@ container-run: ## Run container locally
 
 # ─── Cloud Runtime ───────────────────────────────────────────────────
 
-cloud-init: ## Initialize cloud resources (via Cloud Build)
+cloud-init: ## Bootstrap primary env (TF state, deployer SA, IAM, optional DNS grant)
 \t@bash scripts/cloud.sh init
 
-cloud-build: ## Build and push to Artifact Registry (via Cloud Build)
-\t@bash scripts/cloud.sh build
+cloud-init-prod: ## One-time prod bootstrap (run as prod project owner; grants projectIamAdmin to deployer SA)
+\t@bash scripts/cloud.sh init-prod
 
-cloud-deploy: ## Deploy to cloud runtime (via Cloud Build)
-\t@bash scripts/cloud.sh deploy
+cloud-infra: ## Provision/update infrastructure via Terraform (Cloud Build)
+\t@bash scripts/cloud.sh infra
 
-cloud-clean: ## Tear down cloud resources (via Cloud Build)
+cloud-app-deploy: ## Build image and deploy to current ENVIRONMENT (default: staging)
+\t@bash scripts/cloud.sh app-deploy
+
+cloud-app-promote: ## Promote a staging image to a non-staging env. Requires VERSION=vX.Y.Z and IMAGE=<full-uri>
+\t@bash scripts/cloud.sh app-promote
+
+cloud-app-undeploy: ## Revert Cloud Run to placeholder image (keeps infra)
+\t@bash scripts/cloud.sh app-undeploy
+
+cloud-clean: ## Tear down cloud infrastructure (terraform destroy)
 \t@bash scripts/cloud.sh clean
 
 # ─── Logs ─────────────────────────────────────────────────────────────
@@ -161,7 +171,24 @@ if [[ -f "\${PROJECT_ROOT}/.env" ]]; then
   source "\${PROJECT_ROOT}/.env"
 fi
 
-# ─── Defaults (override in .env or environment) ──────────────────────
+# ─── Environment Selection ───────────────────────────────────────────
+# Priority: CLI env var > .env file > default (staging)
+export ENVIRONMENT="\${ENVIRONMENT:-staging}"
+
+if [[ "\${ENVIRONMENT}" != "staging" && "\${ENVIRONMENT}" != "production" ]]; then
+  die "Invalid ENVIRONMENT '\${ENVIRONMENT}'. Must be 'staging' or 'production'."
+fi
+
+# ─── Config.toml Parsing (via Python) ────────────────────────────────
+# Uses scripts/config.py to parse config.toml and emit shell variables.
+# Python handles the [gcp.default] → [gcp.<env>] merge correctly.
+
+if [[ -f "\${PROJECT_ROOT}/config.toml" ]]; then
+  log_info "Loading config from config.toml (environment: \${ENVIRONMENT})"
+  eval "$(python3 "\${SCRIPT_DIR}/config.py")"
+fi
+
+# ─── Defaults (override in .env, config.toml, or environment) ────────
 
 export PROJECT_NAME="\${PROJECT_NAME:-$(basename "\${PROJECT_ROOT}")}"
 export IMAGE_NAME="\${IMAGE_NAME:-\${PROJECT_NAME}}"
@@ -169,6 +196,22 @@ export IMAGE_TAG="\${IMAGE_TAG:-latest}"
 export GCP_PROJECT="\${GCP_PROJECT:-}"
 export GCP_REGION="\${GCP_REGION:-us-central1}"
 export AR_REPO="\${AR_REPO:-\${PROJECT_NAME}}"
+export TF_STATE_BUCKET="\${TF_STATE_BUCKET:-}"
+export TF_STATE_PREFIX="\${TF_STATE_PREFIX:-\${PROJECT_NAME}/\${ENVIRONMENT}}"
+export DOMAIN="\${DOMAIN:-}"
+export DNS_PROJECT_ID="\${DNS_PROJECT_ID:-}"
+export DNS_MANAGED_ZONE="\${DNS_MANAGED_ZONE:-}"
+export DNS_RECORD_NAME="\${DNS_RECORD_NAME:-}"
+export MIN_INSTANCES="\${MIN_INSTANCES:-0}"
+export MAX_INSTANCES="\${MAX_INSTANCES:-3}"
+export INGRESS="\${INGRESS:-all}"
+
+# Service account defaults
+export DEPLOYER_SA_NAME="\${DEPLOYER_SA_NAME:-\${PROJECT_NAME}-deployer}"
+export RUNTIME_SA_NAME="\${RUNTIME_SA_NAME:-\${PROJECT_NAME}-runtime}"
+export CB_PROJECT="\${CB_PROJECT:-\${GCP_PROJECT}}"
+export CB_SERVICE_ACCOUNT="\${CB_SERVICE_ACCOUNT:-\${DEPLOYER_SA_NAME}@\${CB_PROJECT}.iam.gserviceaccount.com}"
+export RUNTIME_SA_EMAIL="\${RUNTIME_SA_EMAIL:-\${RUNTIME_SA_NAME}@\${GCP_PROJECT}.iam.gserviceaccount.com}"
 
 # ─── Helpers ──────────────────────────────────────────────────────────
 
@@ -380,90 +423,400 @@ esac
 function generateCloudSh(): string {
   return `#!/usr/bin/env bash
 # Cloud runtime operations (via Cloud Build)
-# Usage: bash scripts/cloud.sh {init|build|deploy|clean}
+# Usage: bash scripts/cloud.sh {init|init-prod|infra|app-deploy|app-promote|app-undeploy|clean}
 
 SCRIPT_DIR="$(cd "$(dirname "\${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck disable=SC1091
 source "\${SCRIPT_DIR}/common.sh"
 start_log "cloud-\${1:-unknown}"
 
-AR_LOCATION="\${GCP_REGION}"
-AR_IMAGE="\${AR_LOCATION}-docker.pkg.dev/\${GCP_PROJECT}/\${AR_REPO}/\${IMAGE_NAME}:\${IMAGE_TAG}"
+# Build Cloud Build substitutions from config
+_tf_substitutions() {
+  local subs="_REGION=\${GCP_REGION}"
+  [[ -n "\${TF_STATE_BUCKET}" ]] && subs="\${subs},_TF_STATE_BUCKET=\${TF_STATE_BUCKET}"
+  [[ -n "\${TF_STATE_PREFIX}" ]] && subs="\${subs},_TF_STATE_PREFIX=\${TF_STATE_PREFIX}"
+  subs="\${subs},_SERVICE_NAME=\${PROJECT_NAME}"
+  subs="\${subs},_DOMAIN=\${DOMAIN}"
+  subs="\${subs},_DNS_PROJECT_ID=\${DNS_PROJECT_ID}"
+  subs="\${subs},_DNS_MANAGED_ZONE=\${DNS_MANAGED_ZONE}"
+  subs="\${subs},_DNS_RECORD_NAME=\${DNS_RECORD_NAME}"
+  subs="\${subs},_MIN_INSTANCES=\${MIN_INSTANCES}"
+  subs="\${subs},_MAX_INSTANCES=\${MAX_INSTANCES}"
+  subs="\${subs},_CB_SERVICE_ACCOUNT=\${CB_SERVICE_ACCOUNT}"
+  subs="\${subs},_RUNTIME_SA_NAME=\${RUNTIME_SA_NAME}"
+  subs="\${subs},_CB_PROJECT_ID=\${CB_PROJECT}"
+  subs="\${subs},_PROJECT_ID=\${GCP_PROJECT}"
+  subs="\${subs},_INGRESS=\${INGRESS}"
+  echo "\${subs}"
+}
 
 init() {
-  log_info "Initializing cloud resources..."
+  log_info "Initializing cloud resources (\${ENVIRONMENT})..."
   require_cmd gcloud
 
-  [[ -z "\${GCP_PROJECT}" ]] && die "GCP_PROJECT is not set. Export it or add to .env"
+  [[ -z "\${GCP_PROJECT}" ]] && die "GCP_PROJECT is not set. Add to config.toml or .env"
+  [[ -z "\${TF_STATE_BUCKET}" ]] && die "TF_STATE_BUCKET is not set. Add to config.toml or .env"
 
-  # Submit Cloud Build to run Terraform init + plan
-  gcloud builds submit \\
-    --project="\${GCP_PROJECT}" \\
+  # Refusal guard: cloud-init is for the primary env (where the deployer SA,
+  # AR repo, and TF state live). Secondary envs (e.g. prod) must use
+  # cloud-init-prod which runs as the prod project owner with prod admin
+  # credentials and only grants the bootstrap role on the prod project.
+  if [[ "\${GCP_PROJECT}" != "\${CB_PROJECT}" ]]; then
+    die "make cloud-init is for the primary environment (where GCP_PROJECT == CB_PROJECT, currently \${CB_PROJECT}). For ENVIRONMENT=\${ENVIRONMENT} which targets \${GCP_PROJECT}, the prod project owner should run 'make cloud-init-prod' instead."
+  fi
+
+  # Step 1: Create TF state bucket (if not exists)
+  log_info "Step 1/6: Creating Terraform state bucket..."
+  if ! gcloud storage buckets describe "gs://\${TF_STATE_BUCKET}" --project="\${GCP_PROJECT}" &>/dev/null; then
+    gcloud storage buckets create "gs://\${TF_STATE_BUCKET}" \\
+      --project="\${GCP_PROJECT}" \\
+      --location="\${GCP_REGION}" \\
+      --uniform-bucket-level-access
+    log_ok "Created bucket: gs://\${TF_STATE_BUCKET}"
+  else
+    log_ok "Bucket already exists: gs://\${TF_STATE_BUCKET}"
+  fi
+
+  # Step 2: Enable Cloud Build API
+  log_info "Step 2/6: Enabling Cloud Build API..."
+  gcloud services enable cloudbuild.googleapis.com --project="\${GCP_PROJECT}"
+  log_ok "Cloud Build API enabled"
+
+  # Step 3: Create deployer SA (if not exists)
+  log_info "Step 3/6: Creating deployer service account..."
+  if ! gcloud iam service-accounts describe "\${CB_SERVICE_ACCOUNT}" --project="\${GCP_PROJECT}" &>/dev/null; then
+    gcloud iam service-accounts create "\${DEPLOYER_SA_NAME}" \\
+      --display-name="\${PROJECT_NAME} Deployer" \\
+      --project="\${GCP_PROJECT}"
+    log_ok "Created SA: \${CB_SERVICE_ACCOUNT}"
+  else
+    log_ok "SA already exists: \${CB_SERVICE_ACCOUNT}"
+  fi
+
+  # Step 4: Grant bootstrap IAM roles (minimum for TF self-escalation)
+  log_info "Step 4/6: Granting bootstrap IAM roles..."
+  local bootstrap_roles=(
+    "roles/storage.admin"
+    "roles/logging.logWriter"
+    "roles/resourcemanager.projectIamAdmin"
+    "roles/serviceusage.serviceUsageAdmin"
+    "roles/iam.serviceAccountCreator"
+  )
+
+  for role in "\${bootstrap_roles[@]}"; do
+    gcloud projects add-iam-policy-binding "\${GCP_PROJECT}" \\
+      --member="serviceAccount:\${CB_SERVICE_ACCOUNT}" \\
+      --role="\${role}" \\
+      --condition=None \\
+      --quiet
+  done
+
+  # Bucket-level objectAdmin (belt-and-suspenders for org deny policies)
+  gcloud storage buckets add-iam-policy-binding "gs://\${GCP_PROJECT}_cloudbuild" \\
+    --member="serviceAccount:\${CB_SERVICE_ACCOUNT}" \\
+    --role="roles/storage.objectAdmin" \\
+    --condition=None \\
+    --quiet 2>/dev/null || true
+
+  gcloud storage buckets add-iam-policy-binding "gs://\${TF_STATE_BUCKET}" \\
+    --member="serviceAccount:\${CB_SERVICE_ACCOUNT}" \\
+    --role="roles/storage.objectAdmin" \\
+    --condition=None \\
+    --quiet
+
+  log_ok "Bootstrap IAM roles granted"
+
+  # Step 5: Terraform init (via Cloud Build, using custom SA)
+  log_info "Step 5/6: Running Terraform init..."
+  gcloud builds submit "\${PROJECT_ROOT}" \\
+    --project="\${CB_PROJECT}" \\
+    --service-account="projects/\${CB_PROJECT}/serviceAccounts/\${CB_SERVICE_ACCOUNT}" \\
     --config="\${PROJECT_ROOT}/cicd/cloudbuild-plan.yaml" \\
-    --substitutions="_TF_ACTION=init" \\
-    "\${PROJECT_ROOT}"
+    --substitutions="_TF_ACTION=init,$(_tf_substitutions)" \\
+    --quiet
 
-  log_ok "Cloud resources initialized"
+  # Step 6/6: Grant cross-project DNS permissions (if DNS_PROJECT_ID is set).
+  # Note: We use roles/dns.admin here. A previously-tried "record-set-editor"
+  # variant role does NOT exist in GCP's predefined Cloud DNS role catalog,
+  # despite some references suggesting otherwise. The two predefined roles
+  # for managing DNS resources are roles/dns.admin and roles/dns.reader.
+  # See: https://cloud.google.com/dns/docs/access-control
+  if [[ -n "\${DNS_PROJECT_ID}" ]]; then
+    log_info "Step 6/6: Granting roles/dns.admin on \${DNS_PROJECT_ID}..."
+    if gcloud projects add-iam-policy-binding "\${DNS_PROJECT_ID}" \\
+        --billing-project="\${DNS_PROJECT_ID}" \\
+        --member="serviceAccount:\${CB_SERVICE_ACCOUNT}" \\
+        --role="roles/dns.admin" \\
+        --condition=None \\
+        --quiet; then
+      log_info "Waiting 120s for IAM propagation..."
+      sleep 120
+      log_ok "DNS bootstrap complete"
+    else
+      log_warn ""
+      log_warn "Cross-project DNS IAM grant failed on \${DNS_PROJECT_ID}."
+      log_warn "Most likely cause: operator lacks setIamPolicy permission on the DNS project."
+      log_warn ""
+      log_warn "Workarounds (pick one):"
+      log_warn "  (a) Re-run the grant manually with elevated credentials:"
+      log_warn "      gcloud projects add-iam-policy-binding \${DNS_PROJECT_ID} \\\\"
+      log_warn "        --billing-project=\${DNS_PROJECT_ID} \\\\"
+      log_warn "        --member=serviceAccount:\${CB_SERVICE_ACCOUNT} \\\\"
+      log_warn "        --role=roles/dns.admin --condition=None"
+      log_warn ""
+      log_warn "  (b) Ask the DNS project owner to run the command above."
+      log_warn ""
+      log_warn "  (c) Use a different DNS project where you have setIamPolicy permission."
+      log_warn ""
+      log_warn "Continuing cloud-init. Run 'make cloud-infra' once the grant is in place."
+    fi
+  else
+    log_info "Step 6/6: Skipped (DNS_PROJECT_ID not set)"
+  fi
+
+  log_ok "Cloud resources initialized (\${ENVIRONMENT})"
 }
 
-build() {
-  log_info "Building and pushing image via Cloud Build..."
+# One-time bootstrap of a SECONDARY environment (e.g. production), run by
+# the prod project owner with prod admin credentials. Pure gcloud — no
+# Cloud Build invocation. Grants the staging-resident deployer SA the
+# minimum role needed for it to self-escalate the rest of its IAM via
+# Terraform on subsequent \`make cloud-infra\` runs.
+#
+# Self-escalation chain:
+#   prod owner grants:   projectIamAdmin (here)
+#                              |
+#                              v
+#   TF self-grants:      serviceUsageAdmin, iam.serviceAccountCreator,
+#                        run.admin, artifactregistry.admin,
+#                        iam.serviceAccountUser, plus Compute roles when
+#                        LB enabled.
+init_prod() {
+  log_info "One-time prod bootstrap (\${ENVIRONMENT})..."
   require_cmd gcloud
 
-  [[ -z "\${GCP_PROJECT}" ]] && die "GCP_PROJECT is not set. Export it or add to .env"
+  [[ -z "\${GCP_PROJECT}" ]] && die "GCP_PROJECT is not set. Add to config.toml or .env"
+  [[ -z "\${CB_PROJECT}" ]] && die "CB_PROJECT is not set."
+  [[ -z "\${CB_SERVICE_ACCOUNT}" ]] && die "CB_SERVICE_ACCOUNT is not set."
 
-  gcloud builds submit \\
-    --project="\${GCP_PROJECT}" \\
-    --config="\${PROJECT_ROOT}/cicd/cloudbuild.yaml" \\
-    --substitutions="_IMAGE_NAME=\${AR_IMAGE}" \\
-    "\${PROJECT_ROOT}"
+  # Refusal guard: this target is for secondary envs only
+  if [[ "\${GCP_PROJECT}" == "\${CB_PROJECT}" ]]; then
+    die "make cloud-init-prod is for secondary environments (where GCP_PROJECT differs from CB_PROJECT, currently \${CB_PROJECT}). For ENVIRONMENT=\${ENVIRONMENT} which targets the same project as CB, use 'make cloud-init' instead."
+  fi
 
-  log_ok "Image built and pushed: \${AR_IMAGE}"
+  # Step 1/3: Print summary and confirm
+  log_info "Step 1/3: Confirming bootstrap targets..."
+  log_info ""
+  log_info "  Target prod project:       \${GCP_PROJECT}"
+  log_info "  Deployer SA to be granted: \${CB_SERVICE_ACCOUNT}"
+  log_info "  Role to grant on prod:     roles/resourcemanager.projectIamAdmin"
+  if [[ -n "\${DNS_PROJECT_ID}" ]]; then
+    log_info "  Target DNS project:        \${DNS_PROJECT_ID}"
+    log_info "  Role to grant on DNS:      roles/dns.admin"
+  fi
+  log_info ""
+  if [[ "\${CONFIRM:-}" != "yes" ]]; then
+    if ! confirm "Proceed with these grants?"; then
+      log_warn "Aborted."
+      exit 0
+    fi
+  fi
+
+  # Step 2/3: Grant projectIamAdmin to deployer SA on prod project. This is
+  # the single bootstrap role from which Terraform self-grants all other
+  # roles it needs (serviceUsageAdmin, iam.serviceAccountCreator, run.admin,
+  # artifactregistry.admin, etc.) on subsequent \`make cloud-infra\` runs.
+  log_info "Step 2/3: Granting roles/resourcemanager.projectIamAdmin on \${GCP_PROJECT}..."
+  if ! gcloud projects add-iam-policy-binding "\${GCP_PROJECT}" \\
+      --billing-project="\${GCP_PROJECT}" \\
+      --member="serviceAccount:\${CB_SERVICE_ACCOUNT}" \\
+      --role="roles/resourcemanager.projectIamAdmin" \\
+      --condition=None \\
+      --quiet; then
+    die "Failed to grant projectIamAdmin on \${GCP_PROJECT}. The operator running 'make cloud-init-prod' needs setIamPolicy permission on the prod project (roles/resourcemanager.projectIamAdmin or roles/owner)."
+  fi
+  log_ok "projectIamAdmin granted on \${GCP_PROJECT}"
+
+  # Step 3/3: Grant DNS access (if DNS_PROJECT_ID set) — same warn-and-continue
+  # pattern as init()'s Step 6/6, since the operator running cloud-init-prod
+  # may not have setIamPolicy on a DNS project owned by a different team.
+  if [[ -n "\${DNS_PROJECT_ID}" ]]; then
+    log_info "Step 3/3: Granting roles/dns.admin on \${DNS_PROJECT_ID}..."
+    if gcloud projects add-iam-policy-binding "\${DNS_PROJECT_ID}" \\
+        --billing-project="\${DNS_PROJECT_ID}" \\
+        --member="serviceAccount:\${CB_SERVICE_ACCOUNT}" \\
+        --role="roles/dns.admin" \\
+        --condition=None \\
+        --quiet; then
+      log_ok "DNS access granted"
+    else
+      log_warn ""
+      log_warn "Cross-project DNS IAM grant failed on \${DNS_PROJECT_ID}."
+      log_warn "Most likely cause: operator lacks setIamPolicy on the DNS project."
+      log_warn ""
+      log_warn "Workarounds (pick one):"
+      log_warn "  (a) Re-run the grant manually with elevated credentials:"
+      log_warn "      gcloud projects add-iam-policy-binding \${DNS_PROJECT_ID} \\\\"
+      log_warn "        --billing-project=\${DNS_PROJECT_ID} \\\\"
+      log_warn "        --member=serviceAccount:\${CB_SERVICE_ACCOUNT} \\\\"
+      log_warn "        --role=roles/dns.admin --condition=None"
+      log_warn ""
+      log_warn "  (b) Ask the DNS project owner to run the command above."
+      log_warn ""
+      log_warn "  (c) Use a different DNS project where you have setIamPolicy permission."
+      log_warn ""
+      log_warn "Continuing. cloud-infra will fail until the DNS grant is in place."
+    fi
+  else
+    log_info "Step 3/3: Skipped (DNS_PROJECT_ID not set)"
+  fi
+
+  log_ok "Prod bootstrap complete (\${ENVIRONMENT})"
+  log_info ""
+  log_info "Next: anyone with Cloud Build access on \${CB_PROJECT} can now run:"
+  log_info "  ENVIRONMENT=\${ENVIRONMENT} make cloud-infra"
+  log_info ""
+  log_info "Terraform will self-grant the remaining IAM roles on \${GCP_PROJECT}"
+  log_info "using the projectIamAdmin permission granted above."
 }
 
-deploy() {
-  log_info "Deploying via Cloud Build..."
+infra() {
+  log_info "Creating/updating cloud infrastructure (\${ENVIRONMENT})..."
   require_cmd gcloud
 
-  [[ -z "\${GCP_PROJECT}" ]] && die "GCP_PROJECT is not set. Export it or add to .env"
+  [[ -z "\${GCP_PROJECT}" ]] && die "GCP_PROJECT is not set. Add to config.toml or .env"
+  [[ -z "\${TF_STATE_BUCKET}" ]] && die "TF_STATE_BUCKET is not set. Add to config.toml or .env"
 
-  gcloud builds submit \\
-    --project="\${GCP_PROJECT}" \\
+  gcloud builds submit "\${PROJECT_ROOT}" \\
+    --project="\${CB_PROJECT}" \\
+    --service-account="projects/\${CB_PROJECT}/serviceAccounts/\${CB_SERVICE_ACCOUNT}" \\
     --config="\${PROJECT_ROOT}/cicd/cloudbuild-apply.yaml" \\
-    --substitutions="_TF_ACTION=apply" \\
-    "\${PROJECT_ROOT}"
+    --substitutions="_TF_ACTION=apply,$(_tf_substitutions)" \\
+    --quiet
 
-  log_ok "Deployment complete"
+  log_ok "Infrastructure ready (\${ENVIRONMENT})"
+}
+
+app_deploy() {
+  log_info "Building and deploying application (\${ENVIRONMENT})..."
+  require_cmd gcloud
+
+  [[ -z "\${GCP_PROJECT}" ]] && die "GCP_PROJECT is not set. Add to config.toml or .env"
+  [[ -z "\${TF_STATE_BUCKET}" ]] && die "TF_STATE_BUCKET is not set. Add to config.toml or .env"
+
+  local short_sha
+  short_sha="$(git -C "\${PROJECT_ROOT}" rev-parse --short HEAD)"
+  local image_base="\${GCP_REGION}-docker.pkg.dev/\${GCP_PROJECT}/\${PROJECT_NAME}/\${PROJECT_NAME}"
+
+  # Step 1: Build and push container image (tagged :latest and :sha-<commit>)
+  log_info "Step 1/2: Building and pushing container image..."
+  log_info "  Image: \${image_base}:latest"
+  log_info "  Image: \${image_base}:sha-\${short_sha}"
+  gcloud builds submit "\${PROJECT_ROOT}" \\
+    --project="\${CB_PROJECT}" \\
+    --service-account="projects/\${CB_PROJECT}/serviceAccounts/\${CB_SERVICE_ACCOUNT}" \\
+    --config="\${PROJECT_ROOT}/cicd/cloudbuild.yaml" \\
+    --substitutions="_IMAGE_NAME=\${image_base},_SHORT_SHA=\${short_sha}" \\
+    --quiet
+
+  log_ok "Image built and pushed"
+
+  # Step 2: Update Cloud Run via Terraform to use :latest
+  log_info "Step 2/2: Updating Cloud Run service..."
+  gcloud builds submit "\${PROJECT_ROOT}" \\
+    --project="\${CB_PROJECT}" \\
+    --service-account="projects/\${CB_PROJECT}/serviceAccounts/\${CB_SERVICE_ACCOUNT}" \\
+    --config="\${PROJECT_ROOT}/cicd/cloudbuild-apply.yaml" \\
+    --substitutions="_TF_ACTION=apply,$(_tf_substitutions),_IMAGE=\${image_base}:latest" \\
+    --quiet
+
+  log_ok "Application deployed (sha-\${short_sha})"
+}
+
+app_promote() {
+  log_info "Promoting image to \${ENVIRONMENT}..."
+  require_cmd gcloud
+
+  [[ -z "\${GCP_PROJECT}" ]] && die "GCP_PROJECT is not set. Add to config.toml or .env"
+  [[ -z "\${TF_STATE_BUCKET}" ]] && die "TF_STATE_BUCKET is not set. Add to config.toml or .env"
+  [[ "\${ENVIRONMENT}" == "staging" ]] && die "Cannot promote to staging. Use app-deploy instead."
+  [[ -z "\${VERSION:-}" ]] && die "VERSION is required (e.g., VERSION=v1.0.0)"
+  [[ -z "\${IMAGE:-}" ]] && die "IMAGE is required (full URI of staging image to promote, e.g., IMAGE=us-central1-docker.pkg.dev/<cb-project>/\${PROJECT_NAME}/\${PROJECT_NAME}:sha-abc123f)"
+
+  # Step 1: Tag the source image with the semver version
+  log_info "Step 1/2: Tagging image as \${VERSION}..."
+  gcloud artifacts docker tags add \\
+    "\${IMAGE}" \\
+    "\${IMAGE%%:*}:\${VERSION}"
+
+  log_ok "Tagged \${IMAGE} as \${VERSION}"
+
+  # Step 2: Deploy to target environment via Terraform
+  local versioned_image="\${IMAGE%%:*}:\${VERSION}"
+  log_info "Step 2/2: Deploying \${versioned_image} to \${ENVIRONMENT}..."
+
+  # Cloud Build always runs in the default/staging project (CB_PROJECT)
+  gcloud builds submit "\${PROJECT_ROOT}" \\
+    --project="\${CB_PROJECT}" \\
+    --service-account="projects/\${CB_PROJECT}/serviceAccounts/\${CB_SERVICE_ACCOUNT}" \\
+    --config="\${PROJECT_ROOT}/cicd/cloudbuild-apply.yaml" \\
+    --substitutions="_TF_ACTION=apply,$(_tf_substitutions),_IMAGE=\${versioned_image}" \\
+    --quiet
+
+  log_ok "Promoted \${VERSION} to \${ENVIRONMENT}"
+}
+
+app_undeploy() {
+  log_info "Undeploying application (\${ENVIRONMENT}, reverting to placeholder)..."
+  require_cmd gcloud
+
+  [[ -z "\${GCP_PROJECT}" ]] && die "GCP_PROJECT is not set. Add to config.toml or .env"
+  [[ -z "\${TF_STATE_BUCKET}" ]] && die "TF_STATE_BUCKET is not set. Add to config.toml or .env"
+
+  # Set image to empty string — Terraform will use the placeholder
+  gcloud builds submit "\${PROJECT_ROOT}" \\
+    --project="\${CB_PROJECT}" \\
+    --service-account="projects/\${CB_PROJECT}/serviceAccounts/\${CB_SERVICE_ACCOUNT}" \\
+    --config="\${PROJECT_ROOT}/cicd/cloudbuild-apply.yaml" \\
+    --substitutions="_TF_ACTION=apply,$(_tf_substitutions),_IMAGE=" \\
+    --quiet
+
+  log_ok "Application undeployed (Cloud Run reverted to placeholder)"
 }
 
 clean() {
-  log_info "Tearing down cloud resources..."
+  log_info "Tearing down cloud resources (\${ENVIRONMENT})..."
   require_cmd gcloud
 
-  [[ -z "\${GCP_PROJECT}" ]] && die "GCP_PROJECT is not set. Export it or add to .env"
+  [[ -z "\${GCP_PROJECT}" ]] && die "GCP_PROJECT is not set. Add to config.toml or .env"
+  [[ -z "\${TF_STATE_BUCKET}" ]] && die "TF_STATE_BUCKET is not set. Add to config.toml or .env"
 
-  if ! confirm "This will destroy cloud infrastructure. Continue?"; then
+  if ! confirm "This will destroy cloud infrastructure for \${ENVIRONMENT}. Continue?"; then
     log_warn "Aborted."
     exit 0
   fi
 
-  gcloud builds submit \\
-    --project="\${GCP_PROJECT}" \\
+  gcloud builds submit "\${PROJECT_ROOT}" \\
+    --project="\${CB_PROJECT}" \\
+    --service-account="projects/\${CB_PROJECT}/serviceAccounts/\${CB_SERVICE_ACCOUNT}" \\
     --config="\${PROJECT_ROOT}/cicd/cloudbuild-apply.yaml" \\
-    --substitutions="_TF_ACTION=destroy" \\
-    "\${PROJECT_ROOT}"
+    --substitutions="_TF_ACTION=destroy,$(_tf_substitutions)" \\
+    --quiet
 
-  log_ok "Cloud resources destroyed"
+  log_ok "Cloud resources destroyed (\${ENVIRONMENT})"
 }
 
 # ─── Dispatch ─────────────────────────────────────────────────────────
 
 case "\${1:-}" in
-  init)   init   ;;
-  build)  build  ;;
-  deploy) deploy ;;
-  clean)  clean  ;;
-  *)      die "Usage: $0 {init|build|deploy|clean}" ;;
+  init)         init ;;
+  init-prod)    init_prod ;;
+  infra)        infra ;;
+  app-deploy)   app_deploy ;;
+  app-promote)  app_promote ;;
+  app-undeploy) app_undeploy ;;
+  clean)        clean ;;
+  *)            die "Usage: $0 {init|init-prod|infra|app-deploy|app-promote|app-undeploy|clean}" ;;
 esac
 `
 }
@@ -618,29 +971,34 @@ out/
 
 function generateCloudbuildYaml(): string {
   return `# Main build pipeline: build image and push to Artifact Registry
-# Triggered by: push to main branch or manual submission
+# Triggered by: push to main branch or manual submission via cloud-app-deploy
 steps:
-  # Build container image
+  # Build container image (tagged :latest and :sha-<commit>)
   - name: 'gcr.io/cloud-builders/docker'
     args:
       - 'build'
       - '-f'
       - 'cicd/Dockerfile'
       - '-t'
-      - '\${_IMAGE_NAME}'
+      - '\${_IMAGE_NAME}:latest'
+      - '-t'
+      - '\${_IMAGE_NAME}:sha-\${_SHORT_SHA}'
       - '.'
 
-  # Push to Artifact Registry
+  # Push all tags to Artifact Registry
   - name: 'gcr.io/cloud-builders/docker'
     args:
       - 'push'
+      - '--all-tags'
       - '\${_IMAGE_NAME}'
 
 images:
-  - '\${_IMAGE_NAME}'
+  - '\${_IMAGE_NAME}:latest'
+  - '\${_IMAGE_NAME}:sha-\${_SHORT_SHA}'
 
 substitutions:
-  _IMAGE_NAME: 'us-central1-docker.pkg.dev/\${PROJECT_ID}/app/app:latest'
+  _IMAGE_NAME: 'us-central1-docker.pkg.dev/\${PROJECT_ID}/app/app'
+  _SHORT_SHA: 'unknown'
 
 options:
   logging: CLOUD_LOGGING_ONLY
@@ -653,7 +1011,7 @@ function generateCloudbuildPlanYaml(): string {
 # Runs terraform init + plan and outputs the plan for review
 steps:
   # Initialize Terraform
-  - name: 'hashicorp/terraform:1.7'
+  - name: 'hashicorp/terraform:1.14'
     dir: 'cicd/terraform'
     args:
       - 'init'
@@ -663,7 +1021,7 @@ steps:
       - 'TF_IN_AUTOMATION=true'
 
   # Run plan (or custom action)
-  - name: 'hashicorp/terraform:1.7'
+  - name: 'hashicorp/terraform:1.14'
     dir: 'cicd/terraform'
     args:
       - '\${_TF_ACTION}'
@@ -671,14 +1029,39 @@ steps:
       - '-input=false'
     env:
       - 'TF_IN_AUTOMATION=true'
-      - 'TF_VAR_project_id=\${PROJECT_ID}'
+      - 'TF_VAR_project_id=\${_PROJECT_ID}'
       - 'TF_VAR_region=\${_REGION}'
+      - 'TF_VAR_service_name=\${_SERVICE_NAME}'
+      - 'TF_VAR_image=\${_IMAGE}'
+      - 'TF_VAR_domain=\${_DOMAIN}'
+      - 'TF_VAR_min_instances=\${_MIN_INSTANCES}'
+      - 'TF_VAR_max_instances=\${_MAX_INSTANCES}'
+      - 'TF_VAR_cb_service_account=\${_CB_SERVICE_ACCOUNT}'
+      - 'TF_VAR_runtime_sa_name=\${_RUNTIME_SA_NAME}'
+      - 'TF_VAR_dns_project_id=\${_DNS_PROJECT_ID}'
+      - 'TF_VAR_dns_managed_zone=\${_DNS_MANAGED_ZONE}'
+      - 'TF_VAR_dns_record_name=\${_DNS_RECORD_NAME}'
+      - 'TF_VAR_cb_project=\${_CB_PROJECT_ID}'
+      - 'TF_VAR_ingress=\${_INGRESS}'
 
 substitutions:
   _TF_ACTION: 'plan'
-  _TF_STATE_BUCKET: '\${PROJECT_ID}-tfstate'
+  _TF_STATE_BUCKET: ''
   _TF_STATE_PREFIX: 'app'
   _REGION: 'us-central1'
+  _SERVICE_NAME: 'app'
+  _IMAGE: ''
+  _DOMAIN: ''
+  _MIN_INSTANCES: '0'
+  _MAX_INSTANCES: '3'
+  _CB_SERVICE_ACCOUNT: ''
+  _RUNTIME_SA_NAME: 'app-runtime'
+  _DNS_PROJECT_ID: ''
+  _DNS_MANAGED_ZONE: ''
+  _DNS_RECORD_NAME: ''
+  _CB_PROJECT_ID: ''
+  _PROJECT_ID: ''
+  _INGRESS: 'all'
 
 options:
   logging: CLOUD_LOGGING_ONLY
@@ -691,7 +1074,7 @@ function generateCloudbuildApplyYaml(): string {
 # Runs terraform init + apply (or destroy) with auto-approve
 steps:
   # Initialize Terraform
-  - name: 'hashicorp/terraform:1.7'
+  - name: 'hashicorp/terraform:1.14'
     dir: 'cicd/terraform'
     args:
       - 'init'
@@ -701,7 +1084,7 @@ steps:
       - 'TF_IN_AUTOMATION=true'
 
   # Apply (or destroy)
-  - name: 'hashicorp/terraform:1.7'
+  - name: 'hashicorp/terraform:1.14'
     dir: 'cicd/terraform'
     args:
       - '\${_TF_ACTION}'
@@ -710,14 +1093,39 @@ steps:
       - '-input=false'
     env:
       - 'TF_IN_AUTOMATION=true'
-      - 'TF_VAR_project_id=\${PROJECT_ID}'
+      - 'TF_VAR_project_id=\${_PROJECT_ID}'
       - 'TF_VAR_region=\${_REGION}'
+      - 'TF_VAR_service_name=\${_SERVICE_NAME}'
+      - 'TF_VAR_image=\${_IMAGE}'
+      - 'TF_VAR_domain=\${_DOMAIN}'
+      - 'TF_VAR_min_instances=\${_MIN_INSTANCES}'
+      - 'TF_VAR_max_instances=\${_MAX_INSTANCES}'
+      - 'TF_VAR_cb_service_account=\${_CB_SERVICE_ACCOUNT}'
+      - 'TF_VAR_runtime_sa_name=\${_RUNTIME_SA_NAME}'
+      - 'TF_VAR_dns_project_id=\${_DNS_PROJECT_ID}'
+      - 'TF_VAR_dns_managed_zone=\${_DNS_MANAGED_ZONE}'
+      - 'TF_VAR_dns_record_name=\${_DNS_RECORD_NAME}'
+      - 'TF_VAR_cb_project=\${_CB_PROJECT_ID}'
+      - 'TF_VAR_ingress=\${_INGRESS}'
 
 substitutions:
   _TF_ACTION: 'apply'
-  _TF_STATE_BUCKET: '\${PROJECT_ID}-tfstate'
+  _TF_STATE_BUCKET: ''
   _TF_STATE_PREFIX: 'app'
   _REGION: 'us-central1'
+  _SERVICE_NAME: 'app'
+  _IMAGE: ''
+  _DOMAIN: ''
+  _MIN_INSTANCES: '0'
+  _MAX_INSTANCES: '3'
+  _CB_SERVICE_ACCOUNT: ''
+  _RUNTIME_SA_NAME: 'app-runtime'
+  _DNS_PROJECT_ID: ''
+  _DNS_MANAGED_ZONE: ''
+  _DNS_RECORD_NAME: ''
+  _CB_PROJECT_ID: ''
+  _PROJECT_ID: ''
+  _INGRESS: 'all'
 
 options:
   logging: CLOUD_LOGGING_ONLY
@@ -728,12 +1136,24 @@ options:
 
 function generateTfProviders(): string {
   return `terraform {
-  required_version = ">= 1.5"
+  required_version = ">= 1.14"
 
   required_providers {
     google = {
       source  = "hashicorp/google"
       version = "~> 5.0"
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = "~> 5.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
+    time = {
+      source  = "hashicorp/time"
+      version = "~> 0.9"
     }
   }
 }
@@ -741,6 +1161,30 @@ function generateTfProviders(): string {
 provider "google" {
   project = var.project_id
   region  = var.region
+}
+
+provider "google-beta" {
+  project = var.project_id
+  region  = var.region
+}
+
+# DNS provider alias — scoped to the (separate) DNS project that owns the
+# managed zone. Used only by resources in dns.tf when the LB+DNS stack is
+# enabled. Safe to leave configured with an empty project_id when disabled,
+# because no resources reference it in that case.
+provider "google" {
+  alias   = "dns"
+  project = var.dns_project_id
+}
+
+# Cloud Build project provider alias — scoped to the project that hosts the
+# deployer SA, the AR repo, and the TF state bucket. For the primary env
+# (staging) this equals var.project_id. For secondary envs (e.g. prod) it
+# differs, and is used to write the cross-project Artifact Registry reader
+# binding so the prod runtime SA can pull promoted images from staging's AR.
+provider "google" {
+  alias   = "cb_project"
+  project = var.cb_project
 }
 `
 }
@@ -769,27 +1213,214 @@ variable "region" {
 }
 
 variable "service_name" {
-  description = "Name of the Cloud Run service"
+  description = "Name of the Cloud Run service and related resources"
   type        = string
   default     = "app"
 }
 
 variable "image" {
-  description = "Container image to deploy (full Artifact Registry path)"
+  description = "Container image to deploy. When empty, Cloud Run uses a placeholder image (us-docker.pkg.dev/cloudrun/container/hello:latest) until the real app is deployed via cloud-app-deploy."
   type        = string
   default     = ""
+}
+
+variable "domain" {
+  description = "Custom domain for the external HTTPS LB. Leave empty to skip the LB+DNS stack."
+  type        = string
+  default     = ""
+}
+
+variable "min_instances" {
+  description = "Minimum number of Cloud Run instances"
+  type        = number
+  default     = 0
+}
+
+variable "max_instances" {
+  description = "Maximum number of Cloud Run instances"
+  type        = number
+  default     = 3
+}
+
+variable "cb_service_account" {
+  description = "Cloud Build deployer service account email for IAM management"
+  type        = string
+}
+
+variable "runtime_sa_name" {
+  description = "Short name for the Cloud Run runtime service account"
+  type        = string
+  default     = "app-runtime"
+}
+
+variable "dns_project_id" {
+  description = "GCP project ID hosting the Cloud DNS managed zone (separate per env). Empty disables LB+DNS stack."
+  type        = string
+  default     = ""
+}
+
+variable "dns_managed_zone" {
+  description = "GCP resource name (not DNS name) of the existing managed zone, e.g. 'kunall-demo-altostrat-com'"
+  type        = string
+  default     = ""
+}
+
+variable "dns_record_name" {
+  description = "FQDN with trailing dot for the A record, e.g. 'app.example.com.'"
+  type        = string
+  default     = ""
+}
+
+variable "cb_project" {
+  description = "Cloud Build project ID (where deployer SA + AR repo live). Equals project_id for the primary env; differs for secondary envs (e.g. prod)."
+  type        = string
+}
+
+variable "ingress" {
+  description = "Cloud Run ingress mode. 'all' allows public *.run.app traffic. 'internal-and-cloud-load-balancing' locks ingress to the external HTTPS LB / internal VPC sources."
+  type        = string
+  default     = "all"
 }
 `
 }
 
 function generateTfMain(): string {
-  return `# ─── Artifact Registry ────────────────────────────────────────────────
+  return `# ─── GCP API Enablement ──────────────────────────────────────────────
+
+resource "google_project_service" "apis" {
+  for_each = toset([
+    "run.googleapis.com",
+    "artifactregistry.googleapis.com",
+    "cloudbuild.googleapis.com",
+    "iam.googleapis.com",
+    "compute.googleapis.com",
+  ])
+  service            = each.value
+  disable_on_destroy = false
+
+  depends_on = [time_sleep.wait_for_iam]
+}
+
+# ─── Deployer SA: Functional roles (self-granted via projectIamAdmin) ──
+
+resource "google_project_iam_member" "deployer_run_admin" {
+  project = var.project_id
+  role    = "roles/run.admin"
+  member  = "serviceAccount:\${var.cb_service_account}"
+}
+
+resource "google_project_iam_member" "deployer_ar_admin" {
+  project = var.project_id
+  role    = "roles/artifactregistry.admin"
+  member  = "serviceAccount:\${var.cb_service_account}"
+}
+
+resource "google_project_iam_member" "deployer_sa_user" {
+  project = var.project_id
+  role    = "roles/iam.serviceAccountUser"
+  member  = "serviceAccount:\${var.cb_service_account}"
+}
+
+# Self-escalation chain extenders. With these two grants, the deployer SA
+# can bootstrap the rest of its IAM purely from a single bootstrap role
+# (roles/resourcemanager.projectIamAdmin) granted on the project — needed
+# so secondary envs (prod) can be bootstrapped via cloud-init-prod with
+# just projectIamAdmin granted by the prod owner. On the primary env
+# (staging) these are idempotent no-ops because cloud-init Step 4 already
+# grants the same roles via gcloud.
+
+resource "google_project_iam_member" "deployer_serviceusage_admin" {
+  project = var.project_id
+  role    = "roles/serviceusage.serviceUsageAdmin"
+  member  = "serviceAccount:\${var.cb_service_account}"
+}
+
+resource "google_project_iam_member" "deployer_sa_creator" {
+  project = var.project_id
+  role    = "roles/iam.serviceAccountCreator"
+  member  = "serviceAccount:\${var.cb_service_account}"
+}
+
+# Compute network admin: required by the LB stack (global address, NEG,
+# SSL cert, URL map, target proxies, forwarding rules). Granted only when
+# the LB stack is enabled (gated by local.enable_lb).
+resource "google_project_iam_member" "deployer_network_admin" {
+  count   = local.enable_lb ? 1 : 0
+  project = var.project_id
+  role    = "roles/compute.networkAdmin"
+  member  = "serviceAccount:\${var.cb_service_account}"
+}
+
+# Compute LB admin: required by the LB stack (backend services, URL maps,
+# SSL certificates, target proxies, forwarding rules, serverless NEGs).
+# Granted only when the LB stack is enabled (gated by local.enable_lb).
+resource "google_project_iam_member" "deployer_lb_admin" {
+  count   = local.enable_lb ? 1 : 0
+  project = var.project_id
+  role    = "roles/compute.loadBalancerAdmin"
+  member  = "serviceAccount:\${var.cb_service_account}"
+}
+
+# ─── Wait for IAM propagation ───────────────────────────────
+# GCP IAM changes take 60-120s to propagate across regions/services.
+# Resources that depend on the deployer SA's functional roles must wait
+# for propagation, otherwise they hit eventual-consistency 403s.
+#
+# IMPORTANT: \`time_sleep\` only sleeps on create or when one of its OWN
+# attributes (triggers, create_duration, destroy_duration) changes.
+# Adding bindings to \`depends_on\` does NOT re-trigger the wait. We use
+# \`triggers\` keyed on the IAM binding IDs so any change to the deployer
+# IAM set forces the time_sleep to be recreated and sleep again.
+
+resource "time_sleep" "wait_for_iam" {
+  depends_on = [
+    google_project_iam_member.deployer_run_admin,
+    google_project_iam_member.deployer_ar_admin,
+    google_project_iam_member.deployer_sa_user,
+    google_project_iam_member.deployer_serviceusage_admin,
+    google_project_iam_member.deployer_sa_creator,
+    google_project_iam_member.deployer_network_admin,
+    google_project_iam_member.deployer_lb_admin,
+  ]
+
+  triggers = {
+    iam_members = sha256(jsonencode([
+      google_project_iam_member.deployer_run_admin.id,
+      google_project_iam_member.deployer_ar_admin.id,
+      google_project_iam_member.deployer_sa_user.id,
+      google_project_iam_member.deployer_serviceusage_admin.id,
+      google_project_iam_member.deployer_sa_creator.id,
+      try(google_project_iam_member.deployer_network_admin[0].id, ""),
+      try(google_project_iam_member.deployer_lb_admin[0].id, ""),
+    ]))
+  }
+
+  create_duration = "120s"
+}
+
+# ─── Runtime SA: Cloud Run application identity ─────────────────────
+
+resource "google_service_account" "runtime" {
+  account_id   = var.runtime_sa_name
+  display_name = "\${var.service_name} Cloud Run Runtime"
+  project      = var.project_id
+
+  depends_on = [google_project_service.apis]
+}
+
+# ─── Artifact Registry ────────────────────────────────────────────────
 
 resource "google_artifact_registry_repository" "app" {
+  depends_on = [
+    google_project_service.apis,
+    time_sleep.wait_for_iam,
+  ]
+
   location      = var.region
   repository_id = var.service_name
   format        = "DOCKER"
   description   = "Container images for \${var.service_name}"
+  labels        = { app = var.service_name }
 }
 
 # ─── Cloud Run Service ───────────────────────────────────────────────
@@ -797,10 +1428,21 @@ resource "google_artifact_registry_repository" "app" {
 resource "google_cloud_run_v2_service" "app" {
   name     = var.service_name
   location = var.region
+  labels   = { app = var.service_name }
+
+  # Ingress mode is configurable. Set var.ingress to
+  # "internal-and-cloud-load-balancing" to lock down the service so the
+  # external HTTPS LB (serverless NEG) and internal VPC sources are the
+  # only entry points; direct *.run.app hits then return 403. Default
+  # "all" leaves the public *.run.app URL reachable.
+  ingress = var.ingress == "internal-and-cloud-load-balancing" ? "INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER" : "INGRESS_TRAFFIC_ALL"
 
   template {
+    service_account = google_service_account.runtime.email
+    labels          = { app = var.service_name }
+
     containers {
-      image = var.image != "" ? var.image : "\${var.region}-docker.pkg.dev/\${var.project_id}/\${var.service_name}/\${var.service_name}:latest"
+      image = var.image != "" ? var.image : "us-docker.pkg.dev/cloudrun/container/hello:latest"
 
       resources {
         limits = {
@@ -811,8 +1453,8 @@ resource "google_cloud_run_v2_service" "app" {
     }
 
     scaling {
-      min_instance_count = 0
-      max_instance_count = 3
+      min_instance_count = var.min_instances
+      max_instance_count = var.max_instances
     }
   }
 
@@ -820,17 +1462,51 @@ resource "google_cloud_run_v2_service" "app" {
     percent = 100
     type    = "TRAFFIC_TARGET_ALLOCATION_TYPE_LATEST"
   }
+
+  depends_on = [
+    google_project_service.apis,
+    time_sleep.wait_for_iam,
+  ]
 }
 
 # ─── IAM: Allow unauthenticated access (public service) ─────────────
 # Remove this block if the service should require authentication.
 
 resource "google_cloud_run_v2_service_iam_member" "public" {
+  depends_on = [time_sleep.wait_for_iam]
+
   project  = google_cloud_run_v2_service.app.project
   location = google_cloud_run_v2_service.app.location
   name     = google_cloud_run_v2_service.app.name
   role     = "roles/run.invoker"
   member   = "allUsers"
+}
+
+# ─── Cross-project AR access (secondary envs only) ──────────────────
+#
+# When this env's runtime project differs from the CB project (i.e., this
+# is a secondary env like prod), the runtime SA needs read access to the
+# primary env's AR repo to pull promoted images. The deployer SA already
+# has artifactregistry.admin on CB_PROJECT (granted by the primary env's
+# TF state via the existing deployer_ar_admin resource), so this binding
+# is authorized to write through the google.cb_project provider alias.
+#
+# On the primary env (staging) where project_id == cb_project, the
+# binding is skipped — the runtime SA already has access via in-project
+# IAM granted elsewhere.
+
+locals {
+  is_secondary_env = var.project_id != var.cb_project
+}
+
+resource "google_artifact_registry_repository_iam_member" "runtime_ar_reader" {
+  count      = local.is_secondary_env ? 1 : 0
+  provider   = google.cb_project
+  project    = var.cb_project
+  location   = var.region
+  repository = var.service_name
+  role       = "roles/artifactregistry.reader"
+  member     = "serviceAccount:\${google_service_account.runtime.email}"
 }
 `
 }
@@ -845,6 +1521,367 @@ output "artifact_registry_repo" {
   description = "Artifact Registry repository URL"
   value       = "\${var.region}-docker.pkg.dev/\${var.project_id}/\${google_artifact_registry_repository.app.repository_id}"
 }
+
+# ─── External HTTPS LB / DNS outputs ─────────────────────────────────
+# Empty when the LB+DNS stack is disabled (i.e. dns_* vars are unset).
+
+output "lb_ip" {
+  description = "Reserved global IPv4 address for the external HTTPS LB"
+  value       = local.enable_lb ? google_compute_global_address.lb_ip[0].address : ""
+}
+
+output "dns_fqdn" {
+  description = "FQDN served by the LB"
+  value       = local.enable_lb ? var.dns_record_name : ""
+}
+
+output "ssl_cert_name" {
+  description = <<-EOT
+    Name of the Google-managed SSL cert. The status attribute isn't
+    directly readable from the Terraform resource, so check it via gcloud:
+
+      gcloud compute ssl-certificates describe <name> --global \\
+        --format='value(managed.status)'
+
+    Watch for ACTIVE. Provisioning is asynchronous and typically takes
+    15-60 min after the A record resolves to the LB IP.
+  EOT
+  value       = local.enable_lb ? google_compute_managed_ssl_certificate.app[0].name : ""
+}
+`
+}
+
+function generateTfLb(): string {
+  return `# ─── External HTTPS Load Balancer in front of Cloud Run ──────────────
+#
+# Architecture:
+#   client → reserved IPv4 (anycast) → global external HTTPS LB
+#          → serverless NEG → Cloud Run
+#
+# To force traffic through the LB only, set var.ingress to
+# "internal-and-cloud-load-balancing" — then direct *.run.app hits return
+# 403 and the LB becomes the only public entry point.
+#
+# All resources are gated by \`local.enable_lb\`. When any of dns_project_id /
+# dns_managed_zone / dns_record_name / domain are empty, no LB resources
+# are created — the stack is opt-in.
+
+locals {
+  enable_lb = (
+    var.dns_project_id != "" &&
+    var.dns_managed_zone != "" &&
+    var.dns_record_name != "" &&
+    var.domain != ""
+  )
+}
+
+# 1. Reserved global IPv4 — the anycast IP advertised in DNS.
+resource "google_compute_global_address" "lb_ip" {
+  count   = local.enable_lb ? 1 : 0
+  name    = "\${var.service_name}-lb-ip"
+  project = var.project_id
+
+  depends_on = [google_project_service.apis, time_sleep.wait_for_iam]
+}
+
+# 2. Serverless NEG → Cloud Run. The NEG itself is free.
+resource "google_compute_region_network_endpoint_group" "cloud_run_neg" {
+  count                 = local.enable_lb ? 1 : 0
+  name                  = "\${var.service_name}-neg"
+  network_endpoint_type = "SERVERLESS"
+  region                = var.region
+  project               = var.project_id
+
+  cloud_run {
+    service = google_cloud_run_v2_service.app.name
+  }
+
+  depends_on = [google_project_service.apis, time_sleep.wait_for_iam]
+}
+
+# 3. Backend service. No health check needed for serverless NEGs.
+resource "google_compute_backend_service" "app" {
+  count                 = local.enable_lb ? 1 : 0
+  name                  = "\${var.service_name}-backend"
+  project               = var.project_id
+  protocol              = "HTTPS"
+  load_balancing_scheme = "EXTERNAL_MANAGED"
+
+  backend {
+    group = google_compute_region_network_endpoint_group.cloud_run_neg[0].id
+  }
+
+  depends_on = [google_project_service.apis, time_sleep.wait_for_iam]
+}
+
+# 4. URL map for HTTPS traffic — routes everything to the backend.
+resource "google_compute_url_map" "https" {
+  count           = local.enable_lb ? 1 : 0
+  name            = "\${var.service_name}-https"
+  project         = var.project_id
+  default_service = google_compute_backend_service.app[0].id
+
+  depends_on = [google_project_service.apis, time_sleep.wait_for_iam]
+}
+
+# 5. Google-managed SSL cert (classic). Provisioning is asynchronous;
+#    the resource returns as soon as it's submitted (status PROVISIONING).
+#    Cert reaches ACTIVE 15-60 min after DNS resolves to the LB IP.
+resource "google_compute_managed_ssl_certificate" "app" {
+  count   = local.enable_lb ? 1 : 0
+  name    = "\${var.service_name}-cert"
+  project = var.project_id
+
+  managed {
+    domains = [var.domain]
+  }
+
+  # Recreate cert if the domain list changes — old cert can't be reused.
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  depends_on = [google_project_service.apis, time_sleep.wait_for_iam]
+}
+
+# 6. Target HTTPS proxy — terminates TLS using the managed cert.
+resource "google_compute_target_https_proxy" "app" {
+  count            = local.enable_lb ? 1 : 0
+  name             = "\${var.service_name}-https-proxy"
+  project          = var.project_id
+  url_map          = google_compute_url_map.https[0].id
+  ssl_certificates = [google_compute_managed_ssl_certificate.app[0].id]
+}
+
+# 7. Forwarding rule (443) — binds the reserved IP to the HTTPS proxy.
+resource "google_compute_global_forwarding_rule" "https" {
+  count                 = local.enable_lb ? 1 : 0
+  name                  = "\${var.service_name}-https-fr"
+  project               = var.project_id
+  target                = google_compute_target_https_proxy.app[0].id
+  ip_address            = google_compute_global_address.lb_ip[0].id
+  port_range            = "443"
+  load_balancing_scheme = "EXTERNAL_MANAGED"
+}
+
+# 8. URL map that 301-redirects all HTTP traffic to HTTPS.
+resource "google_compute_url_map" "http_redirect" {
+  count   = local.enable_lb ? 1 : 0
+  name    = "\${var.service_name}-http-redirect"
+  project = var.project_id
+
+  default_url_redirect {
+    https_redirect         = true
+    strip_query            = false
+    redirect_response_code = "MOVED_PERMANENTLY_DEFAULT"
+  }
+
+  depends_on = [google_project_service.apis, time_sleep.wait_for_iam]
+}
+
+# 9. Target HTTP proxy for the redirect URL map.
+resource "google_compute_target_http_proxy" "app" {
+  count   = local.enable_lb ? 1 : 0
+  name    = "\${var.service_name}-http-proxy"
+  project = var.project_id
+  url_map = google_compute_url_map.http_redirect[0].id
+}
+
+# 10. Forwarding rule (80) — same reserved IP, different port.
+resource "google_compute_global_forwarding_rule" "http" {
+  count                 = local.enable_lb ? 1 : 0
+  name                  = "\${var.service_name}-http-fr"
+  project               = var.project_id
+  target                = google_compute_target_http_proxy.app[0].id
+  ip_address            = google_compute_global_address.lb_ip[0].id
+  port_range            = "80"
+  load_balancing_scheme = "EXTERNAL_MANAGED"
+}
+`
+}
+
+function generateTfDns(): string {
+  return `# ─── DNS A record (in separate DNS project) ──────────────────────────
+#
+# Writes a single A record into a pre-existing managed zone owned by a
+# different GCP project (\`var.dns_project_id\`). The deployer SA must hold
+# \`roles/dns.admin\` on that project — granted via gcloud during
+# \`make cloud-init\` (see scripts/cloud.sh::init Step 6/6).
+#
+# Terraform never owns the zone itself, only the record set.
+
+resource "google_dns_record_set" "app" {
+  count    = local.enable_lb ? 1 : 0
+  provider = google.dns
+
+  project      = var.dns_project_id
+  managed_zone = var.dns_managed_zone
+  name         = var.dns_record_name
+  type         = "A"
+  ttl          = 300
+  rrdatas      = [google_compute_global_address.lb_ip[0].address]
+}
+`
+}
+
+// ─── Config Files Generation ────────────────────────────────────────
+
+function generateConfigPy(): string {
+  return `#!/usr/bin/env python3
+"""Parse config.toml and emit shell variable assignments.
+
+Reads [gcp.default] as base config, merges overrides from
+[gcp.{ENVIRONMENT}], and prints KEY='value' lines for eval.
+"""
+
+import os
+import sys
+
+try:
+    import tomllib
+except ModuleNotFoundError:
+    import tomli as tomllib  # Python < 3.11 fallback
+
+
+def main():
+    config_path = os.path.join(os.path.dirname(__file__), '..', 'config.toml')
+    if not os.path.exists(config_path):
+        print(f"echo 'ERROR: config.toml not found at {config_path}'",
+              file=sys.stderr)
+        sys.exit(1)
+
+    with open(config_path, 'rb') as f:
+        config = tomllib.load(f)
+
+    env = os.environ.get('ENVIRONMENT', 'staging')
+
+    # Project-level config
+    project = config.get('project', {})
+    project_name = project.get('name', 'app')
+
+    # GCP defaults
+    defaults = config.get('gcp', {}).get('default', {})
+    tf_defaults = defaults.get('terraform', {})
+
+    # Environment overrides
+    env_overrides = config.get('gcp', {}).get(env, {})
+
+    # Merge: env overrides win
+    resolved = {**defaults, **env_overrides}
+    # Remove nested 'terraform' from resolved (handled separately)
+    resolved.pop('terraform', None)
+
+    # Terraform config (no env override for terraform section)
+    tf_config = tf_defaults
+
+    # Derive SA emails — deployer SA always from defaults (Cloud Build project)
+    cb_project = defaults.get('project_id', '')
+    cb_sa_name = defaults.get('deployer_sa', f'{project_name}-deployer')
+    cb_sa_email = f'{cb_sa_name}@{cb_project}.iam.gserviceaccount.com'
+
+    # Resolved target project
+    project_id = resolved.get('project_id', '')
+
+    # Runtime SA for the target environment
+    runtime_sa_name = resolved.get('runtime_sa', f'{project_name}-runtime')
+    runtime_sa_email = f'{runtime_sa_name}@{project_id}.iam.gserviceaccount.com'
+
+    # Deployer SA name (for gcloud iam create in init)
+    deployer_sa_name = defaults.get('deployer_sa', f'{project_name}-deployer')
+
+    # Auto-derive TF state prefix
+    tf_state_prefix = f'{project_name}/{env}'
+
+    # Output shell variables
+    print(f"ENVIRONMENT='{env}'")
+    print(f"PROJECT_NAME='{project_name}'")
+    print(f"GCP_PROJECT='{project_id}'")
+    print(f"GCP_REGION='{resolved.get('region', 'us-central1')}'")
+    print(f"DOMAIN='{resolved.get('domain', '')}'")
+    print(f"DNS_PROJECT_ID='{resolved.get('dns_project_id', '')}'")
+    print(f"DNS_MANAGED_ZONE='{resolved.get('dns_managed_zone', '')}'")
+    print(f"DNS_RECORD_NAME='{resolved.get('dns_record_name', '')}'")
+    print(f"DEPLOYER_SA_NAME='{deployer_sa_name}'")
+    print(f"RUNTIME_SA_NAME='{runtime_sa_name}'")
+    print(f"CB_PROJECT='{cb_project}'")
+    print(f"CB_SERVICE_ACCOUNT='{cb_sa_email}'")
+    print(f"RUNTIME_SA_EMAIL='{runtime_sa_email}'")
+    print(f"MIN_INSTANCES='{resolved.get('min_instances', '0')}'")
+    print(f"MAX_INSTANCES='{resolved.get('max_instances', '3')}'")
+    print(f"CPU='{resolved.get('cpu', '1')}'")
+    print(f"MEMORY='{resolved.get('memory', '512Mi')}'")
+    print(f"INGRESS='{resolved.get('ingress', 'all')}'")
+    print(f"TF_STATE_BUCKET='{tf_config.get('state_bucket', '')}'")
+    print(f"TF_STATE_PREFIX='{tf_state_prefix}'")
+
+
+if __name__ == '__main__':
+    main()
+`
+}
+
+function generateConfigTomlExample(): string {
+  return `# Project Configuration
+# Copy this file to config.toml and fill in your values.
+# config.toml is gitignored — never commit it.
+
+[project]
+name = "app"
+
+# Default GCP settings (inherited by all environments)
+[gcp.default]
+project_id = "your-gcp-project-id"
+region = "us-central1"
+domain = ""
+min_instances = 0
+max_instances = 3
+cpu = "1"
+memory = "512Mi"
+ingress = "all"
+deployer_sa = "app-deployer"
+runtime_sa = "app-runtime"
+
+# DNS / external HTTPS LB stack (opt-in).
+# Leave empty to disable the LB+DNS stack — Cloud Run remains reachable
+# only via its *.run.app URL. Set all three together (and \`domain\` above)
+# to provision the LB and write the DNS A record.
+#
+#   dns_project_id   - GCP project ID hosting the Cloud DNS managed zone
+#                      (a SEPARATE project from the runtime project, by
+#                      convention; the deployer SA is granted
+#                      roles/dns.admin on it during cloud-init).
+#   dns_managed_zone - GCP RESOURCE NAME of the existing managed zone,
+#                      e.g. 'kunall-demo-altostrat-com' (NOT the DNS name).
+#   dns_record_name  - Fully-qualified record name with a trailing dot,
+#                      e.g. 'app.example.com.'.
+dns_project_id = ""
+dns_managed_zone = ""
+dns_record_name = ""
+
+[gcp.default.terraform]
+state_bucket = "your-tfstate-bucket"
+# state_prefix is auto-derived: {project.name}/{ENVIRONMENT}
+
+# ─── Per-environment overrides ─────────────────────────
+# Each section inherits from [gcp.default].
+# Only specify values that differ from the defaults.
+
+[gcp.staging]
+# Uses all defaults — override here if staging needs different values.
+# Example LB+DNS setup:
+#   domain = "app.example.com"
+#   dns_project_id = "your-staging-dns-project"
+#   dns_managed_zone = "your-zone-resource-name"
+#   dns_record_name = "app.example.com."
+
+[gcp.production]
+project_id = "your-prod-project-id"
+domain = "your-prod-domain.example.com"
+min_instances = 1
+max_instances = 10
+# dns_project_id = "your-prod-dns-project"
+# dns_managed_zone = "your-prod-zone-resource-name"
+# dns_record_name = "your-prod-domain.example.com."
 `
 }
 
@@ -856,6 +1893,7 @@ function gitignoreEntries(pt: ProjectType): string[] {
     ".env",
     ".env.local",
     ".env.*.local",
+    "config.toml",
     "",
     "# OS",
     ".DS_Store",
@@ -916,6 +1954,13 @@ async function scaffoldScripts(root: string, pt: ProjectType, force: boolean): P
     safeWrite(join(dir, "local.sh"), generateLocalSh(pt), force),
     safeWrite(join(dir, "container.sh"), generateContainerSh(pt), force),
     safeWrite(join(dir, "cloud.sh"), generateCloudSh(), force),
+    // config.py is required by common.sh when config.toml exists; ship it
+    // alongside the shell scripts so the cloud workflow is self-contained.
+    safeWrite(join(dir, "config.py"), generateConfigPy(), force),
+    // config.toml.example lives at the project root (the real config.toml
+    // is gitignored). It documents the multi-environment shape that
+    // scripts/config.py and scripts/cloud.sh expect.
+    safeWrite(join(root, "config.toml.example"), generateConfigTomlExample(), force),
   ]
   try {
     await Bun.$`chmod +x ${dir}/*.sh`.text()
@@ -953,6 +1998,8 @@ function scaffoldTerraform(root: string, force: boolean): string[] {
     safeWrite(join(dir, "backend.tf"), generateTfBackend(), force),
     safeWrite(join(dir, "variables.tf"), generateTfVariables(), force),
     safeWrite(join(dir, "main.tf"), generateTfMain(), force),
+    safeWrite(join(dir, "lb.tf"), generateTfLb(), force),
+    safeWrite(join(dir, "dns.tf"), generateTfDns(), force),
     safeWrite(join(dir, "outputs.tf"), generateTfOutputs(), force),
   ]
 }


### PR DESCRIPTION
## Summary

Brings lib-agents' \`/scaffold\` tool to parity with the thinking-games operational pattern (minus the Cloud SQL stack, which is out of scope per the spec).

Generated projects now include:

- **Terraform**: providers ≥ 1.14 with \`google-beta\`, \`random\`, \`time\`, plus \`google.dns\` and \`google.cb_project\` provider aliases. Full deployer-SA self-grant chain with conditional LB IAM and a triggers-keyed \`time_sleep\` for IAM propagation. Cloud Run v2 with configurable ingress and runtime SA. Cross-project AR reader binding so promoted images on secondary envs can be pulled. New \`lb.tf\` (10-resource external HTTPS LB stack, all gated on \`local.enable_lb\`) and \`dns.tf\` (single A record via the \`google.dns\` provider alias). New outputs: \`lb_ip\`, \`dns_fqdn\`, \`ssl_cert_name\`.
- **Cloud Build**: bumped to \`hashicorp/terraform:1.14\`; full set of \`TF_VAR_*\` env entries and matching substitutions (\`_DOMAIN\`, \`_DNS_*\`, \`_MIN/MAX_INSTANCES\`, \`_CB_SERVICE_ACCOUNT\`, \`_RUNTIME_SA_NAME\`, \`_CB_PROJECT_ID\`, \`_INGRESS\`).
- **Scripts**: \`common.sh\` selects \`ENVIRONMENT\` (staging/production) and parses \`config.toml\` via \`scripts/config.py\`. \`cloud.sh\` is the full multi-verb workflow (\`init\` / \`init-prod\` / \`infra\` / \`app-deploy\` / \`app-promote\` / \`app-undeploy\` / \`clean\`) with the primary-vs-secondary refusal guards, the cross-project DNS warn-and-continue fallback, and the prod self-escalation chain via \`projectIamAdmin\`.
- **Config**: \`scripts/config.py\` merges \`[gcp.default]\` with \`[gcp.<env>]\` and emits shell vars; \`config.toml.example\` documents the staging+prod shape with the LB+DNS opt-in trio commented in.
- **Makefile**: replaces \`cloud-build\` / \`cloud-deploy\` with \`cloud-init\`, \`cloud-init-prod\`, \`cloud-infra\`, \`cloud-app-deploy\`, \`cloud-app-promote\`, \`cloud-app-undeploy\`, \`cloud-clean\`.
- **.gitignore**: adds \`config.toml\`.

\`commands/scaffold.md\` gains a sixth menu option (full CI/CD with LB + DNS + multi-env promotion) and a post-scaffold checklist that walks the user through the two-environment bootstrap and promotion workflow.

## Deviations from the brief

- **\`dns.tf\` comment**: the comment was reworded from \`roles/dns.recordSetEditor\` to \`roles/dns.admin\` because that's the role the generated \`scripts/cloud.sh\` actually grants (and matches what thinking-games' actual \`init\` step does — the upstream \`dns.tf\` comment had a known stale reference to a role that does not exist in GCP's predefined catalog).
- **\`lb.tf\` header comment** was reworded to reflect the new configurable \`var.ingress\` (the upstream comment hardcoded the assumption that ingress is always internal).
- **\`generateCloudbuildYaml\`** now emits two image tags (\`:latest\` and \`:sha-\${_SHORT_SHA}\`) with \`_IMAGE_NAME\` as the bare base path — required so \`cloud.sh::app_deploy\` can pass \`_IMAGE_NAME=<base>\` and have the build produce both tags. The DB-conditional Prisma migration step from thinking-games' upstream \`cloudbuild.yaml\` was dropped (DB out of scope).
- All other variable/comment changes are the expected genericization (\`thinking-games\` → \`app\`, \`asia-southeast1\` → \`us-central1\`, no DB blocks).

## Verification

Smoke-tested by scaffolding into \`/tmp/scaffold-smoke\` (force=true, all components, generic project type) and running:

- \`bun tools/scaffold.ts\` runner: all 19 files generated cleanly.
- \`terraform validate\` (via \`hashicorp/terraform:1.14\` in podman): **PASS** — \`Success! The configuration is valid.\`
- \`bash -n\` on \`common.sh\`, \`cloud.sh\`, \`local.sh\`, \`container.sh\`: **PASS** for all four.
- \`python3 -c 'import ast; ast.parse(...)'\` on \`config.py\`: **PASS**.
- \`make -C /tmp/scaffold-smoke help\`: renders all new cloud targets correctly.
- Diffs against \`~/scratchpad/oss/thinking-games\` reduce to exactly the expected genericization (no DB lines, \`app\` placeholders, generic region) and the intentional comment improvements above.

The lib-agents repo itself has no formal test infrastructure (\`make test\` / \`local-test\` not present), so per the post-work protocol the smoke tests above stand in for unit/integration coverage.

Closes #119