### PR TITLE
fix(profile,install): include orchestrator+scribe in default profile; clarify --all help text

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1522,7 +1522,7 @@ Arguments:
   agent-name    One or more agent names to install (e.g., git-ops docs)
 
 Install Options:
-  --all, -a     Install all available agents (shorthand for --profile default)
+  --all, -a     Install agents from the default profile (shorthand for --profile default)
   --profile <n> Install using a named profile (e.g., default, sol-dev)
   --profiles    List available profiles with descriptions
   --project     Install to .opencode/ in the current directory (default)

--- a/profiles/default/PROFILE.md
+++ b/profiles/default/PROFILE.md
@@ -1,6 +1,6 @@
 ---
 name: default
-description: Standard operational setup — DevOps, Git, docs, ideation, and pilot agents with core operational skills
+description: Standard operational setup — DevOps, Git, docs, ideation, pilot, scribe, and orchestrator agents with core operational skills
 
 agents:
   - git-ops
@@ -8,6 +8,8 @@ agents:
   - docs
   - ideate
   - pilot
+  - scribe
+  - orchestrator
 
 agent_skills:
   build: []
@@ -23,11 +25,13 @@ agent_skills:
   docs:
     - readme-conventions
   pilot: []
+  scribe: []
+  orchestrator: []
 ---
 
 # Default Profile
 
-Standard operational setup with 5 agents and 8 operational skills. This is the
+Standard operational setup with 7 agents and 8 operational skills. This is the
 baseline configuration suitable for any project that uses the lib-agents DevOps
 workflow.
 
@@ -40,6 +44,8 @@ workflow.
 | `docs` | README and documentation maintenance |
 | `ideate` | Brainstorming and creative ideation |
 | `pilot` | Isolated experimentation and hypothesis testing |
+| `scribe` | Codebase-grounded technical writing (blog posts, deep-dives, explainers) |
+| `orchestrator` | Plan-then-delegate workflow agent (delegates execution to other agents via Task; no direct edits) |
 
 ## Included Skills
 


### PR DESCRIPTION
## Summary

Two related fixes that close #130:

1. **`profiles/default/PROFILE.md`** — adds `orchestrator` and `scribe` to the `agents:` list (and corresponding `agent_skills:` entries + "Included Agents" table rows). Both agents have existed in `agents/` for a while (scribe since #103, orchestrator since today's #129) but were never added to the default profile, so `--all` / `--profile default` installs were silently incomplete.

2. **`install.sh` `--all` help text** — replaces the contradictory phrase "Install all available agents (shorthand for --profile default)" with "Install agents from the default profile (shorthand for --profile default)". The flag's behavior is unchanged; only documentation. Applied consistently to all occurrences of the misleading phrase in the script.

## Why

Discovered when an operator running the documented one-liner install command (`curl ... | bash -s -- --all --global`) found that `orchestrator` was not installed, despite the `agents/orchestrator/` directory clearly existing on `main`. Investigation traced this to:

- `install.sh:2261-2262`: `--all` is implemented as an alias for `--profile default`, not as "install everything in `agents/`".
- `profiles/default/PROFILE.md`: the default profile's `agents:` list pre-dates both `scribe` (added 7 weeks ago) and `orchestrator` (added today), so it lists only 5 of the 7 available agents.
- The contradiction between `--all`'s description ("Install all available agents") and its parenthetical ("shorthand for `--profile default`") makes this a documentation bug independent of the profile gap.

## What changes

| File | Change |
|---|---|
| `profiles/default/PROFILE.md` | `agents:` list grows from 5 → 7 entries; `agent_skills:` adds `scribe: []` and `orchestrator: []`; embedded "Included Agents" table grows from 5 → 7 rows; description sentence updated from "5 agents" to "7 agents"; top-level `description:` frontmatter updated to mention the additional agents. |
| `install.sh` | Help text for `--all` updated from "Install all available agents (shorthand for --profile default)" to "Install agents from the default profile (shorthand for --profile default)". Single occurrence in the USAGE/Install Options block (line 1525). Behavior unchanged. |

## Verification

- `python3 -c "import yaml; yaml.safe_load(open('profiles/default/PROFILE.md').read().split('---')[1])"` parses cleanly; reports 7 agents and `agent_skills` keys including `scribe` and `orchestrator`.
- `bash -n install.sh` clean.
- After this PR merges: `curl ... | bash -s -- --all --global` will install all 7 agents (`devops`, `docs`, `git-ops`, `ideate`, `orchestrator`, `pilot`, `scribe`).

## Out of scope (deferred follow-ups, file separately if anyone wants them)

- Renaming `--all` to a flag that actually installs every agent in `agents/` (behavior change; back-compat implications).
- Adding a CI check that asserts `agents:` in default profile matches the `agents/` directory listing (guardrail to prevent recurrence).
- Top-level `README.md` "Available Agents" table is also missing `scribe`'s row — separate small drive-by PR.
- Default profile's `agent_skills` mappings for `orchestrator` and `scribe` are intentionally `[]` here; if either agent has natural skill associations (e.g., scribe → readme-conventions?), that's a content decision for a follow-up.

## Notes

- `scribe` is listed before `orchestrator` in the `agents:` list and the "Included Agents" table — chronological order of when each was added to lib-agents. Orchestrator depends on scribe (it can delegate to scribe), so scribe-first is also semantically correct as install order, though the installer handles `DEPENDS` resolution regardless.
- The misleading "Install all available agents" phrase was found in only **1** location (`install.sh:1525`), not the 2-3 anticipated. Adjacent example comments at lines 22-23, 1552, 1556 use the phrasing "Install all agents to current project" / "Install all agents globally" — these describe user intent in shorthand example comments and were left unchanged.
