### PR TITLE
fix(install.sh): rewrite opencode.json {file:...} refs for --global mode (closes #126)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1906,11 +1906,40 @@ install_agent() {
         warn "${root_file} already exists at ${root_dest}. Skipping."
         record_file "$root_dest" "user"
       else
-        if [ "$use_link" = true ]; then
+        # opencode.json in --global mode needs a post-process to strip
+        # the .opencode/ segment from {file:...} refs. The shipped
+        # config uses {file:.opencode/prompts/build.md} and similar,
+        # which only resolve correctly in --project mode (where
+        # .opencode/ is a real subdir of the install root). In
+        # --global mode, the install root IS the equivalent of
+        # what .opencode/ is in --project mode — there's no
+        # .opencode/ segment — so opencode crashes on every command:
+        #   Error: Configuration is invalid at ~/.config/opencode/opencode.json:
+        #   bad file reference: "{file:.opencode/prompts/build.md}"
+        #   ~/.config/opencode/.opencode/prompts/build.md does not exist
+        #
+        # The rewrite requires `cp` (not `ln -s`), so we override
+        # link mode for opencode.json specifically with a warning —
+        # the config is "user-owned" and shouldn't auto-update from
+        # the repo anyway, so the loss of --link convenience here is
+        # acceptable. Other root files (AGENTS.md) still respect
+        # --link as requested.
+        local needs_global_rewrite=false
+        if [ "$mode" = "global" ] && [ "$root_file" = "opencode.json" ]; then
+          needs_global_rewrite=true
+        fi
+
+        if [ "$use_link" = true ] && [ "$needs_global_rewrite" = false ]; then
           ln -sf "$(realpath "${REPO_ROOT}/${root_file}")" "$root_dest"
           ok "Linked ${root_file} -> project root"
         else
+          if [ "$use_link" = true ] && [ "$needs_global_rewrite" = true ]; then
+            warn "${root_file} cannot be symlinked in --global mode (path rewrite required); copying instead."
+          fi
           cp "${REPO_ROOT}/${root_file}" "$root_dest"
+          if [ "$needs_global_rewrite" = true ]; then
+            sed -i 's|{file:\.opencode/|{file:./|g' "$root_dest"
+          fi
           ok "Copied ${root_file} -> project root"
         fi
         record_file "$root_dest" "user"


### PR DESCRIPTION
## Summary

`install.sh --global` copies `opencode.json` verbatim from the repo root. The shipped config uses `{file:.opencode/prompts/build.md}` and `{file:.opencode/prompts/plan.md}` references that only resolve correctly in **--project** mode (where `.opencode/` is a real subdirectory of the install root). In **--global** mode the install flattens — there is no `.opencode/` segment under `~/.config/opencode/` — so opencode crashes on every command with:

```
Error: Configuration is invalid at ~/.config/opencode/opencode.json: bad file reference:
"{file:.opencode/prompts/build.md}" ~/.config/opencode/.opencode/prompts/build.md does not exist
```

This affects every consumer of `install.sh --global` — opencode is unusable until the config is patched manually.

Closes #126.

## Reproduction (verified in podman)

```bash
# debian:trixie-slim with bun + opencode-ai 1.14.29
export BUN_INSTALL=/opt/bun
mkdir -p /opt/bun
curl -fsSL https://bun.sh/install | bash
/opt/bun/bin/bun install -g opencode-ai
ln -s /opt/bun/bin/opencode /usr/local/bin/opencode

curl -fsSL https://raw.githubusercontent.com/kunallimaye/lib-agents/main/install.sh \
  | bash -s -- --all --global

opencode run 'hi'
# Without this PR: Error: Configuration is invalid ... bad file reference
# With this PR:    > build · big-pickle (success)
```

## Fix

In `install.sh`'s root-file loop (lines 1902-1919), when copying `opencode.json` in `--global` mode, post-process it via `sed` to strip the `.opencode/` segment from `{file:...}` references:

```bash
sed -i 's|{file:\\.opencode/|{file:./|g' "$root_dest"
```

This makes the refs resolve relative to the config dir itself, where `prompts/` actually lives in `--global` layout.

## Edge case: `--link --global`

`--link --global` for `opencode.json` is overridden to `cp`+rewrite (with a warning), because `sed -i` doesn't apply through symlinks (it would mutate the source in the repo). The shipped config in the repo can't be safely altered by the installer, AND `opencode.json` is documented as "user-owned" anyway, so the loss of `--link` convenience for this one file is acceptable.

Other root files (`AGENTS.md`) continue to honor `--link` as requested in all modes.

## Behavior matrix (all confirmed working)

| Mode | Before | After |
|---|---|---|
| `--project` (with or without `--link`) | Works | Works (unchanged) |
| `--global` (no `--link`) | **Broken** (config refs invalid) | Works |
| `--global --link` | **Broken** (config refs invalid) | Works (override link with warn) |

## Affected refs

The shipped `opencode.json` references both prompts:
- `{file:.opencode/prompts/build.md}`
- `{file:.opencode/prompts/plan.md}`

The `sed` pattern matches both in one pass.

## Compatibility

- **`--project` mode**: unchanged behavior; the `needs_global_rewrite` flag is false.
- **`--global` mode**: now works (was broken before).
- **`--global --link`**: now works via override + warn (was broken before).
- **Forward**: if anyone manually patches their installed `opencode.json` with `sed -i 's|{file:\\.opencode/|{file:./|g'`, this fix is idempotent (sed pattern is no-op on patched files).

## No automated tests added

lib-agents currently has no test infrastructure / CI. Manual reproduction verified. If you want, I can add a small smoke-test fixture in a follow-up — but matching the existing repo conventions, this PR is just the fix + commit message documentation.

## Downstream context (informational only)

A consumer of this installer (`kunal-labs/workstation`, a custom Cloud Workstations image scaffold) hit this bug and shipped a workaround in their bootstrap script (kunal-labs/workstation#52 — applies the same `sed` to `~/.config/opencode/opencode.json` after the install). Once this PR lands, that downstream workaround becomes a no-op and can be removed.

Field bug-report from the same project: kunal-labs/workstation#51.