### PR TITLE
chore: post-#135 cleanup (install.sh prune + CI guard + .gitignore tighten)

### DIFF
--- a/.github/workflows/repo-hygiene.yml
+++ b/.github/workflows/repo-hygiene.yml
@@ -1,0 +1,59 @@
+name: repo-hygiene
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  repo-hygiene:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Check no opencode.json variant is tracked
+        run: |
+          set -euo pipefail
+          tracked=$(git ls-files \
+            ':(top)opencode.json' \
+            ':(top)opencode.json5' \
+            ':(top)opencode.jsonc' \
+            ':(top)opencode.yaml' \
+            ':(top)opencode.yml' \
+            '**/opencode.json' \
+            '**/opencode.json5' \
+            '**/opencode.jsonc' \
+            '**/opencode.yaml' \
+            '**/opencode.yml' || true)
+          if [ -n "$tracked" ]; then
+            echo "::error::opencode.json (or variant) is tracked in the repo:"
+            echo "$tracked"
+            echo "These files are user-local and gitignored. See issue #134 / PR #135."
+            exit 1
+          fi
+          echo "OK: no opencode.json variant tracked."
+
+      - name: Check no broken file directive in config files
+        run: |
+          set -euo pipefail
+          # Scope to config-file extensions only. Shell scripts (install.sh)
+          # and .gitignore intentionally reference the pattern in comments
+          # / sed strings and must not be flagged. The pattern is built from
+          # parts to avoid this workflow file itself tripping the check.
+          pattern='\{'"file"':\.opencode'
+          # Exclude this workflow file from the scan (it discusses the pattern).
+          matches=$(git ls-files -- \
+            '*.json' '*.json5' '*.jsonc' \
+            '*.yaml' '*.yml' '*.toml' \
+            ':!:.github/workflows/repo-hygiene.yml' \
+            | xargs -r grep -l "$pattern" || true)
+          if [ -n "$matches" ]; then
+            echo "::error::Broken opencode file directive found in:"
+            echo "$matches"
+            echo "See PR #135 for context. The .opencode/ dir is gitignored;"
+            echo "refs to it break opencode startup on fresh clones."
+            exit 1
+          fi
+          echo "OK: no broken opencode file directives in tracked config files."

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,6 @@
 # OpenCode local install artifacts
 .opencode/
-# opencode.json references {file:.opencode/...} prompts which live under the
-# gitignored .opencode/ tree; committing this file breaks opencode startup in
-# fresh clones. See issue #134.
+# opencode.json — user-local config, see #134 / #135
 opencode.json
 
 # Dependencies

--- a/install.sh
+++ b/install.sh
@@ -759,7 +759,7 @@ generate_manifest_for_existing() {
   fi
 
   # Scan user-tier root files
-  for root_file in AGENTS.md opencode.json; do
+  for root_file in AGENTS.md; do
     if [ -f "${project_root}/${root_file}" ]; then
       record_file "${project_root}/${root_file}" "user"
     fi
@@ -1109,7 +1109,7 @@ update_installation() {
 
   # Scan new source: root config files (user tier)
   if should_include_type "configs" "$only_filter"; then
-    for root_file in AGENTS.md opencode.json; do
+    for root_file in AGENTS.md; do
       if [ -f "${REPO_ROOT}/${root_file}" ]; then
         local dest="${project_root}/${root_file}"
         NEW_FILES["$dest"]="${REPO_ROOT}/${root_file}"
@@ -1890,7 +1890,7 @@ install_agent() {
   # Install ALL shared resources (tools, skills, commands, prompts) once
   install_shared_resources "$target" "$use_link"
 
-  # Install project-root config files (AGENTS.md, opencode.json)
+  # Install project-root config files (AGENTS.md)
   # These go to the project root, not inside .opencode/
   local project_root
   if [ "$mode" = "project" ]; then
@@ -1899,47 +1899,18 @@ install_agent() {
     project_root="${HOME}/.config/opencode"
   fi
 
-  for root_file in AGENTS.md opencode.json; do
+  for root_file in AGENTS.md; do
     if [ -f "${REPO_ROOT}/${root_file}" ]; then
       local root_dest="${project_root}/${root_file}"
       if [ -f "$root_dest" ]; then
         warn "${root_file} already exists at ${root_dest}. Skipping."
         record_file "$root_dest" "user"
       else
-        # opencode.json in --global mode needs a post-process to strip
-        # the .opencode/ segment from {file:...} refs. The shipped
-        # config uses {file:.opencode/prompts/build.md} and similar,
-        # which only resolve correctly in --project mode (where
-        # .opencode/ is a real subdir of the install root). In
-        # --global mode, the install root IS the equivalent of
-        # what .opencode/ is in --project mode — there's no
-        # .opencode/ segment — so opencode crashes on every command:
-        #   Error: Configuration is invalid at ~/.config/opencode/opencode.json:
-        #   bad file reference: "{file:.opencode/prompts/build.md}"
-        #   ~/.config/opencode/.opencode/prompts/build.md does not exist
-        #
-        # The rewrite requires `cp` (not `ln -s`), so we override
-        # link mode for opencode.json specifically with a warning —
-        # the config is "user-owned" and shouldn't auto-update from
-        # the repo anyway, so the loss of --link convenience here is
-        # acceptable. Other root files (AGENTS.md) still respect
-        # --link as requested.
-        local needs_global_rewrite=false
-        if [ "$mode" = "global" ] && [ "$root_file" = "opencode.json" ]; then
-          needs_global_rewrite=true
-        fi
-
-        if [ "$use_link" = true ] && [ "$needs_global_rewrite" = false ]; then
+        if [ "$use_link" = true ]; then
           ln -sf "$(realpath "${REPO_ROOT}/${root_file}")" "$root_dest"
           ok "Linked ${root_file} -> project root"
         else
-          if [ "$use_link" = true ] && [ "$needs_global_rewrite" = true ]; then
-            warn "${root_file} cannot be symlinked in --global mode (path rewrite required); copying instead."
-          fi
           cp "${REPO_ROOT}/${root_file}" "$root_dest"
-          if [ "$needs_global_rewrite" = true ]; then
-            sed -i 's|{file:\.opencode/|{file:./|g' "$root_dest"
-          fi
           ok "Copied ${root_file} -> project root"
         fi
         record_file "$root_dest" "user"


### PR DESCRIPTION
## Summary

Three coordinated post-PR-#135 cleanups in a single PR. PR #135 deleted the committed root-level `opencode.json` (it referenced gitignored `{file:.opencode/...}` prompts and broke opencode startup on fresh clones). An audit surfaced three follow-ups, bundled here.

## What this changes

1. **`install.sh` prune** — removes the dormant `opencode.json` branch from the root-file install loop, plus the sibling iteration entries in the manifest-scan and upgrade-scan code paths. The associated rewrite logic (`needs_global_rewrite` flag, `--link` downgrade warning, `sed` rewrite, explanatory comments) is removed since it only ever fired for the now-deleted file. `AGENTS.md` handling is preserved unchanged for both `--project` and `--global` modes. User-facing sidecar references (`opencode.local.json` merge guidance) are kept intact since they describe live functionality for users who maintain their own `opencode.json`.
2. **CI guard** — new `.github/workflows/repo-hygiene.yml` runs on push and pull_request to `main`. Two checks:
   - (a) Fails if any `opencode.{json,json5,jsonc,yaml,yml}` is tracked at any path.
   - (b) Fails if any tracked `.json`/`.json5`/`.jsonc`/`.yaml`/`.yml`/`.toml` file contains the broken `{file:.opencode/...}` directive. The workflow file itself is excluded from this check (and the pattern is built from parts) to avoid self-tripping. Shell scripts and `.gitignore` are out of scope by extension.
3. **`.gitignore` tighten** — collapses the 3-line explanation block above the `opencode.json` entry into a single comment referencing #134 / #135.

## Verification

- `bash -n install.sh` exits 0.
- YAML parses successfully via `python3 -c 'import yaml; yaml.safe_load(...)'`.
- Local simulation of both CI checks against the post-cleanup tree returns zero matches for each.
- Docs validator (`readme-validate`) returned PASS with no errors or warnings.

Closes #136