### PR TITLE
chore(scaffold): clean up deferred review nits from #120

### DIFF
--- a/commands/scaffold.md
+++ b/commands/scaffold.md
@@ -9,16 +9,16 @@ This is a project scaffolding workflow.
 
 1. Detect the project type (Node, Go, Python, etc.).
 2. Ask the user what to scaffold:
-   - **Everything** (Makefile + scripts + container files + Cloud Build + Terraform + .gitignore)
-   - **Local dev only** (Makefile + scripts + .gitignore)
-   - **Container dev** (Makefile + scripts + container files + .gitignore)
-   - **Full CI/CD** (all of the above + Cloud Build + Terraform)
-   - **Cloud Build + Terraform only** (no local/container scripts)
-   - **Full CI/CD with external HTTPS LB + DNS + multi-env promotion**
-     (everything; Terraform includes `lb.tf` + `dns.tf`, scripts include
+   - **Local Dev** (Makefile + scripts + .gitignore)
+   - **Container Dev** (Makefile + scripts + container files + .gitignore)
+   - **CI/CD Only** (Cloud Build + Terraform + .gitignore)
+   - **Full CI/CD** (Makefile + scripts + container files + Cloud Build + Terraform + .gitignore)
+   - **Everything** (alias for Full CI/CD)
+   - **Full CI/CD + External HTTPS LB + DNS + Multi-Env Promotion**
+     (Full CI/CD plus Terraform `lb.tf` + `dns.tf` and scripts
      `config.py` + `config.toml.example` + the multi-verb cloud
-     workflow `init / init-prod / infra / app-deploy / app-promote /
-     app-undeploy / clean`).
+     workflow `init` + `init-prod` + `infra` + `app-deploy` +
+     `app-promote` + `app-undeploy` + `clean`).
 3. If CI/CD is selected, confirm the user wants Terraform executed via Cloud
    Build (plan on PR, apply on merge).
 4. Run the `scaffold` tool with the appropriate `components` parameter

--- a/tools/scaffold.ts
+++ b/tools/scaffold.ts
@@ -1575,9 +1575,24 @@ resource "google_cloud_run_v2_service_iam_member" "public" {
 # On the primary env (staging) where project_id == cb_project, the
 # binding is skipped — the runtime SA already has access via in-project
 # IAM granted elsewhere.
+#
+# We resolve the repo via a \`data\` source instead of hardcoding
+# \`repository = var.service_name\`. This catches misconfiguration (typo,
+# the primary env not yet bootstrapped, repo renamed out from under us)
+# at PLAN time with a clear "data source not found" error, rather than
+# at apply time with a confusing IAM-binding error against a phantom
+# resource.
 
 locals {
   is_secondary_env = var.project_id != var.cb_project
+}
+
+data "google_artifact_registry_repository" "primary" {
+  count         = local.is_secondary_env ? 1 : 0
+  provider      = google.cb_project
+  project       = var.cb_project
+  location      = var.region
+  repository_id = var.service_name
 }
 
 resource "google_artifact_registry_repository_iam_member" "runtime_ar_reader" {
@@ -1585,7 +1600,7 @@ resource "google_artifact_registry_repository_iam_member" "runtime_ar_reader" {
   provider   = google.cb_project
   project    = var.cb_project
   location   = var.region
-  repository = var.service_name
+  repository = data.google_artifact_registry_repository.primary[0].repository_id
   role       = "roles/artifactregistry.reader"
   member     = "serviceAccount:\${google_service_account.runtime.email}"
 }

--- a/tools/scaffold.ts
+++ b/tools/scaffold.ts
@@ -1650,6 +1650,19 @@ output "ssl_cert_name" {
 function generateTfLb(): string {
   return `# ─── External HTTPS Load Balancer in front of Cloud Run ──────────────
 #
+# IMPORTANT: This file defines \`local.enable_lb\` and
+# \`google_compute_global_address.lb_ip\`, which are referenced from
+# dns.tf and from the lb_ip / dns_fqdn / ssl_cert_name outputs in
+# outputs.tf. Do NOT delete this file to "disable the LB stack" — that
+# breaks dns.tf and the outputs with confusing
+# "local does not exist" / "resource not declared" errors.
+#
+# To disable the LB+DNS stack, leave the four gating variables empty in
+# your tfvars / Cloud Build substitutions (var.domain,
+# var.dns_project_id, var.dns_managed_zone, var.dns_record_name). All
+# resources here use \`count = local.enable_lb ? 1 : 0\` and become inert
+# when the gates are unset.
+#
 # Architecture:
 #   client → reserved IPv4 (anycast) → global external HTTPS LB
 #          → serverless NEG → Cloud Run
@@ -1798,6 +1811,18 @@ resource "google_compute_global_forwarding_rule" "http" {
 
 function generateTfDns(): string {
   return `# ─── DNS A record (in separate DNS project) ──────────────────────────
+#
+# IMPORTANT: This file depends on \`local.enable_lb\` and
+# \`google_compute_global_address.lb_ip\`, both defined in lb.tf. Do NOT
+# delete lb.tf or dns.tf to "disable the LB+DNS stack" — that breaks
+# this file and the lb_ip / dns_fqdn / ssl_cert_name outputs with
+# confusing "local does not exist" errors.
+#
+# To disable the stack, leave the four gating variables empty in your
+# tfvars / Cloud Build substitutions (var.domain, var.dns_project_id,
+# var.dns_managed_zone, var.dns_record_name). All resources here use
+# \`count = local.enable_lb ? 1 : 0\` and become inert when the gates
+# are unset.
 #
 # Writes a single A record into a pre-existing managed zone owned by a
 # different GCP project (\`var.dns_project_id\`). The deployer SA must hold

--- a/tools/scaffold.ts
+++ b/tools/scaffold.ts
@@ -1016,7 +1016,12 @@ images:
 
 substitutions:
   _IMAGE_NAME: 'us-central1-docker.pkg.dev/\${PROJECT_ID}/app/app'
-  _SHORT_SHA: 'unknown'
+  # Note: _SHORT_SHA has no default. Cloud Build auto-populates \$SHORT_SHA
+  # for trigger-driven builds; for manual \`gcloud builds submit\`, the
+  # caller MUST pass \`--substitutions=_SHORT_SHA=<sha>\` (which
+  # scripts/cloud.sh::app_deploy does). Forcing a missing-substitution
+  # error here is preferable to silently tagging images :sha-unknown
+  # and overwriting one another across builds.
 
 options:
   logging: CLOUD_LOGGING_ONLY

--- a/tools/scaffold.ts
+++ b/tools/scaffold.ts
@@ -1821,7 +1821,16 @@ import sys
 try:
     import tomllib
 except ModuleNotFoundError:
-    import tomli as tomllib  # Python < 3.11 fallback
+    try:
+        import tomli as tomllib  # Python < 3.11 fallback
+    except ModuleNotFoundError:
+        print(
+            "ERROR: config.py requires Python 3.11+ (for stdlib tomllib) "
+            "or the 'tomli' package on older Python.\\n"
+            "Fix: upgrade Python to 3.11+ OR run: pip install tomli",
+            file=sys.stderr,
+        )
+        sys.exit(1)
 
 
 def main():

--- a/tools/scaffold.ts
+++ b/tools/scaffold.ts
@@ -1438,9 +1438,16 @@ resource "google_project_iam_member" "deployer_lb_admin" {
 #
 # IMPORTANT: \`time_sleep\` only sleeps on create or when one of its OWN
 # attributes (triggers, create_duration, destroy_duration) changes.
-# Adding bindings to \`depends_on\` does NOT re-trigger the wait. We use
-# \`triggers\` keyed on the IAM binding IDs so any change to the deployer
-# IAM set forces the time_sleep to be recreated and sleep again.
+# Adding bindings to \`depends_on\` does NOT re-trigger the wait.
+#
+# We key \`triggers\` on the SORTED SET OF ROLES granted (not on the
+# binding resource IDs). This is intentional for idempotency: a
+# conditional binding flipping in/out (e.g., LB admin appearing when
+# the LB stack is enabled) re-keys an ID-based trigger and forces a
+# spurious 120s wait on every apply that touches IAM. Keying on the
+# role set means the sleep only re-fires when the set of roles
+# actually changes — which is the only case where propagation needs
+# to be re-awaited.
 
 resource "time_sleep" "wait_for_iam" {
   depends_on = [
@@ -1454,15 +1461,15 @@ resource "time_sleep" "wait_for_iam" {
   ]
 
   triggers = {
-    iam_members = sha256(jsonencode([
-      google_project_iam_member.deployer_run_admin.id,
-      google_project_iam_member.deployer_ar_admin.id,
-      google_project_iam_member.deployer_sa_user.id,
-      google_project_iam_member.deployer_serviceusage_admin.id,
-      google_project_iam_member.deployer_sa_creator.id,
-      try(google_project_iam_member.deployer_network_admin[0].id, ""),
-      try(google_project_iam_member.deployer_lb_admin[0].id, ""),
-    ]))
+    iam_roles = sha256(jsonencode(sort(compact([
+      "roles/run.admin",
+      "roles/artifactregistry.admin",
+      "roles/iam.serviceAccountUser",
+      "roles/serviceusage.serviceUsageAdmin",
+      "roles/iam.serviceAccountCreator",
+      local.enable_lb ? "roles/compute.networkAdmin" : "",
+      local.enable_lb ? "roles/compute.loadBalancerAdmin" : "",
+    ]))))
   }
 
   create_duration = "120s"


### PR DESCRIPTION
Closes #121

## Summary

Six yellow-flagged code-review nits from PR #120 (`feat(scaffold): port DNS + external HTTPS LB + multi-env promotion`, merged at d077e38) were intentionally deferred. This PR bundles all six fixes into a single follow-up. All changes are in `tools/scaffold.ts` (the generator), with one fix also touching `commands/scaffold.md`.

## Fixes

| # | Fix | Commit |
|---|-----|--------|
| 1 | Drop `_SHORT_SHA: 'unknown'` fallback in generated `cloudbuild.yaml` so missing-substitution failures are loud rather than producing `:sha-unknown` tags that overwrite each other across builds. | `a98f429` |
| 2 | Stabilise `time_sleep.wait_for_iam` `triggers` by keying on the sorted set of roles granted (rather than binding resource IDs), so conditional bindings flipping in/out don't cause spurious 120s waits on routine applies. | `f003674` |
| 3 | Friendlier error from generated `config.py` when both `tomllib` and `tomli` are missing — print actionable hint and exit cleanly instead of raising a bare `ModuleNotFoundError`. | `fdf63dc` |
| 4 | Replace the naming-convention cross-project AR reader (`repository = var.service_name`) with an explicit `data "google_artifact_registry_repository" "primary"` lookup, so misconfiguration is caught at plan time, not apply time. | `65b11cf` |
| 5 | Add header comments to generated `dns.tf` and `lb.tf` documenting the cross-file dependency on `local.enable_lb` (defined in `lb.tf`) so users don't break the stack by deleting either file. | `c3c4fc6` |
| 6 | Align `/scaffold` menu copy in `commands/scaffold.md` for consistent format (uniform `+` conjunction, Title Case labels, parallel structure, narrowest-to-broadest ordering). | `5e803c7` |

## Verification (smoke test)

No CI for this repo. Regenerated to `/tmp/scaffold-cleanup-smoke` using a containerized `bun` runner (the bundled scaffold tool only writes to the current workspace, so a runner is needed; `docker.io/oven/bun:1-alpine` was used).

| Check | Result |
|---|---|
| `terraform init -backend=false` (hashicorp/terraform:1.14) | OK — 4 providers installed |
| `terraform validate` | **Success! The configuration is valid.** |
| `bash -n scripts/common.sh` | OK |
| `bash -n scripts/cloud.sh` | OK |
| `bash -n scripts/local.sh` | OK |
| `bash -n scripts/container.sh` | OK |
| `python3 -c "import ast; ast.parse(open('scripts/config.py').read())"` (python:3.12-alpine) | **parse OK** |

Spot checks on the generated output:
- `cicd/cloudbuild.yaml` — `_SHORT_SHA: 'unknown'` line gone; explanatory comment added in the substitutions block.
- `cicd/terraform/main.tf` — `triggers = { iam_roles = sha256(jsonencode(sort(compact([...])))) }`.
- `scripts/config.py` — nested try/except with actionable hint pointing to either Python 3.11+ or `pip install tomli`.
- `cicd/terraform/main.tf` — `data "google_artifact_registry_repository" "primary"` block present; IAM binding references `data.google_artifact_registry_repository.primary[0].repository_id`.
- `cicd/terraform/dns.tf` and `cicd/terraform/lb.tf` — matching `IMPORTANT:` header comments documenting the cross-file dependency.
- `commands/scaffold.md` — six menu options now use uniform Title Case labels and `+` conjunction, ordered narrowest → broadest.

## Notes

- All six commits sit cleanly on top of `d077e38` (the merge commit for PR #120).
- No behaviour change for the happy path of any existing flow; the only runtime-visible changes are the failure modes (Fix 1, Fix 3) and a Terraform plan-time validation (Fix 4).
- Do NOT merge — that's a separate decision per the task brief.