### PR TITLE
feat(orchestrator): expand read-only tool access (Posture B) + add @explore delegation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,7 @@ Task tool instead of handling these tasks directly.
 
 | When the user asks about... | Delegate to | The agent handles... |
 |---|---|---|
+| Codebase reconnaissance, fast file/keyword searches during planning | `@explore` | Read-only codebase exploration with quick/medium/very thorough thoroughness levels (built-in OpenCode agent) |
 | Read-only GitHub queries (view issues, list PRs, check status, diffs) | `@git-ops` | Git/GitHub read operations with safety rails |
 | Write GitHub operations (create issues, commits, PRs, reviews, releases, merges) | `@devops` | Issue-driven Git/GitHub writes with pre-flight checks, docs validation, and test validation |
 | Scaffolding, containers, Terraform, CI/CD, GCP, deployment | `@devops` | Issue-driven DevOps workflows with pre-flight checks |
@@ -38,6 +39,8 @@ Task tool instead of handling these tasks directly.
 
 ## Quick Reference
 
+- "find files matching X" / "search the codebase" / "where is Y defined?" → `@explore`
+- "explore the codebase" / "map this project" → `@explore`
 - "view this issue" / "list PRs" / "check git status" / "show diff" → `@git-ops`
 - "create an issue" / "file a bug" / "track this" → `@devops`
 - "commit these changes" / "open a PR" / "merge" → `@devops`

--- a/ANTIGRAVITY-AGENTS.md
+++ b/ANTIGRAVITY-AGENTS.md
@@ -30,6 +30,7 @@ When handling specific domains, delegate to the appropriate specialist role (via
 
 | Domain / Task | Role | Handles |
 |---|---|---|
+| Codebase reconnaissance, fast file/keyword searches | `@explore` | Read-only codebase exploration (built-in agent) |
 | Read-only GitHub queries (view issues, list PRs, check status, diffs) | `@git-ops` | Git/GitHub read operations |
 | Write GitHub operations (create issues, commits, PRs, reviews, merges) | `@devops` | Issue-driven Git/GitHub writes (may delegate to `@git-ops`) |
 | Scaffolding, containers, Terraform, CI/CD, GCP, deployment | `@devops` | Infrastructure and deployment workflows |

--- a/agents/orchestrator/agent.md
+++ b/agents/orchestrator/agent.md
@@ -52,10 +52,8 @@ tools:
   readme-analyze: true
   readme-validate: true
 
-  # Environment readiness checks (read-only)
+  # Environment readiness check (read-only)
   git-ops-init: true
-  git-ops-init_getEnvironmentReport: true
-  git-ops-init_ensureEnvironment: true
 
   # Mutation tools — explicitly disabled
   write: false

--- a/agents/orchestrator/agent.md
+++ b/agents/orchestrator/agent.md
@@ -9,12 +9,55 @@ description: >
 mode: primary
 temperature: 0.4
 tools:
+  # Core orchestration
   task: true
   read: true
   glob: true
   grep: true
   webfetch: true
   todowrite: true
+  question: true
+  skill: true
+
+  # Read-only GitHub inspection
+  gh-issue_view: true
+  gh-issue_list: true
+  gh-pr_view: true
+  gh-pr_list: true
+  gh-review_diff: true
+  gh-review_list_reviews: true
+  gh-release_view: true
+  gh-release_list: true
+  gh-release_generate_notes: true
+
+  # Read-only git state
+  git-status_status: true
+  git-status_diff: true
+  git-status_log: true
+  git-status_blame: true
+  git-status_stash_list: true
+  git-branch_list: true
+  git-branch_current: true
+  git-conflict_detect: true
+  git-conflict_show: true
+  git-commit_diff_staged: true
+
+  # Workspace inventory (read-only)
+  agent-workspace_list: true
+  pilot-workspace_list: true
+  pilot-workspace_inspect: true
+  branch-cleanup_list_stale: true
+
+  # Documentation analysis (read-only)
+  readme-analyze: true
+  readme-validate: true
+
+  # Environment readiness checks (read-only)
+  git-ops-init: true
+  git-ops-init_getEnvironmentReport: true
+  git-ops-init_ensureEnvironment: true
+
+  # Mutation tools — explicitly disabled
   write: false
   edit: false
   patch: false
@@ -97,6 +140,11 @@ responsible for safe execution within its own sandbox.
 
 Permitted Task targets:
 
+- **`@explore`** — fast codebase reconnaissance for planning. Native
+  OpenCode agent (built into the runtime, not lib-agents-managed). Use
+  when you need to find files by patterns, search for keywords/symbols,
+  or answer codebase questions before constructing a plan. Specify
+  thoroughness: `quick`, `medium`, or `very thorough`.
 - **`@pilot`** — hypothesis testing, bug reproduction, prototyping. Runs in
   ephemeral `/tmp/pilot-*` workspaces with file-write isolation enforced by
   `external_directory`. Use for "does X work?" / "can I reproduce this?" /
@@ -166,6 +214,8 @@ specialist receives the same brief format it has been trained to consume.
 
 ## Choosing the Right Specialist
 
+- Need to map the codebase, find files, or search for symbols before
+  planning → `@explore`
 - Code analysis says "we need to verify X behaves like Y" → `@pilot`
 - Plan calls for any file change, commit, PR, container build, infra
   change, or deployment → `@devops`


### PR DESCRIPTION
Closes #132.

## Summary

Adopts **Posture B (read-rich planner)** for the `@orchestrator` agent and documents `@explore` as a recognized delegation target across the project's agent guidance.

### Audit findings

The orchestrator agent (`agents/orchestrator/agent.md`) is `mode: primary` and its job is "analyze, ask clarifying questions, plan, delegate — never act directly." An audit of its frontmatter and prose surfaced three gaps:

1. **`question` and `skill` were missing** from the inclusion-style `tools:` allowlist, even though the agent's description and body explicitly say it asks clarifying questions and would benefit from loading domain skills (e.g., `design-core`, `crypto-core`) before planning.
2. **Read-only state inspection was under-powered.** The orchestrator only had `read`/`glob`/`grep`/`webfetch` plus a bash readonly allowlist. Trivial reads like "what's the current branch" or "what's in PR #42" required spawning a `@git-ops` subagent — adding round-trip latency for no isolation benefit.
3. **`@explore` was undocumented.** `@explore` is a **native OpenCode agent** (built into the `~/.opencode/bin/opencode` binary, not lib-agents-managed). The Task tool's `subagent_type` parameter is unrestricted at the runtime level, but the orchestrator's "Permitted Task targets" prose listed 6 agents and read as exhaustive, suppressing valid `@explore` delegation during planning. Both `AGENTS.md` and `ANTIGRAVITY-AGENTS.md` Delegation Tables also omitted it.

### Posture B vs. A vs. C — trade-off

| Posture | Tool surface | Trade-off |
|---|---|---|
| A (minimal) | Add only `question` + `skill` | Smallest blast radius, but doesn't address the round-trip-latency problem for trivial state reads. |
| **B (read-rich planner)** ✓ | Add `question`, `skill`, plus curated read-only MCP tools: gh-* read, git-status_*, git-branch_*, git-conflict_*, `git-commit_diff_staged`, agent/pilot workspace inventory, `readme-analyze`/`validate`, git-ops-init readiness checks. **All write/mutation tools explicitly denied.** | Sweet spot: orchestrator can self-serve all read-only inspection it needs for planning, while file-write/state-mutation work still requires delegation to a sandboxed specialist. |
| C (maximal) | Posture B + cloud/infra/troubleshoot reads (`gcloud_*`, `cloudbuild_list_*`, `troubleshoot_*`) | Larger surface, blurs the boundary with `@devops`. Deferred — those tools stay `@devops` territory for now. |

### Changes

| File | Change |
|---|---|
| `agents/orchestrator/agent.md` | Replaced `tools:` block with the Posture B inclusion-style allowlist (39 keys total: 8 core + 9 gh-* + 10 git-* + 4 workspace + 2 readme + 3 git-ops-init + 3 explicit denies). Added `@explore` as the first entry in "Permitted Task targets" and "Choosing the Right Specialist". |
| `AGENTS.md` | Added `@explore` row at the top of the Delegation Table; added 2 Quick Reference entries at the top of that list. |
| `ANTIGRAVITY-AGENTS.md` | Added `@explore` row at the top of the Delegation Table. |

### Verification

- `git diff --stat` confirms only the 3 files above are modified (54 insertions, 0 deletions).
- The orchestrator's `permission:` block is preserved **byte-identical** to `main` (sha256 of lines 21-78 on `main` matches sha256 of lines 64-121 on this branch: `115d623…d177c01`).
- YAML frontmatter parses cleanly via `python3 -c "import yaml; yaml.safe_load(...)"` — top-level keys are `[description, mode, temperature, tools, permission]`; `tools` count is 39.
- No changes to other agents (`devops`, `docs`, `git-ops`, `ideate`, `pilot`, `scribe`), no changes to `opencode.json`, no changes to `skills/`, `tools/`, or `commands/` directories.

### Workflow notes

- This is a docs/config-only change. There is no code path to test and no project-wide test infrastructure (`make test` not defined). `validate_tests` returned `WARN: No test infrastructure was found`. Per the issue brief, this is expected and acceptable for a docs/config-only change. Reversion is a single `git revert`.
- Verification post-merge: open a fresh opencode session with `agent: orchestrator` and confirm (a) `question` and `skill` are invocable, (b) the new `gh-*` / `git-status_*` / `agent-workspace_list` / `readme-validate` tools are invocable, and (c) `write`/`edit`/`patch` are denied. This matches Acceptance Criterion #2 in #132.
- Out of scope (deliberately): no audit of `@build` or `@plan` primary agents in this pass; no `task` permission rules added to `opencode.json`.

Not draft — ready for review.


### Scope notes

**`git-ops-init: true` is a minor scope expansion of Posture B.** Issue
#132's Acceptance Criterion #2 enumerated the tools that must be
invocable (`question`, `skill`, `gh-issue_view`, `git-status_status`,
`agent-workspace_list`, `readme-validate`); the `git-ops-init` tool was
not on that list. It is enabled here because it is a read-only
environment-readiness check — the sibling write-class tool
`git-ops-init_setup` (which creates labels/milestones) remains denied via
implicit omission from the inclusion-style allowlist. Including the
read-only check lets the orchestrator self-verify environment health
when planning git-related work without round-tripping through
`@git-ops`. Flagging for transparency.

### Fixup applied during review

A self-review surfaced two erroneous keys in the original `tools:`
block: `git-ops-init_getEnvironmentReport` and
`git-ops-init_ensureEnvironment`. These correspond to plain helper
functions exported from `tools/git-ops-init.ts` (consumed by other tool
modules), not to OpenCode-registered tools — only `git-ops-init`
(default export) and `git-ops-init_setup` (named `export const ... =
tool(...)`) are real registered keys. The fixup commit removes the two
non-existent keys, keeps `git-ops-init: true`, and updates the section
comment from plural to singular. Tool count drops from 39 → 37 (34
enabled + 3 explicitly denied). Permission block remains byte-identical
to `main`. No functional change (OpenCode silently ignores unknown
keys), just corrected documentation.
