### PR TITLE
fix(agents): apply #124 bash treatment to git-ops agent

### DIFF
--- a/agents/git-ops/agent.md
+++ b/agents/git-ops/agent.md
@@ -29,22 +29,7 @@ permission:
     git-pr-workflow: allow
     git-release: allow
   bash:
-    "*": deny
-    # Git operations scoped to workspaces — prevent branch switching in main tree
-    "git -C /tmp/agent-*": allow
-    "git remote*": allow
-    "git rev-parse*": allow
-    "git log*": allow
-    "git diff*": allow
-    "git show*": allow
-    "git ls-files*": allow
-    "git fetch*": allow
-    "git push*": allow
-    "git branch*": allow
-    "git tag*": allow
-    "git stash*": allow
-    # GitHub CLI
-    "gh *": allow
+    "*": allow
 ---
 
 You are a Git and GitHub operations assistant. You help users manage their
@@ -80,6 +65,32 @@ for bash commands.
 
 **NEVER switch branches in the main working tree.** The main working tree's
 HEAD must remain unchanged.
+
+## Safety Model
+
+The git-ops agent runs with **unrestricted bash** (`bash: "*": allow`). File-
+write isolation is the sole opencode-enforced filesystem-level guarantee,
+and it is bounded by the `permission.external_directory: "/tmp/agent-*":
+allow` declaration in the agent's frontmatter.
+
+- **File-write boundary**: The `write`, `edit`, and `patch` tools cannot
+  target paths outside `/tmp/agent-*`. The `external_directory` permission
+  is the sole opencode-enforced guarantee that git-ops cannot mutate the
+  main project via the file tools.
+- **Bash redirects**: Bash is unrestricted, so `cat > ...`, `tee`, `cp`,
+  `mv`, and similar shell redirects are available. Redirects targeting
+  paths outside `/tmp/agent-*` are subject to the same `external_directory`
+  policy where opencode enforces it. The agent is trusted not to mutate the
+  main project even where bash mechanics could permit it.
+- **Git on the main project**: Inspection commands (`git log`, `git diff`,
+  `git show`, `git status`, `gh ...` read operations) are the expected use
+  on the main repo. All branch-mutating operations (commit, push, branch
+  create/switch) MUST run inside a `/tmp/agent-*` workspace via the
+  `workspace` parameter or `workdir`.
+
+The prose safety rules below (never switch branches in the main tree, never
+force-push to protected branches, conventional commit format, etc.) remain
+in force and are the primary discipline for this agent.
 
 ## Core Responsibilities
 


### PR DESCRIPTION
## Summary

Applies the #124 bash-permission treatment to `agents/git-ops/agent.md`, completing the sweep started in #114 / #124 across the three agents that own `/tmp/agent-*` or `/tmp/pilot-*` workspaces (`@devops`, `@pilot`, `@git-ops`).

## Changes

- **Frontmatter**: Collapsed the curated `permission.bash` allowlist (15 entries + `"*": deny`) to a single `"*": allow`. The previous allowlist was missing common helpers (`mkdir`, `cp`, `mv`, `mktemp`, `tee`, `chmod`, `rm`, `ls`, `pwd`, `cat`, …) which triggered opencode permission prompts on every routine workspace operation.
- **Body prose**: Added a `## Safety Model` section between `## Workspace Isolation` and `## Core Responsibilities`. The new section mirrors the wording in `agents/pilot/agent.md` (lines 70–97) and `agents/devops/agent.md` (lines 118–128), and explicitly declares that the `external_directory: "/tmp/agent-*": allow` declaration (from #114) is the sole opencode-enforced filesystem-isolation guarantee, with bash redirects subject to the same policy where opencode enforces it. The existing prose safety rules (never switch branches in the main tree, never force-push to protected branches, conventional commit format, etc.) remain authoritative.

## Pattern reference

| Agent | external_directory (#114) | bash: \"*\": allow (#124) | Safety Model prose |
|---|---|---|---|
| @pilot | /tmp/pilot-* | ✓ | ✓ |
| @devops | /tmp/agent-* | ✓ | ✓ |
| @git-ops (this PR) | /tmp/agent-* | ✓ (newly added) | ✓ (newly added) |

## Out of scope / follow-up

The owner [noted on the issue](https://github.com/kunallimaye/lib-agents/issues/138#issuecomment-4549234206) that the same treatment should likely be extended to the `build` and (especially) `plan` agent blocks in the installer's `opencode.json` template. Those agents are opencode built-ins configured directly in the top-level `agent` map rather than in `agents/*/agent.md`, so an `agents/`-only fix does not pick them up. `@plan` in particular is used for codebase reconnaissance and routinely needs to `read` files under `/tmp/agent-*` workspaces created by `@devops`; without `permission.external_directory: \"/tmp/agent-*\": allow` (and `/tmp/pilot-*`) on the `plan` block, the friction tracked in `kunal-labs/workstation#86` will keep firing even after this PR lands.

This is **deliberately out of scope** for this PR (which is scoped to the title of issue #138). A separate follow-up issue should be filed to track the `opencode.json` `build` / `plan` block treatment.

## Related

- #114 — added `external_directory` to devops/git-ops/pilot, re-enabled write/edit/patch
- #124 — replaced curated bash allowlist with `bash: \"*\": allow` on @pilot and @devops
- kunal-labs/workstation#86 — downstream motivating issue

Closes #138
