### PR TITLE
feat(scaffold): three-role topology, IAM hardening, detached orchestration (closes #141, #140)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,171 @@
+# Changelog
+
+All notable changes to `lib-agents` are documented here.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/);
+this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased] — three-role topology + detached orchestration (BREAKING)
+
+Closes [#141](https://github.com/kunallimaye/lib-agents/issues/141) and
+[#140](https://github.com/kunallimaye/lib-agents/issues/140).
+
+This release is a **major-version-bump-worthy breaking change** to the
+`/scaffold` Full CI/CD bundle. Existing projects scaffolded from older
+bundles must re-scaffold and reconcile by hand — there is no migration
+script.
+
+### BREAKING
+
+- **`config.toml` schema replaced.** The old `[gcp.default]` +
+  `[gcp.staging]` + `[gcp.production]` environment-axis schema is GONE.
+  Replaced with a **role-axis** schema: `[gcp.defaults]` (required
+  catch-all) + `[gcp.orchestration]` + `[gcp.build]` + `[gcp.runtime]`.
+  Environment-axis layering (e.g. `[gcp.production.runtime]`) still
+  works on top.
+- **`scripts/cloud.sh` verbs replaced.**
+  - `init` / `init-prod` → `admin-cloud-init` (single Owner-tier
+    bootstrap, cross-project-aware; no more separate "primary vs
+    secondary env" code paths).
+  - `infra` → `cloud-infra`.
+  - `app-deploy` → `cloud-app-deploy`.
+  - `app-promote` → `cloud-app-promote`.
+  - `app-undeploy` → `cloud-app-undeploy`.
+  - `clean` → `cloud-clean`.
+  - New: `admin-cloud-destroy`, `cloud-preflight`, `cloud-status`,
+    `cloud-recover`, `cloud-help`.
+  - Stubs print a clear redirect on the old verbs (will be removed in
+    the next major bump).
+- **Makefile targets renamed.** `make cloud-init` → `make admin-cloud-init`,
+  `make cloud-init-prod` → `make admin-cloud-init` (collapsed),
+  `make cloud-clean` → `make cloud-clean` (unchanged), etc. See the
+  generated Makefile for the full list.
+- **Terraform variables replaced.** `var.project_id` / `var.region` /
+  `var.cb_project` / `var.cb_service_account` are GONE. Replaced with
+  the role-axis variables: `var.orchestration_project_id` /
+  `var.build_project_id` / `var.runtime_project_id` (+ matching
+  `_region` variables), and `var.builder_sa_email`.
+- **Terraform resources removed.**
+  - `google_project_service.bootstrap_apis` — API enable moves to
+    `admin-cloud-init`.
+  - `google_project_service.apis` — same.
+  - `google_project_iam_member.deployer_run_admin` /
+    `deployer_ar_admin` / `deployer_sa_user` /
+    `deployer_serviceusage_admin` / `deployer_sa_creator` /
+    `deployer_network_admin` / `deployer_lb_admin` — TF self-escalation
+    forbidden (#141 lesson 1). Project IAM moves to `admin-cloud-init`.
+  - `time_sleep.wait_for_iam` — moot without TF doing IAM.
+  - `google_artifact_registry_repository.app` (resource) — now a
+    `data` source instead. AR repo created by `admin-cloud-init`.
+- **Builder SA's required IAM tightened.** Generated TF works with a
+  builder SA that holds ONLY 6 predefined functional roles
+  (`run.admin`, `artifactregistry.admin`, `iam.serviceAccountUser`,
+  `iam.serviceAccountAdmin`, `logging.logWriter`, `storage.admin`).
+  No `projectIamAdmin`, no `serviceUsageAdmin`. Anyone running the old
+  bundle's TF must remove those broad grants from the builder SA after
+  re-scaffolding.
+- **Provider config in `providers.tf` replaced.** Old `google.dns` +
+  `google.cb_project` aliases are GONE; new aliases are
+  `google.orchestration` / `google.build` / `google.runtime` (+ a
+  `google.dns` alias retained for the DNS project). When all three
+  role projects collapse to one, the aliases are functionally identical.
+- **The `commands/scaffold.md` menu option** "Full CI/CD + External
+  HTTPS LB + DNS + Multi-Env Promotion" is renamed to "Full CI/CD +
+  Three-Role Topology + LB+DNS" and the bundle behind it is the new
+  shape. Old behavior is gone.
+- **Rust scaffold** defaults `make local-run` to `cargo run --release`
+  (was `cargo run`). Dev profile users need an explicit
+  `local-run-dev` target.
+
+### Added
+
+- **`config.toml.example`** with role-axis schema, fully commented.
+- **`.env.example`** generated alongside, documenting sensitive
+  overrides (project IDs, billing accounts, emails, API keys) and the
+  `ORCH_FORCE_RESTART=1` operator escape hatch.
+- **`scripts/config.py`** rewritten to resolve `env > role > defaults
+  > error` precedence. Same parser is the source of truth for shell
+  scripts and Terraform.
+- **`scripts/common.sh`** ports the stepwise orchestration helpers
+  from #140 with step-list-hash checkpoint invalidation per #141
+  lesson 3:
+  - `run_detached_stepwise` — N idempotent steps, checkpoint after
+    each, resume on re-run, restart-from-1 when step list changes.
+  - `run_detached_cloudbuild` — single atomic remote job + heartbeat.
+  - `heartbeat_status` / `recovery_summary` — read state for
+    `cloud-status` / `cloud-recover`.
+  - Tier-1 hygiene now guaranteed: `set -euo pipefail`, `die` helper,
+    traps on EXIT/INT/TERM/HUP, stable `logs/<timestamp>-<action>.log`
+    paths, no `|| true` swallowing failures.
+- **`cicd/iam/<project>-deployer-role.yaml`** — curated 37-permission
+  custom role for the agent SA. Diff-reviewable in git. Bound by
+  `admin-cloud-init` with a 30-day expiry condition.
+- **`docs/decisions/ADR-template-cloud-topology.md`** — template
+  projects copy to `ADR-XXX-cloud-topology.md` and fill in.
+- **`AGENTS.local.md`** — detached-orchestration convention section
+  (appended, not overwritten — operator-owned).
+- **`scaffold` tool components**: `iam`, `adr`, `agentslocal`.
+  Default bundle includes all of them.
+- **`/scaffold` command UX**: new "When should I run `/scaffold`?"
+  section covering 5 trigger scenarios (fresh repo, lib-agents
+  upgrade, incremental add, topology change, custom-role tightening).
+- **Skills updates**:
+  - `skills/cloudbuild-ops/SKILL.md` documents three-role topology,
+    custom-role pattern, builder-SA role surface, TF / admin-cloud-init
+    boundary, and the 6 lessons from #141.
+  - `skills/gcloud-ops/SKILL.md` documents `format=full` identity-token
+    pattern and cross-project IAM grant pattern.
+  - `skills/makefile-ops/SKILL.md` codifies "Makefile = operator
+    interface" as a hard rule; documents `cargo run --release`
+    default; documents distinct bin names across sibling crates.
+- **`.gitignore`** includes `.orchestration/` (heartbeat / checkpoint /
+  recovery state).
+
+### Removed
+
+- TF self-escalation chain (see BREAKING).
+- TF-driven API enablement (see BREAKING).
+- `time_sleep.wait_for_iam` (see BREAKING).
+- The pre-#141 menu wording in `commands/scaffold.md`.
+
+### Motivating downstream failures
+
+Both issues were driven by real production incidents in downstream
+projects. Cited here so future-readers can understand the design rationale:
+
+- **`kunal-labs/onchain-markets`** epic
+  [#44](https://github.com/kunal-labs/onchain-markets/issues/44),
+  PRs [#81](https://github.com/kunal-labs/onchain-markets/pull/81),
+  [#86](https://github.com/kunal-labs/onchain-markets/pull/86),
+  [#87](https://github.com/kunal-labs/onchain-markets/issues/87),
+  [#88](https://github.com/kunal-labs/onchain-markets/pull/88),
+  [#89](https://github.com/kunal-labs/onchain-markets/issues/89),
+  [#90](https://github.com/kunal-labs/onchain-markets/pull/90),
+  [#91](https://github.com/kunal-labs/onchain-markets/issues/91),
+  [#92](https://github.com/kunal-labs/onchain-markets/pull/92) —
+  origin of #141's 6 lessons. 4 restructure passes (H6 → H7 → H7.5
+  → H7.6) for what was supposed to be "deploy a Cloud Run service in
+  Tokyo." Each restructure was a fix for a real architectural bug
+  that should have been caught by the scaffold from day one.
+- **`kunal-labs/dex-arb-agent`**
+  [#136](https://github.com/kunal-labs/dex-arb-agent/issues/136) —
+  origin of #140's Tier-1 hygiene + detached-orchestration module.
+  Operator-driven `make local-cloud-deploy` died on parent-shell
+  disconnect; remote Cloud Build ran to SUCCESS but the local
+  orchestrator that was supposed to drive subsequent capture-window +
+  teardown phases was gone. Cloud Run kept burning ~43 minutes of
+  Tokyo compute past intended teardown.
+
+### Smoke testing
+
+The PR includes a dry-run smoke test (scaffold into a pilot workspace
++ `terraform fmt` + `terraform validate` + `shellcheck` + `python -m
+py_compile` + `make -n` on every `cloud-*` and `admin-*` target). The
+results are in the PR body.
+
+**What still needs human verification on real GCP before tagging this
+release:** end-to-end `make admin-cloud-init` → `make cloud-preflight`
+→ `make cloud-infra` → `make cloud-app-deploy` → curl against a live
+URL. Plus a real-GCP test of the cross-project IAM branching in
+`_grant_role` (the dry-run smoke test exercises the local-project path
+only).

--- a/commands/scaffold.md
+++ b/commands/scaffold.md
@@ -1,5 +1,5 @@
 ---
-description: Scaffold Makefile, scripts, container files, Cloud Build, and Terraform for the project
+description: Scaffold Makefile, scripts, container files, Cloud Build, Terraform, IAM, and docs for the project
 agent: devops
 ---
 
@@ -7,77 +7,159 @@ $ARGUMENTS
 
 This is a project scaffolding workflow.
 
-1. Detect the project type (Node, Go, Python, etc.).
+1. Detect the project type (Node, Go, Python, Rust, Java, generic).
 2. Ask the user what to scaffold:
    - **Local Dev** (Makefile + scripts + .gitignore)
    - **Container Dev** (Makefile + scripts + container files + .gitignore)
    - **CI/CD Only** (Cloud Build + Terraform + .gitignore)
-   - **Full CI/CD** (Makefile + scripts + container files + Cloud Build + Terraform + .gitignore)
-   - **Everything** (alias for Full CI/CD)
-   - **Full CI/CD + External HTTPS LB + DNS + Multi-Env Promotion**
-     (Full CI/CD plus Terraform `lb.tf` + `dns.tf` and scripts
-     `config.py` + `config.toml.example` + the multi-verb cloud
-     workflow `init` + `init-prod` + `infra` + `app-deploy` +
-     `app-promote` + `app-undeploy` + `clean`).
-3. If CI/CD is selected, confirm the user wants Terraform executed via Cloud
-   Build (plan on PR, apply on merge).
+   - **Full CI/CD + Three-Role Topology + LB+DNS** *(default; recommended)*
+     The complete bundle:
+     - Makefile (operator interface — every script wrapped)
+     - `scripts/common.sh` with Tier-1 hygiene (traps, stable log paths,
+       exit-code discipline) and Tier-2 detached-orchestration helpers
+       (heartbeat / checkpoint / recovery), per issue #140.
+     - `scripts/local.sh` + `scripts/container.sh` + `scripts/cloud.sh`
+       with the role-aware vocabulary: `admin-cloud-init`,
+       `admin-cloud-destroy`, `cloud-preflight`, `cloud-infra`,
+       `cloud-app-deploy`, `cloud-app-promote`, `cloud-app-undeploy`,
+       `cloud-clean`, `cloud-status`, `cloud-recover`, `cloud-help`.
+     - `scripts/config.py` resolving `env > role > defaults > error`.
+     - `config.toml.example` + `.env.example` with role-axis schema
+       (orchestration / build / runtime + per-env overrides).
+     - Container files (`cicd/Dockerfile`, `cicd/.dockerignore`).
+     - Cloud Build configs (`cicd/cloudbuild*.yaml`).
+     - Terraform (`cicd/terraform/`) — RESOURCE CONSTRUCTION ONLY.
+       NO API enable, NO project IAM self-escalation. AR repo is a
+       `data` source. Three provider aliases. Works with a builder SA
+       that holds only 6 predefined functional roles.
+     - Custom deployer-role YAML (`cicd/iam/<project>-deployer-role.yaml`).
+       37-permission curated list, bound to the agent SA with 30-day
+       expiry by `admin-cloud-init`. Per issue #141 lesson 2.
+     - Cloud-topology ADR template
+       (`docs/decisions/ADR-template-cloud-topology.md`) — copy and
+       fill in to document the project's topology choice.
+     - `AGENTS.local.md` detached-orchestration convention section.
+     - `.gitignore` (includes `.orchestration/` for heartbeat files).
+3. **Breaking change notice**: The pre-#141 menu option "Full CI/CD +
+   External HTTPS LB + DNS + Multi-Env Promotion" is GONE. Existing
+   projects scaffolded from the older bundle must re-scaffold and
+   reconcile by hand — there is no migration script. See the lib-agents
+   CHANGELOG for the full break list.
 4. Run the `scaffold` tool with the appropriate `components` parameter
    (or omit `components` for everything).
-5. Show a summary of all files created/skipped.
-6. If the user picked the LB + DNS + multi-env option, show the post-scaffold
+5. Show a summary of all files created/skipped/appended.
+6. If the user picked the Full CI/CD bundle, walk through the post-scaffold
    checklist below.
 7. Follow the standard post-work protocol.
 
-## Post-scaffold checklist (LB + DNS + multi-env)
+## When should I run `/scaffold`?
 
-When the user picked the full CI/CD with LB + DNS + multi-env option, walk
-them through:
+Five trigger scenarios:
 
-1. **Copy the example config:**
+1. **First time in a fresh repo.** Obvious, but state it: this is the
+   common case. Default to the Full CI/CD bundle unless the project is
+   strictly local-dev or container-only.
+
+2. **After upgrading `lib-agents`.** When generator templates change
+   (new fields, new files, new safety machinery), re-run `/scaffold`
+   with `force=true` to refresh the generated files. **Always back up
+   any local edits to scaffold-generated files first** (Makefile,
+   scripts/, cicd/) — `force=true` overwrites silently. Diff before
+   committing so you can re-apply your local changes on top.
+
+3. **Adding components incrementally.** Started with Local Dev, now
+   adding Container Dev or CI/CD? Use the `components` parameter to
+   target only the new bits:
+   - `components: ["container"]` — just Dockerfile + .dockerignore
+   - `components: ["cloudbuild", "terraform", "iam"]` — just CI/CD
+   - `components: ["agentslocal"]` — append detached-orchestration
+     section to `AGENTS.local.md`
+
+4. **After a topology change.** Splitting build from runtime projects,
+   or moving the agent SA to a separate orchestration project? Re-scaffold
+   `scripts/cloud.sh`, `config.toml.example`, and `cicd/terraform/`
+   (target `components: ["scripts", "terraform"]`). Hand-merge any
+   project-specific edits.
+
+5. **After custom-role tightening.** If you're trimming permissions in
+   `cicd/iam/<project>-deployer-role.yaml`, re-scaffold just the IAM
+   component (`components: ["iam"]`) to get the latest curated
+   defaults as a baseline. Diff against your tightened version.
+
+**NEVER** for files you've hand-edited without backing them up first.
+`force=false` (the default) skips collisions, but `force=true` will
+overwrite silently. If in doubt, run with `force=false` and inspect
+the SKIP list to find what would have been overwritten.
+
+## Post-scaffold checklist (Full CI/CD bundle)
+
+1. **Copy the example config files:**
    ```bash
    cp config.toml.example config.toml
+   cp .env.example .env
    ```
-   `config.toml` is gitignored — never commit it.
+   Both `config.toml` and `.env` are gitignored — never commit them.
 
-2. **Fill in the staging / Cloud Build project (`[gcp.default]`):**
-   - `project_id` — the GCP project that owns the deployer SA, the AR repo,
-     and the Terraform state bucket (this is your Cloud Build project).
-   - `[gcp.default.terraform].state_bucket` — pre-existing or to-be-created
-     GCS bucket name for Terraform state.
-   - DNS trio (only if you want the external HTTPS LB + custom domain):
-     - `dns_project_id` — GCP project hosting the Cloud DNS managed zone
-       (typically a SEPARATE project, owned by the DNS / platform team).
-     - `dns_managed_zone` — GCP RESOURCE NAME of the existing managed zone
-       (not the DNS name; e.g. `kunall-demo-altostrat-com`).
-     - `dns_record_name` — FQDN with trailing dot, e.g. `app.example.com.`.
-   - `domain` — same FQDN without the trailing dot, e.g. `app.example.com`.
+2. **Fill in `config.toml`:**
+   - At minimum, set `[gcp.defaults].project` to your GCP project ID.
+     This is the 90% case — all three roles (orchestration, build,
+     runtime) collapse to one project. Fine for personal/hobby use.
+   - Set `[gcp.build].state_bucket` to a TF state bucket name (will be
+     created by `make admin-cloud-init` if it doesn't exist).
+   - For a split topology (e.g. production runtime in a separate
+     project), uncomment and fill `[gcp.production.runtime].project`.
+   - For LB+DNS, fill in `[gcp.runtime].domain` + the DNS trio
+     (`dns_project_id`, `dns_managed_zone`, `dns_record_name`).
 
-3. **Fill in `[gcp.production].project_id`** with a SEPARATE GCP project ID
-   (a different project from staging/CB). Optionally override `domain` and
-   the DNS trio for the prod-specific record.
+3. **Optionally fill `.env`** with sensitive overrides (project IDs you
+   don't want in committed `config.toml`, API keys, per-operator
+   agent SA name).
 
-4. **Run the two-environment workflow:**
+4. **Document the topology decision.** Copy
+   `docs/decisions/ADR-template-cloud-topology.md` to
+   `docs/decisions/ADR-XXX-cloud-topology.md` (next ADR number),
+   fill in the chosen topology + rationale, and commit it. Future
+   you will thank present you.
+
+5. **Run the lifecycle:**
    ```bash
-   # Bootstrap staging / Cloud Build project (TF state bucket, deployer SA,
-   # bootstrap IAM, optional cross-project DNS grant). Run as the staging
-   # project owner.
-   make cloud-init
+   # Verify the resolved three-role topology before doing anything.
+   make cloud-help
 
-   # One-time prod bootstrap: grants projectIamAdmin on the prod project
-   # to the staging-resident deployer SA, so Terraform can self-escalate
-   # on subsequent cloud-infra runs. Run as the PROD project owner.
-   ENVIRONMENT=production make cloud-init-prod
+   # Owner-tier 8-step bootstrap (run as Owner once per project).
+   # Cross-project-aware: each grant branches on local-vs-cross-project.
+   # Stepwise + checkpointed: re-run resumes; ORCH_FORCE_RESTART=1
+   # invalidates the checkpoint and restarts from step 1.
+   make admin-cloud-init
 
-   # Provision prod infrastructure (Cloud Run, AR, IAM, optional LB+DNS).
-   ENVIRONMENT=production make cloud-infra
+   # Read-only audit. Per-role-aware messaging so multi-project
+   # topology debugs cleanly.
+   make cloud-preflight
 
-   # Deploy the app to staging (build + push + Cloud Run update).
+   # Provision runtime infrastructure (Cloud Run, runtime SA, LB/DNS).
+   # TF apply runs via Cloud Build using the builder SA.
+   make cloud-infra
+
+   # Build container image + swap Cloud Run revision (current ENVIRONMENT).
    make cloud-app-deploy
 
-   # Promote a specific staging image to production with a semver tag.
-   # IMAGE = full URI of the staging image you want to promote (use the
-   #         :sha-<short_sha> tag printed by cloud-app-deploy).
-   ENVIRONMENT=production VERSION=v1.0.0 \\
-     IMAGE=us-central1-docker.pkg.dev/<cb-project>/<service>/<service>:sha-abc123f \\
+   # Check status of long-running operations (heartbeat-aware).
+   make cloud-status
+
+   # If something went wrong during a detached run, read the recovery
+   # hints written by the EXIT/HUP trap handler.
+   make cloud-recover
+
+   # Promote a specific image to a non-staging runtime with a semver tag.
+   # IMAGE = full URI of the staging image (use the :sha-<sha> tag
+   #         printed by cloud-app-deploy).
+   ENVIRONMENT=production VERSION=v1.0.0 \
+     IMAGE=us-central1-docker.pkg.dev/<build-project>/<repo>/<svc>:sha-abc123f \
      make cloud-app-promote
    ```
+
+6. **Operator escape hatch:** `ORCH_FORCE_RESTART=1` on any
+   `admin-cloud-*` or `cloud-*` target invalidates the stepwise
+   checkpoint and restarts from step 1. Always safe (step idempotency
+   is a contract). Use when the step list has changed since your last
+   partial run, or when the checkpoint state is suspect.

--- a/skills/cloudbuild-ops/SKILL.md
+++ b/skills/cloudbuild-ops/SKILL.md
@@ -127,24 +127,81 @@ terraform {
 The bucket name is passed as a substitution: `_TF_STATE_BUCKET`.
 Convention: `${PROJECT_ID}-tfstate` with prefix matching the service name.
 
-### Service Account Permissions
+### Three-role topology + two-SA model (issue #141)
 
-The Cloud Build service account (`<project-number>@cloudbuild.gserviceaccount.com`)
-needs these roles:
+The scaffolded projects use a **three-role topology** (orchestration / build /
+runtime) and a **two-SA model** with explicit predefined roles. Replaces the
+old "two-phase IAM with TF self-escalation" framing from #116.
 
-| Role | Purpose |
-|------|---------|
-| `roles/artifactregistry.admin` | Push images to Artifact Registry |
-| `roles/run.admin` | Deploy Cloud Run services |
-| `roles/iam.serviceAccountUser` | Act as the service account |
-| `roles/storage.admin` | Read/write Terraform state in GCS |
+**Roles:**
 
-Grant via:
-```bash
-gcloud projects add-iam-policy-binding PROJECT_ID \
-  --member="serviceAccount:<number>@cloudbuild.gserviceaccount.com" \
-  --role="roles/run.admin"
-```
+| Role            | What it owns                                          |
+|-----------------|-------------------------------------------------------|
+| orchestration   | Agent SA (operator identity), custom IAM role, daily-deploy entry point |
+| build           | Builder SA, Cloud Build, Artifact Registry, TF state |
+| runtime         | Runtime SA, Cloud Run service, service-managed resources |
+
+The 90% case: all three roles collapse to one project. Splitting later is
+a config edit, not a refactor — bootstrap script + TF + operator commands
+all work identically; only IAM grants branch local-vs-cross-project.
+
+**Two service accounts** (NOT the default Cloud Build SA, NOT the default
+Compute Engine SA):
+
+| SA          | Lives in    | Permissions                                | Used by                                |
+|-------------|-------------|--------------------------------------------|----------------------------------------|
+| **agent**   | orch project| Custom role (curated YAML, 30-day expiry)  | Human/CI operator running daily deploys|
+| **builder** | build project| 6 predefined functional roles + storage.admin| Cloud Build via `--service-account=...`|
+
+**Custom role for the agent SA** (NOT predefined). Lives in
+`cicd/iam/<project>-deployer-role.yaml`, diff-reviewable in git. The
+30-day expiry condition on the agent → custom-role binding forces
+graceful credential rotation; re-run `make admin-cloud-init` to refresh.
+
+**Builder SA's 6 predefined roles** (scoped to what TF actually needs to
+construct resources):
+
+| Role                              | On project | Why                              |
+|-----------------------------------|------------|----------------------------------|
+| `roles/run.admin`                 | runtime    | Deploy Cloud Run services        |
+| `roles/artifactregistry.admin`    | runtime    | Manage AR repo (existence checks)|
+| `roles/iam.serviceAccountUser`    | runtime    | actAs runtime SA                 |
+| `roles/iam.serviceAccountAdmin`   | runtime    | Create + manage runtime SA       |
+| `roles/logging.logWriter`         | runtime    | Cloud Build log emission         |
+| `roles/storage.admin`             | build      | TF state bucket + CB staging     |
+
+**NOT granted to the builder SA** (these would defeat the agent's
+least-privilege model — agent can impersonate builder via Cloud Build,
+so anything granted to builder becomes part of agent's effective authority):
+
+- `roles/resourcemanager.projectIamAdmin`
+- `roles/serviceusage.serviceUsageAdmin`
+- `roles/iam.serviceAccountCreator`
+- `roles/compute.networkAdmin`
+- `roles/compute.loadBalancerAdmin`
+
+### TF / admin-cloud-init boundary (non-negotiable)
+
+Per issue #141 lesson 1, **Terraform does NOT mutate project scope**.
+The boundary is:
+
+| Layer                  | Owns                                                          |
+|------------------------|---------------------------------------------------------------|
+| `admin-cloud-init`     | API enablement; AR repo creation; TF state bucket creation; project-wide IAM of other principals (agent SA → custom role; builder SA → predefined functional roles; agent SA → actAs on builder SA) |
+| Terraform (`main.tf`)  | Resource construction: runtime SA, Cloud Run service, IAM bindings on Terraform's own resources (run.invoker, cross-project AR reader, LB/DNS) |
+
+The pre-#141 scaffold had Terraform doing a two-phase API enable
+(`bootstrap_apis` + `apis`) and self-grant chains
+(`google_project_iam_member.deployer_*`). That worked but required
+granting the builder SA `projectIamAdmin` + `serviceUsageAdmin`, which
+defeats the agent's curated-role design. **Removed entirely in #141.**
+
+**Pre-existing build-project resources are read via `data` sources.**
+The AR repo is read into `main.tf` via
+`data "google_artifact_registry_repository" "app"`. This makes the
+dependency on the bootstrap step explicit at *plan* time: a missing
+repo fails with a clear "data source not found" error instead of a
+confusing IAM-binding error at apply time.
 
 ## Trigger Types
 
@@ -209,13 +266,38 @@ gcloud builds triggers run TRIGGER_ID --branch=main
 | Substitution not resolved | Ensure variable starts with `_` and is declared in `substitutions` |
 | Build timeout | Increase `timeout` in `options` (default: 10 minutes) |
 
+## Reference: lessons baked in (issue #141)
+
+Six concrete bug-class lessons from the `kunal-labs/onchain-markets` cloud
+workstream (epic #44, 4 restructure passes for "deploy a Cloud Run service
+in Tokyo"). All preventable from the scaffold; all now baked in:
+
+1. **TF does not self-escalate IAM.** Project-scope concerns live in
+   `admin-cloud-init`. Builder SA holds only 6 predefined functional roles.
+2. **Custom YAML role + 30-day expiry for the agent SA.** Diff-reviewable;
+   forces graceful credential rotation.
+3. **Stepwise checkpoint invalidates on step-list-hash mismatch.** A change
+   to the step list silently invalidates stale checkpoints — restart from
+   step 1. Step idempotency is a contract; restart is always safe.
+4. **`format=full` on identity-token metadata fetch.** See `skills/gcloud-ops`.
+5. **Operator CLI conventions baked in.** Default `cargo run --release`;
+   distinct bin names across sibling crates; Makefile is the operator
+   interface — never invoke scripts directly.
+6. **Role-aware CLI vocabulary.** `admin-cloud-init` / `cloud-preflight` /
+   `cloud-infra` / `cloud-app-deploy` etc., not `init` / `cloud-init` /
+   `init-prod` (which described the operation, not the role).
+
 ## Agent Integration
 
 - Terraform runs via Cloud Build, not locally. Cloud Build is the execution
   environment for all infrastructure changes.
 - Cloud Build configs and Terraform modules live in `cicd/`.
+- The custom deployer role YAML lives in `cicd/iam/`.
 - NEVER run `terraform apply` or `terraform destroy` without first showing
   the plan output and getting user confirmation.
 - NEVER submit Cloud Build jobs that run `terraform apply` without user
   confirmation.
 - ALWAYS show plan output before any apply operation.
+- ALWAYS use `make <target>` instead of `bash scripts/cloud.sh ...` —
+  the wrappers engage trap handlers + heartbeat/checkpoint machinery
+  that catches operator shell disconnects (per issue #140).

--- a/skills/gcloud-ops/SKILL.md
+++ b/skills/gcloud-ops/SKILL.md
@@ -194,8 +194,72 @@ provider "google" {
 - Store state in a GCS backend: `terraform { backend "gcs" { bucket = "..." } }`
 - Use workspaces for environment separation (dev/staging/prod)
 
+## Identity Tokens from the Metadata Server: ALWAYS `format=full`
+
+When a GCP workload (Cloud Run service, GKE pod, GCE VM, Cloud Workstation)
+fetches an identity token to call an IAM-gated Cloud Run service, it goes
+through the local metadata server:
+
+```bash
+curl -H "Metadata-Flavor: Google" \
+  "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/identity?audience=https://my-svc-...run.app&format=full"
+```
+
+**The `format=full` query param is mandatory.** Without it, the returned
+token has only the `sub` claim. For "normal" service accounts that's
+enough — but for Cloud Workstations runtime SAs and a handful of other
+edge cases, the token comes back without the `email` claim, and the
+receiver's Cloud Run service rejects with **403** at the platform-IAM
+layer (before any code in the receiver runs).
+
+This bit `mkt-desk` hard in `kunal-labs/onchain-markets#91`. The fix is
+defensive and has no downside — `format=full` always returns a richer
+token; no payload-size or latency cost worth worrying about.
+
+**Bake it in.** Any client code (Rust, Go, Python) that fetches identity
+tokens from the metadata server should default to `format=full`. The
+scaffold doesn't generate identity-token client code today, but if/when
+it does, this is the default.
+
+## Cross-project IAM Grants
+
+When the three-role topology (per `cloudbuild-ops` skill) splits roles
+across projects, IAM grants become cross-project. The pattern:
+
+```bash
+# Local grant (member's project == target project): no --billing-project
+gcloud projects add-iam-policy-binding "${BUILD_PROJECT}" \
+  --member="serviceAccount:${BUILDER_SA_EMAIL}" \
+  --role="roles/storage.admin" \
+  --condition=None --quiet
+
+# Cross-project grant: add --billing-project=<target> so the API call
+# is billed to the target project (otherwise an org policy can reject
+# the call as "no billing project").
+gcloud projects add-iam-policy-binding "${RUNTIME_PROJECT}" \
+  --billing-project="${RUNTIME_PROJECT}" \
+  --member="serviceAccount:${BUILDER_SA_EMAIL}" \
+  --role="roles/run.admin" \
+  --condition=None --quiet
+```
+
+The scaffolded `scripts/cloud.sh` has a `_grant_role` helper that
+branches automatically on local-vs-cross — emits an operator log line
+when the grant is cross-project so the operator can spot mis-topology
+at a glance.
+
+**Required operator authority for cross-project grants.** The operator
+running `make admin-cloud-init` needs `setIamPolicy` on every project in
+the topology that receives an IAM grant. In a fully-split topology,
+that's three or four projects — usually requires coordination across
+the orgs that own each project.
+
 ## Agent Integration
 
 - NEVER modify IAM policies without showing the diff and getting user
   confirmation.
 - ALWAYS show what will change before executing destructive GCP operations.
+- ALWAYS default to `format=full` on metadata-server identity-token fetches
+  in any generated client code.
+- When the topology is split, ALWAYS surface the cross-project grants in
+  the operator log — silent cross-project grants are a debug nightmare.

--- a/skills/makefile-ops/SKILL.md
+++ b/skills/makefile-ops/SKILL.md
@@ -42,6 +42,35 @@ local-build: ## Build the project locally
 - Add `## description` comments for `make help` support
 - All `.PHONY` targets declared at the top
 
+### Hard rule: Makefile = operator interface, scripts = implementation
+
+This is the convention, not a suggestion (#141 lesson 5 + #140):
+
+**`make <target>` is the operator interface. Bash scripts under
+`scripts/` are the implementation.** Never document `bash scripts/foo.sh
+...` directly in READMEs, runbooks, or onboarding docs. Always wrap in
+`make foo` and document the Make target.
+
+Why:
+
+- The Make target engages logging (`start_log`), trap handlers, and
+  the heartbeat / checkpoint / recovery machinery in `scripts/common.sh`.
+  Direct `bash` invocation bypasses those — orphaned cloud resources
+  on shell disconnect (the failure shape that motivated #140).
+- The Make target is what `make help` discovers. Adding an operator-
+  facing target that's invokable only via raw `bash` makes it
+  invisible to discovery.
+- The Make target is the diff-reviewable surface. Bash script flag
+  changes hide; Make target renames don't.
+- Future-you and any subagent re-reading the project six months later
+  knows where to look: `make help` first, scripts/ only when
+  debugging.
+
+The scaffold bakes this in: every script gets a Makefile wrapper, and
+the generated `scripts/cloud.sh` includes a header comment telling
+operators "never invoke this script directly — go through `make
+<target>`."
+
 ### Help Target
 
 Include a `help` target that extracts descriptions from `##` comments:
@@ -177,10 +206,32 @@ making it easy to review past runs and diagnose failures.
 ### Rust
 - **init**: `cargo fetch`
 - **build**: `cargo build --release`
-- **run**: `cargo run`
+- **run**: `cargo run --release` *(operator-facing run is release by
+  default; #141 lesson 5. Dev profile is fine for `cargo test`, wrong
+  for "operator-facing run this against prod." Add a `local-run-dev`
+  target with bare `cargo run` if you need the dev profile.)*
 - **test**: `cargo test`
 - **lint**: `cargo clippy -- -D warnings`
 - **Dockerfile**: Multi-stage with `rust:1.77-alpine`, `distroless` runtime
+
+#### Sibling crates: distinct bin names
+
+In a Cargo workspace with multiple crates each shipping `src/bin/<name>.rs`,
+Cargo warns about colliding output filenames (e.g., both crates produce a
+`target/debug/server` binary). This will become a hard error in a future
+Cargo release.
+
+The fix: set distinct bin names per crate in each `Cargo.toml`:
+
+```toml
+[[bin]]
+name = "agent-mkt-historical"
+path = "src/bin/server.rs"
+```
+
+The scaffold's Rust workspace template enforces this. When adding a new
+sibling crate, pick a unique bin name (prefix with the crate's short
+name is the convention).
 
 ### Java
 - **init**: `mvn dependency:resolve` or `gradle dependencies`
@@ -206,7 +257,14 @@ making it easy to review past runs and diagnose failures.
 
 - All operational tasks go through `make` targets. If a project has no
   Makefile, offer to scaffold one first using the `scaffold` tool.
+- NEVER document or invoke `bash scripts/foo.sh ...` directly — always
+  go through `make foo`. The wrappers engage trap handlers + heartbeat
+  / checkpoint machinery (see `scripts/common.sh`); direct invocation
+  bypasses them.
 - Detect the project type automatically and tailor all generated files.
 - Scaffolding generates Makefile, modular scripts in `scripts/`, container
-  files, Cloud Build configs, and Terraform modules -- all in `cicd/`.
+  files, Cloud Build configs, Terraform modules, the custom deployer-role
+  YAML in `cicd/iam/`, the cloud-topology ADR template in
+  `docs/decisions/`, the detached-orchestration section in
+  `AGENTS.local.md`, and `.gitignore` (including `.orchestration/`).
 - Use the `scaffold` tool directly. Do not delegate scaffolding to other agents.

--- a/tools/scaffold.ts
+++ b/tools/scaffold.ts
@@ -60,8 +60,10 @@ function generateMakefile(_pt: ProjectType): string {
   return `.PHONY: help \\
   local-init local-clean local-build local-run local-test local-lint \\
   container-init container-clean container-build container-run \\
-  cloud-init cloud-init-prod cloud-infra cloud-app-deploy \\
+  cloud-help admin-cloud-init admin-cloud-destroy \\
+  cloud-preflight cloud-infra cloud-app-deploy \\
   cloud-app-promote cloud-app-undeploy cloud-clean \\
+  cloud-status cloud-recover \\
   logs-list logs-last logs-clean
 
 help: ## Show this help
@@ -102,28 +104,44 @@ container-build: ## Build container image
 container-run: ## Run container locally
 \t@bash scripts/container.sh run
 
-# ─── Cloud Runtime ───────────────────────────────────────────────────
+# ─── Cloud Runtime (three-role topology: orchestration / build / runtime) ──
 
-cloud-init: ## Bootstrap primary env (TF state, deployer SA, IAM, optional DNS grant)
-\t@bash scripts/cloud.sh init
+cloud-help: ## Print the resolved three-role topology (orchestration/build/runtime)
+\t@bash scripts/cloud.sh help
 
-cloud-init-prod: ## One-time prod bootstrap (run as prod project owner; grants projectIamAdmin to deployer SA)
-\t@bash scripts/cloud.sh init-prod
+admin-cloud-init: ## Owner-tier bootstrap: APIs, AR, TF state, builder SA, custom role, agent SA grants. Run as Owner.
+\t@bash scripts/cloud.sh admin-cloud-init
 
-cloud-infra: ## Provision/update infrastructure via Terraform (Cloud Build)
-\t@bash scripts/cloud.sh infra
+admin-cloud-destroy: ## Owner-tier teardown of bootstrap (preserves TF state bucket + AR repo by default)
+\t@bash scripts/cloud.sh admin-cloud-destroy
 
-cloud-app-deploy: ## Build image and deploy to current ENVIRONMENT (default: staging)
-\t@bash scripts/cloud.sh app-deploy
+cloud-preflight: ## Read-only audit: APIs ✓, AR ✓, builder SA roles ✓ (per-role-aware messaging)
+\t@bash scripts/cloud.sh cloud-preflight
 
-cloud-app-promote: ## Promote a staging image to a non-staging env. Requires VERSION=vX.Y.Z and IMAGE=<full-uri>
-\t@bash scripts/cloud.sh app-promote
+cloud-infra: ## TF apply via Cloud Build (builder SA in build project, provisions runtime-project resources)
+\t@bash scripts/cloud.sh cloud-infra
+
+cloud-app-deploy: ## Image build + Cloud Run revision swap (current ENVIRONMENT)
+\t@bash scripts/cloud.sh cloud-app-deploy
+
+cloud-app-promote: ## Tag + deploy to non-staging runtime. Requires VERSION=vX.Y.Z and IMAGE=<full-uri>
+\t@bash scripts/cloud.sh cloud-app-promote
 
 cloud-app-undeploy: ## Revert Cloud Run to placeholder image (keeps infra)
-\t@bash scripts/cloud.sh app-undeploy
+\t@bash scripts/cloud.sh cloud-app-undeploy
 
-cloud-clean: ## Tear down cloud infrastructure (terraform destroy)
-\t@bash scripts/cloud.sh clean
+cloud-clean: ## Tear down runtime infrastructure (terraform destroy via Cloud Build)
+\t@bash scripts/cloud.sh cloud-clean
+
+# ─── Detached Orchestration (cloud-status / cloud-recover) ──
+# These targets read state written by run_detached_with_heartbeat in
+# scripts/common.sh. See AGENTS.local.md for the convention.
+
+cloud-status: ## Show detached-orchestration status: RUNNING | STALLED | COMPLETE | NEVER_STARTED
+\t@bash scripts/cloud.sh cloud-status
+
+cloud-recover: ## Read EXIT/HUP trap recovery file and complete teardown
+\t@bash scripts/cloud.sh cloud-recover
 
 # ─── Logs ─────────────────────────────────────────────────────────────
 
@@ -135,6 +153,14 @@ logs-last: ## Show the most recent log file
 
 logs-clean: ## Remove all log files
 \t@rm -rf logs/*.log && echo "Cleaned log files" || true
+
+# ─── Operator notes ──────────────────────────────────────────────────
+# - ORCH_FORCE_RESTART=1 on any admin-cloud-* / cloud-* target invalidates
+#   the stepwise checkpoint and restarts the run from step 1. Step
+#   idempotency is a contract; restart is always safe.
+# - Every Make target is a thin wrapper around scripts/. Never invoke
+#   the scripts directly — go through \`make <target>\` so logging, trap
+#   handlers, and the heartbeat/checkpoint machinery engage.
 `
 }
 
@@ -143,6 +169,8 @@ logs-clean: ## Remove all log files
 function generateCommonSh(): string {
   return `#!/usr/bin/env bash
 # Common functions sourced by all scripts
+# Tier-1 hygiene (issue #140): set -euo pipefail, traps, stable log paths,
+# exit-code discipline. Tier-2 detached-orchestration helpers are below.
 set -euo pipefail
 
 # ─── Logging ──────────────────────────────────────────────────────────
@@ -160,28 +188,31 @@ log_error() { echo -e "\${RED}[ERROR]\${NC} $*" >&2; }
 
 die() { log_error "$@"; exit 1; }
 
-# ─── Environment ─────────────────────────────────────────────────────
+# ─── Paths ───────────────────────────────────────────────────────────
 
 SCRIPT_DIR="$(cd "$(dirname "\${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "\${SCRIPT_DIR}/.." && pwd)"
 
-# Load .env if it exists (do NOT commit .env files)
+# Load .env if it exists. .env is the override layer for sensitive values
+# (project IDs, billing accounts, emails, API keys). Never committed.
 if [[ -f "\${PROJECT_ROOT}/.env" ]]; then
+  set -a
   # shellcheck disable=SC1091
   source "\${PROJECT_ROOT}/.env"
+  set +a
 fi
 
 # ─── Environment Selection ───────────────────────────────────────────
-# Priority: CLI env var > .env file > default (staging)
+# Priority: CLI env var > .env file > default (staging).
+# Environment-axis layering (per #115) is independent of the role axis
+# (per #141). A single environment slices through all three roles.
 export ENVIRONMENT="\${ENVIRONMENT:-staging}"
 
-if [[ "\${ENVIRONMENT}" != "staging" && "\${ENVIRONMENT}" != "production" ]]; then
-  die "Invalid ENVIRONMENT '\${ENVIRONMENT}'. Must be 'staging' or 'production'."
-fi
-
 # ─── Config.toml Parsing (via Python) ────────────────────────────────
-# Uses scripts/config.py to parse config.toml and emit shell variables.
-# Python handles the [gcp.default] → [gcp.<env>] merge correctly.
+# scripts/config.py parses config.toml with role-axis (defaults +
+# orchestration + build + runtime) and environment-axis layering, then
+# emits shell exports. Same parser is the source of truth for Terraform
+# (via Cloud Build TF_VAR_* substitutions).
 
 if [[ -f "\${PROJECT_ROOT}/config.toml" ]]; then
   log_info "Loading config from config.toml (environment: \${ENVIRONMENT})"
@@ -193,8 +224,24 @@ fi
 export PROJECT_NAME="\${PROJECT_NAME:-$(basename "\${PROJECT_ROOT}")}"
 export IMAGE_NAME="\${IMAGE_NAME:-\${PROJECT_NAME}}"
 export IMAGE_TAG="\${IMAGE_TAG:-latest}"
-export GCP_PROJECT="\${GCP_PROJECT:-}"
-export GCP_REGION="\${GCP_REGION:-us-central1}"
+
+# Three-role topology resolved values.
+# Each role can collapse to the same project (90% case) or split.
+# config.py resolves env > role > defaults > error.
+export ORCH_PROJECT="\${ORCH_PROJECT:-}"
+export ORCH_REGION="\${ORCH_REGION:-}"
+export BUILD_PROJECT="\${BUILD_PROJECT:-}"
+export BUILD_REGION="\${BUILD_REGION:-}"
+export RUNTIME_PROJECT="\${RUNTIME_PROJECT:-}"
+export RUNTIME_REGION="\${RUNTIME_REGION:-}"
+
+# Legacy aliases for back-compat with downstream snippets that still use
+# the pre-role-topology names. Resolve to the matching role.
+export GCP_PROJECT="\${GCP_PROJECT:-\${RUNTIME_PROJECT}}"
+export GCP_REGION="\${GCP_REGION:-\${RUNTIME_REGION:-us-central1}}"
+export CB_PROJECT="\${CB_PROJECT:-\${BUILD_PROJECT}}"
+
+# Resource defaults
 export AR_REPO="\${AR_REPO:-\${PROJECT_NAME}}"
 export TF_STATE_BUCKET="\${TF_STATE_BUCKET:-}"
 export TF_STATE_PREFIX="\${TF_STATE_PREFIX:-\${PROJECT_NAME}/\${ENVIRONMENT}}"
@@ -206,12 +253,34 @@ export MIN_INSTANCES="\${MIN_INSTANCES:-0}"
 export MAX_INSTANCES="\${MAX_INSTANCES:-3}"
 export INGRESS="\${INGRESS:-all}"
 
-# Service account defaults
-export DEPLOYER_SA_NAME="\${DEPLOYER_SA_NAME:-\${PROJECT_NAME}-deployer}"
+# Service account defaults — agent runs in orchestration project (operator
+# CLI identity), builder runs in build project (Cloud Build identity),
+# runtime runs in runtime project (Cloud Run app identity).
+export AGENT_SA_NAME="\${AGENT_SA_NAME:-\${PROJECT_NAME}-agent}"
+export BUILDER_SA_NAME="\${BUILDER_SA_NAME:-\${PROJECT_NAME}-builder}"
 export RUNTIME_SA_NAME="\${RUNTIME_SA_NAME:-\${PROJECT_NAME}-runtime}"
-export CB_PROJECT="\${CB_PROJECT:-\${GCP_PROJECT}}"
-export CB_SERVICE_ACCOUNT="\${CB_SERVICE_ACCOUNT:-\${DEPLOYER_SA_NAME}@\${CB_PROJECT}.iam.gserviceaccount.com}"
-export RUNTIME_SA_EMAIL="\${RUNTIME_SA_EMAIL:-\${RUNTIME_SA_NAME}@\${GCP_PROJECT}.iam.gserviceaccount.com}"
+
+# Custom role for the agent SA (curated YAML in cicd/iam/).
+# The custom role ID GCP wants is camelCase (no dashes / slashes).
+_to_camel() {
+  echo "$1" | awk -F'[-_]' '{out=$1; for(i=2;i<=NF;i++) out=out toupper(substr($i,1,1)) substr($i,2); print out}'
+}
+export DEPLOYER_ROLE_ID="\${DEPLOYER_ROLE_ID:-$(_to_camel "\${PROJECT_NAME}")Deployer}"
+export DEPLOYER_ROLE_YAML="\${DEPLOYER_ROLE_YAML:-\${PROJECT_ROOT}/cicd/iam/\${PROJECT_NAME}-deployer-role.yaml}"
+
+# 30-day expiry for the agent → custom-role binding (#141 lesson 2).
+# Operator re-runs admin-cloud-init to refresh.
+export AGENT_ROLE_EXPIRY_DAYS="\${AGENT_ROLE_EXPIRY_DAYS:-30}"
+
+# Derived SA emails. When all three role projects collapse to one, these
+# all live in the same project but have distinct local-parts.
+export AGENT_SA_EMAIL="\${AGENT_SA_EMAIL:-\${AGENT_SA_NAME}@\${ORCH_PROJECT:-\${BUILD_PROJECT}}.iam.gserviceaccount.com}"
+export BUILDER_SA_EMAIL="\${BUILDER_SA_EMAIL:-\${BUILDER_SA_NAME}@\${BUILD_PROJECT}.iam.gserviceaccount.com}"
+export RUNTIME_SA_EMAIL="\${RUNTIME_SA_EMAIL:-\${RUNTIME_SA_NAME}@\${RUNTIME_PROJECT}.iam.gserviceaccount.com}"
+
+# Legacy alias: some downstream snippets still reference CB_SERVICE_ACCOUNT.
+# Map it to the builder SA (which is what Cloud Build submits as).
+export CB_SERVICE_ACCOUNT="\${CB_SERVICE_ACCOUNT:-\${BUILDER_SA_EMAIL}}"
 
 # ─── Helpers ──────────────────────────────────────────────────────────
 
@@ -225,18 +294,266 @@ confirm() {
   [[ "\${response}" =~ ^[Yy]$ ]]
 }
 
+# Print the resolved three-role topology. Used by \`make cloud-help\` and
+# preflight. When all three projects collapse to one, the operator sees
+# an explicit "collapsed to one project" note so the choice is obvious.
+print_topology() {
+  local op="\${ORCH_PROJECT:-<unset>}"
+  local bp="\${BUILD_PROJECT:-<unset>}"
+  local rp="\${RUNTIME_PROJECT:-<unset>}"
+  echo "Cloud topology: orchestration=\${op}, build=\${bp}, runtime=\${rp}"
+  if [[ "\${op}" == "\${bp}" && "\${bp}" == "\${rp}" && "\${op}" != "<unset>" ]]; then
+    echo "               (all three collapsed to one project — fine for personal/hobby use)"
+  elif [[ "\${bp}" == "\${rp}" ]]; then
+    echo "               (build + runtime collapsed; orchestration split — useful when agent identity lives outside build/runtime)"
+  elif [[ "\${op}" == "\${bp}" ]]; then
+    echo "               (orchestration + build collapsed; runtime split — production tenancy pattern)"
+  else
+    echo "               (fully split — production multi-project tenancy)"
+  fi
+}
+
+# Returns 0 (true) when role_a project equals role_b project.
+# Usage: same_project ORCH_PROJECT BUILD_PROJECT && echo collapsed
+same_project() {
+  local a_val b_val
+  a_val="$(eval "echo \\\${$1:-}")"
+  b_val="$(eval "echo \\\${$2:-}")"
+  [[ -n "\${a_val}" && "\${a_val}" == "\${b_val}" ]]
+}
+
 # ─── Log Capture ─────────────────────────────────────────────────────
 
 LOG_DIR="\${PROJECT_ROOT}/logs"
 mkdir -p "\${LOG_DIR}"
 
 # Start capturing all stdout/stderr to a per-run log file.
+# Stable path convention (#140 Tier-1): logs/<timestamp>-<action>.log.
+# Operators and agents always know where to look after the fact.
 # Usage: start_log <action-name>
 start_log() {
   local action="\${1:-unknown}"
   LOG_FILE="\${LOG_DIR}/$(date +%Y%m%d-%H%M%S)-\${action}.log"
   exec > >(tee -a "\${LOG_FILE}") 2>&1
   log_info "Logging to \${LOG_FILE}"
+}
+
+# ─── Tier-1 hygiene: trap on EXIT/INT/TERM/HUP ────────────────────────
+# The real universal lesson from kunal-labs/dex-arb-agent#136 is that
+# any script mutating external state must leave a forensic breadcrumb
+# when interrupted. Even a stub handler that logs "interrupted at line N"
+# is a huge win when the parent shell disconnects mid-deploy.
+#
+# Scripts that want richer behavior (recovery file, heartbeat cleanup)
+# should override _trap_handler after sourcing common.sh.
+
+_trap_handler() {
+  local exit_code="\$1"
+  local line_no="\${2:-?}"
+  if (( exit_code != 0 )); then
+    log_error "Script interrupted (exit=\${exit_code}, line=\${line_no})."
+    log_error "Action: \${SCRIPT_ACTION:-unknown}"
+    log_error "Log file: \${LOG_FILE:-(none — start_log not called)}"
+    # If a heartbeat / checkpoint is active, surface it so the operator
+    # knows recovery state may exist.
+    if [[ -n "\${HEARTBEAT_FILE:-}" && -f "\${HEARTBEAT_FILE}" ]]; then
+      log_error "Heartbeat file: \${HEARTBEAT_FILE} (run 'make cloud-status' for state)"
+    fi
+    if [[ -n "\${RECOVERY_FILE:-}" ]]; then
+      echo "interrupted exit=\${exit_code} line=\${line_no} time=$(date +%s) action=\${SCRIPT_ACTION:-unknown}" \\
+        >> "\${RECOVERY_FILE}"
+      log_error "Recovery hint written to \${RECOVERY_FILE} (run 'make cloud-recover')"
+    fi
+  fi
+}
+
+trap '_trap_handler $? \${LINENO}' EXIT
+trap '_trap_handler 130 \${LINENO}; exit 130' INT
+trap '_trap_handler 143 \${LINENO}; exit 143' TERM
+trap '_trap_handler 129 \${LINENO}; exit 129' HUP
+
+# ─── Tier-2 detached orchestration helpers (#140 + #141 lesson 3) ─────
+#
+# Two flavors:
+#
+#   1. run_detached_cloudbuild  — single atomic remote job.
+#      Heartbeat fields: build_id, started_at, last_seen_at, status.
+#      tfstate-lock-aware recovery: if the parent dies but the build
+#      runs to SUCCESS, the next 'make cloud-status' / 'cloud-recover'
+#      can break a stuck tfstate lock and reconcile.
+#
+#   2. run_detached_stepwise    — N sequential local steps + checkpoint.
+#      Checkpoint embeds sha256 of the step list (#141 lesson 3): on
+#      resume, mismatch = treat checkpoint as stale and restart from
+#      step 1. Step idempotency is a contract; restart-from-1 is safe.
+#
+# Operator escape hatch: ORCH_FORCE_RESTART=1 invalidates the checkpoint
+# unconditionally and starts fresh. Document prominently in cloud.sh
+# help text + Makefile.
+
+ORCH_STATE_DIR="\${PROJECT_ROOT}/.orchestration"
+mkdir -p "\${ORCH_STATE_DIR}"
+
+# Heartbeat / checkpoint / recovery file paths are per-action.
+_orch_paths() {
+  local action="\$1"
+  HEARTBEAT_FILE="\${ORCH_STATE_DIR}/\${action}.heartbeat"
+  CHECKPOINT_FILE="\${ORCH_STATE_DIR}/\${action}.checkpoint"
+  RECOVERY_FILE="\${ORCH_STATE_DIR}/\${action}.recovery"
+}
+
+# Write a JSON-ish heartbeat line. Append-only; cloud-status reads tail.
+_heartbeat_write() {
+  local action="\$1" phase="\$2" extra="\${3:-}"
+  local now
+  now="$(date +%s)"
+  printf '{"action":"%s","phase":"%s","ts":%s%s}\\n' \\
+    "\${action}" "\${phase}" "\${now}" "\${extra:+,\${extra}}" \\
+    >> "\${HEARTBEAT_FILE}"
+}
+
+# Compute checkpoint key = sha256 of the step list string. When the step
+# list changes between runs, the key changes; a stale checkpoint is
+# silently invalidated. Prevents the dex-arb-agent #87 / onchain-markets
+# #89 class of bug ("we added two new steps but the checkpoint=6 skipped
+# them silently").
+_step_list_hash() {
+  printf '%s\\n' "$@" | sha256sum | awk '{print $1}'
+}
+
+_checkpoint_read() {
+  [[ -f "\${CHECKPOINT_FILE}" ]] || { echo ""; return 0; }
+  cat "\${CHECKPOINT_FILE}"
+}
+
+_checkpoint_write() {
+  local hash="\$1" step_idx="\$2"
+  printf 'hash=%s\\nstep=%s\\nupdated_at=%s\\n' "\${hash}" "\${step_idx}" "$(date +%s)" \\
+    > "\${CHECKPOINT_FILE}"
+}
+
+_checkpoint_clear() { rm -f "\${CHECKPOINT_FILE}"; }
+
+# Drive a sequence of idempotent step functions through with checkpoint
+# resume + step-list-hash invalidation. The caller passes the action
+# name as $1 and the step-function names as $2..$N.
+#
+# Each step function takes no arguments. Each MUST be idempotent (run
+# twice is a no-op the second time). Exit nonzero = halt + leave
+# checkpoint at the last-completed step so re-run picks up there.
+run_detached_stepwise() {
+  local action="\$1"; shift
+  local -a steps=("$@")
+  local nsteps="\${#steps[@]}"
+  (( nsteps > 0 )) || die "run_detached_stepwise: no steps provided"
+
+  _orch_paths "\${action}"
+  local current_hash
+  current_hash="$(_step_list_hash "\${steps[@]}")"
+
+  local start_step=1
+  local prior
+  prior="$(_checkpoint_read)"
+
+  if [[ "\${ORCH_FORCE_RESTART:-0}" == "1" ]]; then
+    log_warn "ORCH_FORCE_RESTART=1 set — clearing checkpoint and restarting from step 1."
+    _checkpoint_clear
+  elif [[ -n "\${prior}" ]]; then
+    local prior_hash prior_step
+    prior_hash="$(echo "\${prior}" | awk -F'=' '/^hash=/ {print $2}')"
+    prior_step="$(echo "\${prior}" | awk -F'=' '/^step=/ {print $2}')"
+    if [[ "\${prior_hash}" == "\${current_hash}" ]]; then
+      start_step=$((prior_step + 1))
+      log_info "Resuming from step \${start_step}/\${nsteps} (checkpoint hash matches)."
+    else
+      log_warn "Checkpoint hash mismatch (step list changed since last run)."
+      log_warn "Treating checkpoint as stale — restarting from step 1."
+      log_warn "(Override: set ORCH_FORCE_RESTART=1 to silence this. Step idempotency makes restart safe.)"
+      _checkpoint_clear
+    fi
+  fi
+
+  _heartbeat_write "\${action}" "start" "\\"nsteps\\":\${nsteps},\\"start_step\\":\${start_step}"
+  SCRIPT_ACTION="\${action}"
+
+  local i=0
+  for step_fn in "\${steps[@]}"; do
+    i=$((i + 1))
+    if (( i < start_step )); then
+      log_info "Step \${i}/\${nsteps}: \${step_fn} — skipped (checkpoint)."
+      continue
+    fi
+    log_info "Step \${i}/\${nsteps}: \${step_fn}"
+    _heartbeat_write "\${action}" "step" "\\"i\\":\${i},\\"fn\\":\\"\${step_fn}\\""
+    if ! "\${step_fn}"; then
+      _heartbeat_write "\${action}" "failed" "\\"i\\":\${i},\\"fn\\":\\"\${step_fn}\\""
+      die "Step \${i}/\${nsteps} (\${step_fn}) failed. Re-run to resume; ORCH_FORCE_RESTART=1 to restart from scratch."
+    fi
+    _checkpoint_write "\${current_hash}" "\${i}"
+  done
+
+  _heartbeat_write "\${action}" "complete" "\\"nsteps\\":\${nsteps}"
+  _checkpoint_clear
+  log_ok "Detached run complete: \${action} (\${nsteps} steps)."
+}
+
+# Single atomic remote job (Cloud Build). The caller provides the
+# gcloud-builds-submit command as a function name. The helper records
+# the build_id, heartbeats while it runs, and writes a recovery hint if
+# the parent dies. tfstate-lock-aware recovery is out of scope here
+# (the runner is expected to use a tfstate backend with the lock TTL
+# tuned to the build's max duration).
+run_detached_cloudbuild() {
+  local action="\$1" submit_fn="\$2"
+  _orch_paths "\${action}"
+  _heartbeat_write "\${action}" "submit"
+  SCRIPT_ACTION="\${action}"
+  if ! "\${submit_fn}"; then
+    _heartbeat_write "\${action}" "failed"
+    die "Cloud Build submit failed for action: \${action}"
+  fi
+  _heartbeat_write "\${action}" "complete"
+}
+
+# Read the most recent heartbeat phase. Used by cloud-status.
+heartbeat_status() {
+  local action="\$1"
+  _orch_paths "\${action}"
+  if [[ ! -f "\${HEARTBEAT_FILE}" ]]; then
+    echo "NEVER_STARTED"
+    return 0
+  fi
+  local last phase ts now age
+  last="$(tail -1 "\${HEARTBEAT_FILE}")"
+  phase="$(echo "\${last}" | sed -E 's/.*"phase":"([^"]+)".*/\\1/')"
+  ts="$(echo "\${last}" | sed -E 's/.*"ts":([0-9]+).*/\\1/')"
+  now="$(date +%s)"
+  age=$((now - ts))
+  case "\${phase}" in
+    complete) echo "COMPLETE (age=\${age}s)" ;;
+    failed)   echo "FAILED (age=\${age}s, see \${HEARTBEAT_FILE})" ;;
+    start|step|submit)
+      if (( age > 600 )); then
+        echo "STALLED (phase=\${phase}, age=\${age}s)"
+      else
+        echo "RUNNING (phase=\${phase}, age=\${age}s)"
+      fi
+      ;;
+    *) echo "UNKNOWN (phase=\${phase})" ;;
+  esac
+}
+
+# Read the recovery file (written by the EXIT/HUP trap) and emit hints
+# to the operator. Used by cloud-recover.
+recovery_summary() {
+  local action="\$1"
+  _orch_paths "\${action}"
+  if [[ ! -f "\${RECOVERY_FILE}" ]]; then
+    echo "No recovery state for \${action}."
+    return 0
+  fi
+  echo "Recovery state for \${action}:"
+  cat "\${RECOVERY_FILE}"
 }
 `
 }
@@ -271,7 +588,10 @@ function generateLocalSh(pt: ProjectType): string {
       init: '  require_cmd cargo\n  cargo fetch\n  log_ok "Dependencies fetched"',
       clean: '  cargo clean\n  log_ok "Cleaned local artifacts"',
       build: '  cargo build --release\n  log_ok "Build complete"',
-      run: '  cargo run',
+      // #141 lesson 5: operator-facing run defaults to --release.
+      // Dev profile is fine for `cargo test`, wrong for "operator-facing run this against prod."
+      // For dev profile, add `local-run-dev: cargo run` manually.
+      run: '  cargo run --release',
       test: '  cargo test\n  log_ok "Tests passed"',
       lint: '  cargo clippy -- -D warnings\n  log_ok "Lint passed"',
     },
@@ -422,17 +742,39 @@ esac
 
 function generateCloudSh(): string {
   return `#!/usr/bin/env bash
-# Cloud runtime operations (via Cloud Build)
-# Usage: bash scripts/cloud.sh {init|init-prod|infra|app-deploy|app-promote|app-undeploy|clean}
+# Cloud runtime operations — three-role topology (orchestration / build / runtime)
+#
+# Operator interface is the Makefile; this script is the implementation.
+# Never invoke this script directly — go through 'make <target>' so logging,
+# trap handlers, and the heartbeat/checkpoint machinery engage.
+#
+# Verbs (role-aware vocabulary, #141 lesson 6):
+#
+#   help                — print resolved three-role topology
+#   admin-cloud-init    — Owner-tier 8-step bootstrap (run as Owner once)
+#   admin-cloud-destroy — symmetric teardown (preserves TF state + AR by default)
+#   cloud-preflight     — read-only audit (per-role-aware messaging)
+#   cloud-infra         — TF apply via Cloud Build (builder SA in build project)
+#   cloud-app-deploy    — image build + Cloud Run revision swap
+#   cloud-app-promote   — semver tag + deploy to non-staging runtime (VERSION + IMAGE required)
+#   cloud-app-undeploy  — revert Cloud Run to placeholder image
+#   cloud-clean         — TF destroy (runtime resources only)
+#   cloud-status        — read heartbeat: RUNNING | STALLED | COMPLETE | NEVER_STARTED
+#   cloud-recover       — read EXIT/HUP recovery file, complete teardown
+#
+# Operator escape hatch:
+#   ORCH_FORCE_RESTART=1 — invalidates stepwise checkpoint, restarts from step 1.
+#                          Step idempotency is a contract; restart-from-1 is safe.
 
 SCRIPT_DIR="$(cd "$(dirname "\${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck disable=SC1091
 source "\${SCRIPT_DIR}/common.sh"
 start_log "cloud-\${1:-unknown}"
 
-# Build Cloud Build substitutions from config
+# Build Cloud Build substitutions from config. Carries the three-role
+# topology to Terraform via TF_VAR_* env (see cloudbuild-apply.yaml).
 _tf_substitutions() {
-  local subs="_REGION=\${GCP_REGION}"
+  local subs="_REGION=\${RUNTIME_REGION:-\${GCP_REGION}}"
   [[ -n "\${TF_STATE_BUCKET}" ]] && subs="\${subs},_TF_STATE_BUCKET=\${TF_STATE_BUCKET}"
   [[ -n "\${TF_STATE_PREFIX}" ]] && subs="\${subs},_TF_STATE_PREFIX=\${TF_STATE_PREFIX}"
   subs="\${subs},_SERVICE_NAME=\${PROJECT_NAME}"
@@ -442,260 +784,440 @@ _tf_substitutions() {
   subs="\${subs},_DNS_RECORD_NAME=\${DNS_RECORD_NAME}"
   subs="\${subs},_MIN_INSTANCES=\${MIN_INSTANCES}"
   subs="\${subs},_MAX_INSTANCES=\${MAX_INSTANCES}"
-  subs="\${subs},_CB_SERVICE_ACCOUNT=\${CB_SERVICE_ACCOUNT}"
+  subs="\${subs},_BUILDER_SA_EMAIL=\${BUILDER_SA_EMAIL}"
   subs="\${subs},_RUNTIME_SA_NAME=\${RUNTIME_SA_NAME}"
-  subs="\${subs},_CB_PROJECT_ID=\${CB_PROJECT}"
-  subs="\${subs},_PROJECT_ID=\${GCP_PROJECT}"
+  subs="\${subs},_ORCH_PROJECT_ID=\${ORCH_PROJECT}"
+  subs="\${subs},_BUILD_PROJECT_ID=\${BUILD_PROJECT}"
+  subs="\${subs},_RUNTIME_PROJECT_ID=\${RUNTIME_PROJECT}"
   subs="\${subs},_INGRESS=\${INGRESS}"
   echo "\${subs}"
 }
 
-init() {
-  log_info "Initializing cloud resources (\${ENVIRONMENT})..."
-  require_cmd gcloud
-
-  [[ -z "\${GCP_PROJECT}" ]] && die "GCP_PROJECT is not set. Add to config.toml or .env"
-  [[ -z "\${TF_STATE_BUCKET}" ]] && die "TF_STATE_BUCKET is not set. Add to config.toml or .env"
-
-  # Refusal guard: cloud-init is for the primary env (where the deployer SA,
-  # AR repo, and TF state live). Secondary envs (e.g. prod) must use
-  # cloud-init-prod which runs as the prod project owner with prod admin
-  # credentials and only grants the bootstrap role on the prod project.
-  if [[ "\${GCP_PROJECT}" != "\${CB_PROJECT}" ]]; then
-    die "make cloud-init is for the primary environment (where GCP_PROJECT == CB_PROJECT, currently \${CB_PROJECT}). For ENVIRONMENT=\${ENVIRONMENT} which targets \${GCP_PROJECT}, the prod project owner should run 'make cloud-init-prod' instead."
+# Cross-project IAM grant helper. Each grant in admin-cloud-init may target
+# the local project (current role) or a different one (cross-project). The
+# behavior is uniform — branch on local-vs-cross-project for the operator
+# warning message and the --billing-project flag.
+_grant_role() {
+  local target_project="\$1" member="\$2" role="\$3"
+  local extra_flag=""
+  if [[ "\${target_project}" != "\${ORCH_PROJECT}" ]]; then
+    extra_flag="--billing-project=\${target_project}"
+    log_info "  cross-project grant: \${role} on \${target_project} for \${member}"
   fi
+  # shellcheck disable=SC2086
+  gcloud projects add-iam-policy-binding "\${target_project}" \\
+    \${extra_flag} \\
+    --member="\${member}" \\
+    --role="\${role}" \\
+    --condition=None \\
+    --quiet
+}
 
-  # Step 1: Create TF state bucket (if not exists)
-  log_info "Step 1/6: Creating Terraform state bucket..."
-  if ! gcloud storage buckets describe "gs://\${TF_STATE_BUCKET}" --project="\${GCP_PROJECT}" &>/dev/null; then
-    gcloud storage buckets create "gs://\${TF_STATE_BUCKET}" \\
-      --project="\${GCP_PROJECT}" \\
-      --location="\${GCP_REGION}" \\
-      --uniform-bucket-level-access
-    log_ok "Created bucket: gs://\${TF_STATE_BUCKET}"
-  else
-    log_ok "Bucket already exists: gs://\${TF_STATE_BUCKET}"
-  fi
+_require_topology() {
+  [[ -z "\${ORCH_PROJECT}" ]]    && die "ORCH_PROJECT not set. Fill [gcp.defaults].project or [gcp.orchestration].project in config.toml."
+  [[ -z "\${BUILD_PROJECT}" ]]   && die "BUILD_PROJECT not set. Fill [gcp.defaults].project or [gcp.build].project in config.toml."
+  [[ -z "\${RUNTIME_PROJECT}" ]] && die "RUNTIME_PROJECT not set. Fill [gcp.defaults].project or [gcp.runtime].project in config.toml."
+}
 
-  # Step 2: Enable Cloud Build API
-  log_info "Step 2/6: Enabling Cloud Build API..."
-  gcloud services enable cloudbuild.googleapis.com --project="\${GCP_PROJECT}"
-  log_ok "Cloud Build API enabled"
+# ─── help ─────────────────────────────────────────────────────────────
 
-  # Step 3: Create deployer SA (if not exists)
-  log_info "Step 3/6: Creating deployer service account..."
-  # NOTE: This block assumes CB_PROJECT == GCP_PROJECT (enforced by the
-  # refusal guard above). The \`describe\` call uses the full SA email
-  # (CB_SERVICE_ACCOUNT) which is only valid in CB_PROJECT, while \`create\`
-  # uses the short DEPLOYER_SA_NAME. If the refusal guard is ever relaxed
-  # to allow init on a different project, this detection logic will break
-  # silently — switch to using the short name with --project=CB_PROJECT.
-  if ! gcloud iam service-accounts describe "\${CB_SERVICE_ACCOUNT}" --project="\${GCP_PROJECT}" &>/dev/null; then
-    gcloud iam service-accounts create "\${DEPLOYER_SA_NAME}" \\
-      --display-name="\${PROJECT_NAME} Deployer" \\
-      --project="\${GCP_PROJECT}"
-    log_ok "Created SA: \${CB_SERVICE_ACCOUNT}"
-  else
-    log_ok "SA already exists: \${CB_SERVICE_ACCOUNT}"
-  fi
+help_cmd() {
+  print_topology
+  echo ""
+  echo "Operator interface: see 'make help' (the Makefile is the operator surface."
+  echo "                    Never invoke scripts/cloud.sh directly.)"
+  echo ""
+  echo "Escape hatch: ORCH_FORCE_RESTART=1 invalidates the stepwise checkpoint"
+  echo "              and restarts the run from step 1. Always safe (step"
+  echo "              idempotency is a contract)."
+}
 
-  # Step 4: Grant bootstrap IAM roles (minimum for TF self-escalation)
-  log_info "Step 4/6: Granting bootstrap IAM roles..."
-  local bootstrap_roles=(
-    "roles/storage.admin"
-    "roles/logging.logWriter"
-    "roles/resourcemanager.projectIamAdmin"
-    "roles/serviceusage.serviceUsageAdmin"
-    "roles/iam.serviceAccountCreator"
+# ─── admin-cloud-init ─────────────────────────────────────────────────
+# Owner-tier 8-step bootstrap. Runs in the orchestration project as Owner.
+# Cross-project-aware: each grant branches on local-vs-cross-project.
+# Stepwise checkpointed via run_detached_stepwise — re-run resumes; the
+# step-list hash invalidates stale checkpoints automatically (#141 lesson 3).
+# All steps are idempotent.
+
+_step_enable_apis() {
+  local apis=(
+    "serviceusage.googleapis.com"
+    "iam.googleapis.com"
+    "cloudresourcemanager.googleapis.com"
+    "cloudbuild.googleapis.com"
+    "artifactregistry.googleapis.com"
+    "run.googleapis.com"
+    "storage.googleapis.com"
+    "logging.googleapis.com"
   )
+  # API enable is per-project (each role's project that owns resources).
+  # Build project needs build-time APIs; runtime needs runtime APIs.
+  # We enable the full set on each distinct project for simplicity —
+  # idempotent and cheap.
+  local projects=()
+  projects+=("\${BUILD_PROJECT}")
+  same_project BUILD_PROJECT RUNTIME_PROJECT || projects+=("\${RUNTIME_PROJECT}")
+  for p in "\${projects[@]}"; do
+    log_info "  enabling APIs on \${p}..."
+    for api in "\${apis[@]}"; do
+      gcloud services enable "\${api}" --project="\${p}" --quiet
+    done
+  done
+}
 
-  for role in "\${bootstrap_roles[@]}"; do
-    gcloud projects add-iam-policy-binding "\${GCP_PROJECT}" \\
-      --member="serviceAccount:\${CB_SERVICE_ACCOUNT}" \\
-      --role="\${role}" \\
-      --condition=None \\
+_step_create_ar_repo() {
+  if gcloud artifacts repositories describe "\${AR_REPO}" \\
+      --location="\${BUILD_REGION:-\${GCP_REGION}}" \\
+      --project="\${BUILD_PROJECT}" &>/dev/null; then
+    log_ok "  AR repo already exists: \${AR_REPO} in \${BUILD_PROJECT}"
+    return 0
+  fi
+  gcloud artifacts repositories create "\${AR_REPO}" \\
+    --repository-format=docker \\
+    --location="\${BUILD_REGION:-\${GCP_REGION}}" \\
+    --description="Container images for \${PROJECT_NAME}" \\
+    --project="\${BUILD_PROJECT}" \\
+    --quiet
+}
+
+_step_create_tfstate_bucket() {
+  [[ -z "\${TF_STATE_BUCKET}" ]] && die "TF_STATE_BUCKET not set."
+  if gcloud storage buckets describe "gs://\${TF_STATE_BUCKET}" --project="\${BUILD_PROJECT}" &>/dev/null; then
+    log_ok "  TF state bucket already exists: gs://\${TF_STATE_BUCKET}"
+    return 0
+  fi
+  gcloud storage buckets create "gs://\${TF_STATE_BUCKET}" \\
+    --project="\${BUILD_PROJECT}" \\
+    --location="\${BUILD_REGION:-\${GCP_REGION}}" \\
+    --uniform-bucket-level-access \\
+    --quiet
+}
+
+_step_create_builder_sa() {
+  if gcloud iam service-accounts describe "\${BUILDER_SA_EMAIL}" --project="\${BUILD_PROJECT}" &>/dev/null; then
+    log_ok "  Builder SA already exists: \${BUILDER_SA_EMAIL}"
+    return 0
+  fi
+  gcloud iam service-accounts create "\${BUILDER_SA_NAME}" \\
+    --display-name="\${PROJECT_NAME} Builder (Cloud Build)" \\
+    --project="\${BUILD_PROJECT}" \\
+    --quiet
+}
+
+_step_create_custom_role() {
+  [[ -f "\${DEPLOYER_ROLE_YAML}" ]] || die "Custom role YAML missing: \${DEPLOYER_ROLE_YAML}. Re-run /scaffold to generate it."
+  # Custom role lives on the orchestration project (where the agent identity lives).
+  if gcloud iam roles describe "\${DEPLOYER_ROLE_ID}" --project="\${ORCH_PROJECT}" &>/dev/null; then
+    log_info "  Custom role exists — updating from YAML..."
+    gcloud iam roles update "\${DEPLOYER_ROLE_ID}" \\
+      --project="\${ORCH_PROJECT}" \\
+      --file="\${DEPLOYER_ROLE_YAML}" \\
       --quiet
+  else
+    log_info "  Creating custom role from YAML..."
+    gcloud iam roles create "\${DEPLOYER_ROLE_ID}" \\
+      --project="\${ORCH_PROJECT}" \\
+      --file="\${DEPLOYER_ROLE_YAML}" \\
+      --quiet
+  fi
+}
+
+_step_create_agent_sa_and_bind() {
+  # Create agent SA (operator identity) in orchestration project.
+  if ! gcloud iam service-accounts describe "\${AGENT_SA_EMAIL}" --project="\${ORCH_PROJECT}" &>/dev/null; then
+    gcloud iam service-accounts create "\${AGENT_SA_NAME}" \\
+      --display-name="\${PROJECT_NAME} Agent (operator identity)" \\
+      --project="\${ORCH_PROJECT}" \\
+      --quiet
+  else
+    log_ok "  Agent SA already exists: \${AGENT_SA_EMAIL}"
+  fi
+
+  # Bind agent SA to custom role on orchestration project with 30-day expiry.
+  # Expiry condition forces graceful credential rotation (re-run admin-cloud-init).
+  local expiry_ts
+  expiry_ts="$(date -u -d "+\${AGENT_ROLE_EXPIRY_DAYS} days" '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null \\
+    || date -u -v+\${AGENT_ROLE_EXPIRY_DAYS}d '+%Y-%m-%dT%H:%M:%SZ')"
+  local condition_title="agent-role-expiry-\${AGENT_ROLE_EXPIRY_DAYS}d"
+  log_info "  binding agent SA → custom role with expiry \${expiry_ts}"
+  gcloud projects add-iam-policy-binding "\${ORCH_PROJECT}" \\
+    --member="serviceAccount:\${AGENT_SA_EMAIL}" \\
+    --role="projects/\${ORCH_PROJECT}/roles/\${DEPLOYER_ROLE_ID}" \\
+    --condition="expression=request.time < timestamp(\\"\${expiry_ts}\\"),title=\${condition_title},description=Auto-expires; re-run admin-cloud-init to refresh." \\
+    --quiet
+}
+
+_step_grant_agent_actas_builder() {
+  # Agent SA needs iam.serviceAccountUser on the builder SA so it can
+  # pass --service-account=<builder> to gcloud builds submit.
+  gcloud iam service-accounts add-iam-policy-binding "\${BUILDER_SA_EMAIL}" \\
+    --project="\${BUILD_PROJECT}" \\
+    --member="serviceAccount:\${AGENT_SA_EMAIL}" \\
+    --role="roles/iam.serviceAccountUser" \\
+    --condition=None \\
+    --quiet
+}
+
+_step_grant_builder_roles() {
+  # The 6 predefined roles the builder SA holds. Scoped to what TF
+  # actually needs to construct resources (NO projectIamAdmin, NO
+  # serviceUsageAdmin — those would defeat the agent's least-privilege model).
+  #
+  # Each grant targets the runtime project (where TF builds things), with
+  # one grant on the build project for storage admin (TF state + Cloud
+  # Build staging bucket). Cross-project-aware: branches on local-vs-cross.
+  local builder_roles_runtime=(
+    "roles/run.admin"
+    "roles/artifactregistry.admin"
+    "roles/iam.serviceAccountUser"
+    "roles/iam.serviceAccountAdmin"
+    "roles/logging.logWriter"
+  )
+  local builder_member="serviceAccount:\${BUILDER_SA_EMAIL}"
+
+  log_info "  granting builder SA 5 functional roles on runtime project (\${RUNTIME_PROJECT})"
+  for role in "\${builder_roles_runtime[@]}"; do
+    _grant_role "\${RUNTIME_PROJECT}" "\${builder_member}" "\${role}"
   done
 
-  # Bucket-level objectAdmin (belt-and-suspenders for org deny policies)
-  gcloud storage buckets add-iam-policy-binding "gs://\${GCP_PROJECT}_cloudbuild" \\
-    --member="serviceAccount:\${CB_SERVICE_ACCOUNT}" \\
-    --role="roles/storage.objectAdmin" \\
-    --condition=None \\
-    --quiet 2>/dev/null || true
+  # Storage admin lives on the build project (TF state bucket + Cloud
+  # Build staging bucket are both there).
+  log_info "  granting builder SA storage.admin on build project (\${BUILD_PROJECT})"
+  _grant_role "\${BUILD_PROJECT}" "\${builder_member}" "roles/storage.admin"
 
-  gcloud storage buckets add-iam-policy-binding "gs://\${TF_STATE_BUCKET}" \\
-    --member="serviceAccount:\${CB_SERVICE_ACCOUNT}" \\
-    --role="roles/storage.objectAdmin" \\
-    --condition=None \\
-    --quiet
-
-  log_ok "Bootstrap IAM roles granted"
-
-  # Step 5: Terraform init (via Cloud Build, using custom SA)
-  log_info "Step 5/6: Running Terraform init..."
-  gcloud builds submit "\${PROJECT_ROOT}" \\
-    --project="\${CB_PROJECT}" \\
-    --service-account="projects/\${CB_PROJECT}/serviceAccounts/\${CB_SERVICE_ACCOUNT}" \\
-    --config="\${PROJECT_ROOT}/cicd/cloudbuild-plan.yaml" \\
-    --substitutions="_TF_ACTION=init,$(_tf_substitutions)" \\
-    --quiet
-
-  # Step 6/6: Grant cross-project DNS permissions (if DNS_PROJECT_ID is set).
-  # Note: We use roles/dns.admin here. A previously-tried "record-set-editor"
-  # variant role does NOT exist in GCP's predefined Cloud DNS role catalog,
-  # despite some references suggesting otherwise. The two predefined roles
-  # for managing DNS resources are roles/dns.admin and roles/dns.reader.
-  # See: https://cloud.google.com/dns/docs/access-control
+  # DNS admin if a DNS project is configured. Cross-project-aware.
   if [[ -n "\${DNS_PROJECT_ID}" ]]; then
-    log_info "Step 6/6: Granting roles/dns.admin on \${DNS_PROJECT_ID}..."
-    if gcloud projects add-iam-policy-binding "\${DNS_PROJECT_ID}" \\
-        --billing-project="\${DNS_PROJECT_ID}" \\
-        --member="serviceAccount:\${CB_SERVICE_ACCOUNT}" \\
-        --role="roles/dns.admin" \\
-        --condition=None \\
-        --quiet; then
-      log_info "Waiting 120s for IAM propagation..."
-      sleep 120
-      log_ok "DNS bootstrap complete"
-    else
-      log_warn ""
-      log_warn "Cross-project DNS IAM grant failed on \${DNS_PROJECT_ID}."
-      log_warn "Most likely cause: operator lacks setIamPolicy permission on the DNS project."
-      log_warn ""
-      log_warn "Workarounds (pick one):"
-      log_warn "  (a) Re-run the grant manually with elevated credentials:"
-      log_warn "      gcloud projects add-iam-policy-binding \${DNS_PROJECT_ID} \\\\"
-      log_warn "        --billing-project=\${DNS_PROJECT_ID} \\\\"
-      log_warn "        --member=serviceAccount:\${CB_SERVICE_ACCOUNT} \\\\"
-      log_warn "        --role=roles/dns.admin --condition=None"
-      log_warn ""
-      log_warn "  (b) Ask the DNS project owner to run the command above."
-      log_warn ""
-      log_warn "  (c) Use a different DNS project where you have setIamPolicy permission."
-      log_warn ""
-      log_warn "Continuing cloud-init. Run 'make cloud-infra' once the grant is in place."
-    fi
-  else
-    log_info "Step 6/6: Skipped (DNS_PROJECT_ID not set)"
+    log_info "  granting builder SA dns.admin on DNS project (\${DNS_PROJECT_ID})"
+    _grant_role "\${DNS_PROJECT_ID}" "\${builder_member}" "roles/dns.admin"
   fi
-
-  log_ok "Cloud resources initialized (\${ENVIRONMENT})"
 }
 
-# One-time bootstrap of a SECONDARY environment (e.g. production), run by
-# the prod project owner with prod admin credentials. Pure gcloud — no
-# Cloud Build invocation. Grants the staging-resident deployer SA the
-# minimum role needed for it to self-escalate the rest of its IAM via
-# Terraform on subsequent \`make cloud-infra\` runs.
-#
-# Self-escalation chain:
-#   prod owner grants:   projectIamAdmin (here)
-#                              |
-#                              v
-#   TF self-grants:      serviceUsageAdmin, iam.serviceAccountCreator,
-#                        run.admin, artifactregistry.admin,
-#                        iam.serviceAccountUser, plus Compute roles when
-#                        LB enabled.
-init_prod() {
-  log_info "One-time prod bootstrap (\${ENVIRONMENT})..."
+admin_cloud_init() {
+  log_info "Owner-tier bootstrap (\${ENVIRONMENT})..."
+  print_topology
   require_cmd gcloud
+  _require_topology
+  [[ -z "\${TF_STATE_BUCKET}" ]] && die "TF_STATE_BUCKET is not set."
 
-  [[ -z "\${GCP_PROJECT}" ]] && die "GCP_PROJECT is not set. Add to config.toml or .env"
-  [[ -z "\${CB_PROJECT}" ]] && die "CB_PROJECT is not set."
-  [[ -z "\${CB_SERVICE_ACCOUNT}" ]] && die "CB_SERVICE_ACCOUNT is not set."
-
-  # Refusal guard: this target is for secondary envs only
-  if [[ "\${GCP_PROJECT}" == "\${CB_PROJECT}" ]]; then
-    die "make cloud-init-prod is for secondary environments (where GCP_PROJECT differs from CB_PROJECT, currently \${CB_PROJECT}). For ENVIRONMENT=\${ENVIRONMENT} which targets the same project as CB, use 'make cloud-init' instead."
-  fi
-
-  # Step 1/3: Print summary and confirm
-  log_info "Step 1/3: Confirming bootstrap targets..."
-  log_info ""
-  log_info "  Target prod project:       \${GCP_PROJECT}"
-  log_info "  Deployer SA to be granted: \${CB_SERVICE_ACCOUNT}"
-  log_info "  Role to grant on prod:     roles/resourcemanager.projectIamAdmin"
-  if [[ -n "\${DNS_PROJECT_ID}" ]]; then
-    log_info "  Target DNS project:        \${DNS_PROJECT_ID}"
-    log_info "  Role to grant on DNS:      roles/dns.admin"
-  fi
-  log_info ""
   if [[ "\${CONFIRM:-}" != "yes" ]]; then
-    if ! confirm "Proceed with these grants?"; then
-      log_warn "Aborted."
-      exit 0
-    fi
+    confirm "Proceed with 8-step bootstrap?" || { log_warn "Aborted."; exit 0; }
   fi
 
-  # Step 2/3: Grant projectIamAdmin to deployer SA on prod project. This is
-  # the single bootstrap role from which Terraform self-grants all other
-  # roles it needs (serviceUsageAdmin, iam.serviceAccountCreator, run.admin,
-  # artifactregistry.admin, etc.) on subsequent \`make cloud-infra\` runs.
-  log_info "Step 2/3: Granting roles/resourcemanager.projectIamAdmin on \${GCP_PROJECT}..."
-  if ! gcloud projects add-iam-policy-binding "\${GCP_PROJECT}" \\
-      --billing-project="\${GCP_PROJECT}" \\
-      --member="serviceAccount:\${CB_SERVICE_ACCOUNT}" \\
-      --role="roles/resourcemanager.projectIamAdmin" \\
-      --condition=None \\
-      --quiet; then
-    die "Failed to grant projectIamAdmin on \${GCP_PROJECT}. The operator running 'make cloud-init-prod' needs setIamPolicy permission on the prod project (roles/resourcemanager.projectIamAdmin or roles/owner)."
-  fi
-  log_ok "projectIamAdmin granted on \${GCP_PROJECT}"
+  run_detached_stepwise "admin-cloud-init" \\
+    _step_enable_apis \\
+    _step_create_ar_repo \\
+    _step_create_tfstate_bucket \\
+    _step_create_builder_sa \\
+    _step_create_custom_role \\
+    _step_create_agent_sa_and_bind \\
+    _step_grant_agent_actas_builder \\
+    _step_grant_builder_roles
 
-  # Step 3/3: Grant DNS access (if DNS_PROJECT_ID set) — same warn-and-continue
-  # pattern as init()'s Step 6/6, since the operator running cloud-init-prod
-  # may not have setIamPolicy on a DNS project owned by a different team.
-  if [[ -n "\${DNS_PROJECT_ID}" ]]; then
-    log_info "Step 3/3: Granting roles/dns.admin on \${DNS_PROJECT_ID}..."
-    if gcloud projects add-iam-policy-binding "\${DNS_PROJECT_ID}" \\
-        --billing-project="\${DNS_PROJECT_ID}" \\
-        --member="serviceAccount:\${CB_SERVICE_ACCOUNT}" \\
-        --role="roles/dns.admin" \\
-        --condition=None \\
-        --quiet; then
-      log_ok "DNS access granted"
-    else
-      log_warn ""
-      log_warn "Cross-project DNS IAM grant failed on \${DNS_PROJECT_ID}."
-      log_warn "Most likely cause: operator lacks setIamPolicy on the DNS project."
-      log_warn ""
-      log_warn "Workarounds (pick one):"
-      log_warn "  (a) Re-run the grant manually with elevated credentials:"
-      log_warn "      gcloud projects add-iam-policy-binding \${DNS_PROJECT_ID} \\\\"
-      log_warn "        --billing-project=\${DNS_PROJECT_ID} \\\\"
-      log_warn "        --member=serviceAccount:\${CB_SERVICE_ACCOUNT} \\\\"
-      log_warn "        --role=roles/dns.admin --condition=None"
-      log_warn ""
-      log_warn "  (b) Ask the DNS project owner to run the command above."
-      log_warn ""
-      log_warn "  (c) Use a different DNS project where you have setIamPolicy permission."
-      log_warn ""
-      log_warn "Continuing. cloud-infra will fail until the DNS grant is in place."
-    fi
-  else
-    log_info "Step 3/3: Skipped (DNS_PROJECT_ID not set)"
-  fi
-
-  log_ok "Prod bootstrap complete (\${ENVIRONMENT})"
-  log_info ""
-  log_info "Next: anyone with Cloud Build access on \${CB_PROJECT} can now run:"
-  log_info "  ENVIRONMENT=\${ENVIRONMENT} make cloud-infra"
-  log_info ""
-  log_info "Terraform will self-grant the remaining IAM roles on \${GCP_PROJECT}"
-  log_info "using the projectIamAdmin permission granted above."
+  log_ok "admin-cloud-init complete."
+  log_info "Next: 'make cloud-preflight' to verify, then 'make cloud-infra' to provision runtime resources."
 }
 
-infra() {
-  log_info "Creating/updating cloud infrastructure (\${ENVIRONMENT})..."
-  require_cmd gcloud
+# ─── admin-cloud-destroy ──────────────────────────────────────────────
+# Symmetric to admin-cloud-init. Preserves TF state bucket + AR repo by
+# default (those are too destructive to remove without explicit confirm).
+# Set DESTROY_STATE_BUCKET=yes / DESTROY_AR_REPO=yes to include them.
 
-  [[ -z "\${GCP_PROJECT}" ]] && die "GCP_PROJECT is not set. Add to config.toml or .env"
-  [[ -z "\${TF_STATE_BUCKET}" ]] && die "TF_STATE_BUCKET is not set. Add to config.toml or .env"
+_step_destroy_grant_builder_roles() {
+  local builder_roles_runtime=(
+    "roles/run.admin"
+    "roles/artifactregistry.admin"
+    "roles/iam.serviceAccountUser"
+    "roles/iam.serviceAccountAdmin"
+    "roles/logging.logWriter"
+  )
+  local builder_member="serviceAccount:\${BUILDER_SA_EMAIL}"
+  for role in "\${builder_roles_runtime[@]}"; do
+    gcloud projects remove-iam-policy-binding "\${RUNTIME_PROJECT}" \\
+      --member="\${builder_member}" \\
+      --role="\${role}" \\
+      --quiet 2>/dev/null || true
+  done
+  gcloud projects remove-iam-policy-binding "\${BUILD_PROJECT}" \\
+    --member="\${builder_member}" \\
+    --role="roles/storage.admin" \\
+    --quiet 2>/dev/null || true
+}
+
+_step_destroy_agent_actas_builder() {
+  gcloud iam service-accounts remove-iam-policy-binding "\${BUILDER_SA_EMAIL}" \\
+    --project="\${BUILD_PROJECT}" \\
+    --member="serviceAccount:\${AGENT_SA_EMAIL}" \\
+    --role="roles/iam.serviceAccountUser" \\
+    --quiet 2>/dev/null || true
+}
+
+_step_destroy_agent_sa() {
+  gcloud iam service-accounts delete "\${AGENT_SA_EMAIL}" --project="\${ORCH_PROJECT}" --quiet 2>/dev/null || true
+}
+
+_step_destroy_custom_role() {
+  gcloud iam roles delete "\${DEPLOYER_ROLE_ID}" --project="\${ORCH_PROJECT}" --quiet 2>/dev/null || true
+}
+
+_step_destroy_builder_sa() {
+  gcloud iam service-accounts delete "\${BUILDER_SA_EMAIL}" --project="\${BUILD_PROJECT}" --quiet 2>/dev/null || true
+}
+
+_step_destroy_tfstate_bucket() {
+  if [[ "\${DESTROY_STATE_BUCKET:-no}" == "yes" ]]; then
+    log_warn "  DESTROY_STATE_BUCKET=yes — removing gs://\${TF_STATE_BUCKET}"
+    gcloud storage rm -r "gs://\${TF_STATE_BUCKET}" --project="\${BUILD_PROJECT}" --quiet 2>/dev/null || true
+  else
+    log_info "  preserving TF state bucket gs://\${TF_STATE_BUCKET} (set DESTROY_STATE_BUCKET=yes to remove)"
+  fi
+}
+
+_step_destroy_ar_repo() {
+  if [[ "\${DESTROY_AR_REPO:-no}" == "yes" ]]; then
+    log_warn "  DESTROY_AR_REPO=yes — removing AR repo \${AR_REPO}"
+    gcloud artifacts repositories delete "\${AR_REPO}" \\
+      --location="\${BUILD_REGION:-\${GCP_REGION}}" \\
+      --project="\${BUILD_PROJECT}" --quiet 2>/dev/null || true
+  else
+    log_info "  preserving AR repo \${AR_REPO} (set DESTROY_AR_REPO=yes to remove)"
+  fi
+}
+
+admin_cloud_destroy() {
+  log_warn "Owner-tier teardown of bootstrap (\${ENVIRONMENT})..."
+  print_topology
+  require_cmd gcloud
+  _require_topology
+
+  if [[ "\${CONFIRM:-}" != "yes" ]]; then
+    confirm "Proceed with destructive teardown of agent/builder SAs and IAM bindings?" \\
+      || { log_warn "Aborted."; exit 0; }
+  fi
+
+  run_detached_stepwise "admin-cloud-destroy" \\
+    _step_destroy_grant_builder_roles \\
+    _step_destroy_agent_actas_builder \\
+    _step_destroy_agent_sa \\
+    _step_destroy_custom_role \\
+    _step_destroy_builder_sa \\
+    _step_destroy_tfstate_bucket \\
+    _step_destroy_ar_repo
+
+  log_ok "admin-cloud-destroy complete."
+}
+
+# ─── cloud-preflight ──────────────────────────────────────────────────
+# Read-only audit. Verifies bootstrap state across all three roles with
+# per-role-aware messaging. Never mutates.
+
+cloud_preflight() {
+  log_info "Cloud preflight audit (read-only)..."
+  print_topology
+  require_cmd gcloud
+  _require_topology
+
+  local errors=0
+  local checks=0
+
+  # APIs (sample one critical API per project where resources live)
+  for p in "\${BUILD_PROJECT}" "\${RUNTIME_PROJECT}"; do
+    checks=$((checks + 1))
+    if gcloud services list --enabled --project="\${p}" --filter="config.name=run.googleapis.com" --format="value(config.name)" 2>/dev/null | grep -q "run.googleapis.com"; then
+      log_ok "  APIs enabled on \${p} (run.googleapis.com sentinel ✓)"
+    else
+      log_error "  APIs not enabled on \${p} — run 'make admin-cloud-init'"
+      errors=$((errors + 1))
+    fi
+  done
+
+  # AR repo exists in build project
+  checks=$((checks + 1))
+  if gcloud artifacts repositories describe "\${AR_REPO}" \\
+      --location="\${BUILD_REGION:-\${GCP_REGION}}" \\
+      --project="\${BUILD_PROJECT}" &>/dev/null; then
+    log_ok "  AR repo exists: \${AR_REPO} in \${BUILD_PROJECT}"
+  else
+    log_error "  AR repo missing: \${AR_REPO} in \${BUILD_PROJECT}"
+    errors=$((errors + 1))
+  fi
+
+  # TF state bucket exists in build project
+  checks=$((checks + 1))
+  if [[ -n "\${TF_STATE_BUCKET}" ]] && gcloud storage buckets describe "gs://\${TF_STATE_BUCKET}" --project="\${BUILD_PROJECT}" &>/dev/null; then
+    log_ok "  TF state bucket exists: gs://\${TF_STATE_BUCKET} in \${BUILD_PROJECT}"
+  else
+    log_error "  TF state bucket missing: gs://\${TF_STATE_BUCKET:-<unset>}"
+    errors=$((errors + 1))
+  fi
+
+  # Builder SA exists in build project
+  checks=$((checks + 1))
+  if gcloud iam service-accounts describe "\${BUILDER_SA_EMAIL}" --project="\${BUILD_PROJECT}" &>/dev/null; then
+    log_ok "  Builder SA exists: \${BUILDER_SA_EMAIL}"
+  else
+    log_error "  Builder SA missing: \${BUILDER_SA_EMAIL}"
+    errors=$((errors + 1))
+  fi
+
+  # Builder SA has expected 5 roles on runtime project
+  checks=$((checks + 1))
+  local builder_member="serviceAccount:\${BUILDER_SA_EMAIL}"
+  local policy
+  policy="$(gcloud projects get-iam-policy "\${RUNTIME_PROJECT}" --format=json 2>/dev/null || echo '{}')"
+  local missing_roles=()
+  for role in "roles/run.admin" "roles/artifactregistry.admin" "roles/iam.serviceAccountUser" "roles/iam.serviceAccountAdmin" "roles/logging.logWriter"; do
+    # grep for the quoted role string in the JSON IAM policy.
+    if ! grep -q "\\\"\${role}\\\"" <<<"\${policy}"; then
+      missing_roles+=("\${role}")
+    fi
+  done
+  if (( \${#missing_roles[@]} == 0 )); then
+    log_ok "  Builder SA has all 5 functional roles on runtime project (\${RUNTIME_PROJECT})"
+  else
+    log_error "  Builder SA missing roles on \${RUNTIME_PROJECT}: \${missing_roles[*]}"
+    errors=$((errors + 1))
+  fi
+
+  # Agent SA exists in orchestration project
+  checks=$((checks + 1))
+  if gcloud iam service-accounts describe "\${AGENT_SA_EMAIL}" --project="\${ORCH_PROJECT}" &>/dev/null; then
+    log_ok "  Agent SA exists: \${AGENT_SA_EMAIL}"
+  else
+    log_warn "  Agent SA missing: \${AGENT_SA_EMAIL} (run 'make admin-cloud-init')"
+    errors=$((errors + 1))
+  fi
+
+  # Custom role exists on orchestration project
+  checks=$((checks + 1))
+  if gcloud iam roles describe "\${DEPLOYER_ROLE_ID}" --project="\${ORCH_PROJECT}" &>/dev/null; then
+    log_ok "  Custom role exists: \${DEPLOYER_ROLE_ID} in \${ORCH_PROJECT}"
+  else
+    log_warn "  Custom role missing: \${DEPLOYER_ROLE_ID} in \${ORCH_PROJECT}"
+    errors=$((errors + 1))
+  fi
+
+  echo ""
+  if (( errors == 0 )); then
+    log_ok "Preflight passed: \${checks}/\${checks} checks OK."
+    return 0
+  fi
+  log_error "Preflight failed: \${errors}/\${checks} checks failed."
+  return 1
+}
+
+# ─── cloud-infra ──────────────────────────────────────────────────────
+# TF apply via Cloud Build. Builder SA runs in the build project and
+# provisions runtime-project resources (Cloud Run, runtime SA, LB/DNS).
+
+cloud_infra() {
+  log_info "Provisioning runtime infrastructure (\${ENVIRONMENT})..."
+  require_cmd gcloud
+  _require_topology
+  [[ -z "\${TF_STATE_BUCKET}" ]] && die "TF_STATE_BUCKET not set."
 
   gcloud builds submit "\${PROJECT_ROOT}" \\
-    --project="\${CB_PROJECT}" \\
-    --service-account="projects/\${CB_PROJECT}/serviceAccounts/\${CB_SERVICE_ACCOUNT}" \\
+    --project="\${BUILD_PROJECT}" \\
+    --service-account="projects/\${BUILD_PROJECT}/serviceAccounts/\${BUILDER_SA_EMAIL}" \\
     --config="\${PROJECT_ROOT}/cicd/cloudbuild-apply.yaml" \\
     --substitutions="_TF_ACTION=apply,$(_tf_substitutions)" \\
     --quiet
@@ -703,35 +1225,33 @@ infra() {
   log_ok "Infrastructure ready (\${ENVIRONMENT})"
 }
 
-app_deploy() {
-  log_info "Building and deploying application (\${ENVIRONMENT})..."
-  require_cmd gcloud
+# ─── cloud-app-deploy ─────────────────────────────────────────────────
+# Build image (tagged :latest + :sha-<commit>) and swap Cloud Run revision.
 
-  [[ -z "\${GCP_PROJECT}" ]] && die "GCP_PROJECT is not set. Add to config.toml or .env"
-  [[ -z "\${TF_STATE_BUCKET}" ]] && die "TF_STATE_BUCKET is not set. Add to config.toml or .env"
+cloud_app_deploy() {
+  log_info "Build + deploy application (\${ENVIRONMENT})..."
+  require_cmd gcloud
+  _require_topology
+  [[ -z "\${TF_STATE_BUCKET}" ]] && die "TF_STATE_BUCKET not set."
 
   local short_sha
-  short_sha="$(git -C "\${PROJECT_ROOT}" rev-parse --short HEAD)"
-  local image_base="\${GCP_REGION}-docker.pkg.dev/\${GCP_PROJECT}/\${PROJECT_NAME}/\${PROJECT_NAME}"
+  short_sha="$(git -C "\${PROJECT_ROOT}" rev-parse --short HEAD 2>/dev/null || echo manual)"
+  local image_base="\${BUILD_REGION:-\${GCP_REGION}}-docker.pkg.dev/\${BUILD_PROJECT}/\${AR_REPO}/\${PROJECT_NAME}"
 
-  # Step 1: Build and push container image (tagged :latest and :sha-<commit>)
-  log_info "Step 1/2: Building and pushing container image..."
+  log_info "Step 1/2: build + push image"
   log_info "  Image: \${image_base}:latest"
   log_info "  Image: \${image_base}:sha-\${short_sha}"
   gcloud builds submit "\${PROJECT_ROOT}" \\
-    --project="\${CB_PROJECT}" \\
-    --service-account="projects/\${CB_PROJECT}/serviceAccounts/\${CB_SERVICE_ACCOUNT}" \\
+    --project="\${BUILD_PROJECT}" \\
+    --service-account="projects/\${BUILD_PROJECT}/serviceAccounts/\${BUILDER_SA_EMAIL}" \\
     --config="\${PROJECT_ROOT}/cicd/cloudbuild.yaml" \\
     --substitutions="_IMAGE_NAME=\${image_base},_SHORT_SHA=\${short_sha}" \\
     --quiet
 
-  log_ok "Image built and pushed"
-
-  # Step 2: Update Cloud Run via Terraform to use :latest
-  log_info "Step 2/2: Updating Cloud Run service..."
+  log_info "Step 2/2: swap Cloud Run revision"
   gcloud builds submit "\${PROJECT_ROOT}" \\
-    --project="\${CB_PROJECT}" \\
-    --service-account="projects/\${CB_PROJECT}/serviceAccounts/\${CB_SERVICE_ACCOUNT}" \\
+    --project="\${BUILD_PROJECT}" \\
+    --service-account="projects/\${BUILD_PROJECT}/serviceAccounts/\${BUILDER_SA_EMAIL}" \\
     --config="\${PROJECT_ROOT}/cicd/cloudbuild-apply.yaml" \\
     --substitutions="_TF_ACTION=apply,$(_tf_substitutions),_IMAGE=\${image_base}:latest" \\
     --quiet
@@ -739,40 +1259,34 @@ app_deploy() {
   log_ok "Application deployed (sha-\${short_sha})"
 }
 
-app_promote() {
+# ─── cloud-app-promote ────────────────────────────────────────────────
+# Tag a specific image with a semver and deploy to a non-staging runtime.
+# Requires VERSION=vX.Y.Z and IMAGE=<full-uri> (the source image to promote).
+
+cloud_app_promote() {
   log_info "Promoting image to \${ENVIRONMENT}..."
   require_cmd gcloud
-
-  [[ -z "\${GCP_PROJECT}" ]] && die "GCP_PROJECT is not set. Add to config.toml or .env"
-  [[ -z "\${TF_STATE_BUCKET}" ]] && die "TF_STATE_BUCKET is not set. Add to config.toml or .env"
-  [[ "\${ENVIRONMENT}" == "staging" ]] && die "Cannot promote to staging. Use app-deploy instead."
+  _require_topology
+  [[ "\${ENVIRONMENT}" == "staging" ]] && die "Cannot promote to staging. Use cloud-app-deploy instead."
   [[ -z "\${VERSION:-}" ]] && die "VERSION is required (e.g., VERSION=v1.0.0)"
-  [[ -z "\${IMAGE:-}" ]] && die "IMAGE is required (full URI of staging image to promote, e.g., IMAGE=us-central1-docker.pkg.dev/<cb-project>/\${PROJECT_NAME}/\${PROJECT_NAME}:sha-abc123f)"
+  [[ -z "\${IMAGE:-}" ]] && die "IMAGE is required (full URI of source image, e.g., IMAGE=us-central1-docker.pkg.dev/<build-project>/<repo>/<svc>:sha-abc123f)"
 
-  # Validate IMAGE belongs to the CB project's AR (where promote is rooted).
-  # Cross-project promotion is not supported — the source image must live in
-  # \${CB_PROJECT}'s AR for the runtime SA cross-project read binding to work.
-  local expected_prefix="\${GCP_REGION}-docker.pkg.dev/\${CB_PROJECT}/\${PROJECT_NAME}/"
+  # Source image must live in BUILD_PROJECT's AR — that's where the
+  # cross-project runtime-SA read binding points (see main.tf).
+  local expected_prefix="\${BUILD_REGION:-\${GCP_REGION}}-docker.pkg.dev/\${BUILD_PROJECT}/\${AR_REPO}/"
   if [[ "\${IMAGE}" != "\${expected_prefix}"* ]]; then
-    die "IMAGE must start with '\${expected_prefix}' (got: \${IMAGE}). Source images must live in CB_PROJECT's Artifact Registry."
+    die "IMAGE must start with '\${expected_prefix}' (got: \${IMAGE}). Source images must live in BUILD_PROJECT's Artifact Registry."
   fi
 
-  # Step 1: Tag the source image with the semver version
   log_info "Step 1/2: Tagging image as \${VERSION}..."
-  gcloud artifacts docker tags add \\
-    "\${IMAGE}" \\
-    "\${IMAGE%%:*}:\${VERSION}"
-
+  gcloud artifacts docker tags add "\${IMAGE}" "\${IMAGE%%:*}:\${VERSION}"
   log_ok "Tagged \${IMAGE} as \${VERSION}"
 
-  # Step 2: Deploy to target environment via Terraform
   local versioned_image="\${IMAGE%%:*}:\${VERSION}"
   log_info "Step 2/2: Deploying \${versioned_image} to \${ENVIRONMENT}..."
-
-  # Cloud Build always runs in the default/staging project (CB_PROJECT)
   gcloud builds submit "\${PROJECT_ROOT}" \\
-    --project="\${CB_PROJECT}" \\
-    --service-account="projects/\${CB_PROJECT}/serviceAccounts/\${CB_SERVICE_ACCOUNT}" \\
+    --project="\${BUILD_PROJECT}" \\
+    --service-account="projects/\${BUILD_PROJECT}/serviceAccounts/\${BUILDER_SA_EMAIL}" \\
     --config="\${PROJECT_ROOT}/cicd/cloudbuild-apply.yaml" \\
     --substitutions="_TF_ACTION=apply,$(_tf_substitutions),_IMAGE=\${versioned_image}" \\
     --quiet
@@ -780,21 +1294,18 @@ app_promote() {
   log_ok "Promoted \${VERSION} to \${ENVIRONMENT}"
 }
 
-app_undeploy() {
-  log_info "Undeploying application (\${ENVIRONMENT}, reverting to placeholder)..."
+# ─── cloud-app-undeploy ───────────────────────────────────────────────
+
+cloud_app_undeploy() {
+  log_info "Undeploying (\${ENVIRONMENT}, reverting to placeholder)..."
   require_cmd gcloud
+  _require_topology
 
-  [[ -z "\${GCP_PROJECT}" ]] && die "GCP_PROJECT is not set. Add to config.toml or .env"
-  [[ -z "\${TF_STATE_BUCKET}" ]] && die "TF_STATE_BUCKET is not set. Add to config.toml or .env"
-
-  # Pass the \`__placeholder__\` sentinel — Terraform's main.tf substitutes
-  # the Cloud Run hello-world image when it sees this value. We use a
-  # sentinel rather than an empty \`_IMAGE=\` because some Cloud Build
-  # invocations reject empty substitution values, and \`cloudbuild-apply.yaml\`'s
-  # default of \`_IMAGE: ''\` is not guaranteed to work everywhere.
+  # Sentinel string — main.tf substitutes the Cloud Run hello-world image
+  # when it sees this value.
   gcloud builds submit "\${PROJECT_ROOT}" \\
-    --project="\${CB_PROJECT}" \\
-    --service-account="projects/\${CB_PROJECT}/serviceAccounts/\${CB_SERVICE_ACCOUNT}" \\
+    --project="\${BUILD_PROJECT}" \\
+    --service-account="projects/\${BUILD_PROJECT}/serviceAccounts/\${BUILDER_SA_EMAIL}" \\
     --config="\${PROJECT_ROOT}/cicd/cloudbuild-apply.yaml" \\
     --substitutions="_TF_ACTION=apply,$(_tf_substitutions),_IMAGE=__placeholder__" \\
     --quiet
@@ -802,39 +1313,81 @@ app_undeploy() {
   log_ok "Application undeployed (Cloud Run reverted to placeholder)"
 }
 
-clean() {
-  log_info "Tearing down cloud resources (\${ENVIRONMENT})..."
+# ─── cloud-clean ──────────────────────────────────────────────────────
+# TF destroy. Removes runtime resources (Cloud Run, runtime SA, LB/DNS).
+# Does NOT remove bootstrap state (use admin-cloud-destroy for that).
+
+cloud_clean() {
+  log_warn "Tearing down runtime infrastructure (\${ENVIRONMENT})..."
   require_cmd gcloud
+  _require_topology
 
-  [[ -z "\${GCP_PROJECT}" ]] && die "GCP_PROJECT is not set. Add to config.toml or .env"
-  [[ -z "\${TF_STATE_BUCKET}" ]] && die "TF_STATE_BUCKET is not set. Add to config.toml or .env"
-
-  if ! confirm "This will destroy cloud infrastructure for \${ENVIRONMENT}. Continue?"; then
-    log_warn "Aborted."
-    exit 0
+  if [[ "\${CONFIRM:-}" != "yes" ]]; then
+    confirm "Destroy runtime infrastructure for \${ENVIRONMENT}?" \\
+      || { log_warn "Aborted."; exit 0; }
   fi
 
   gcloud builds submit "\${PROJECT_ROOT}" \\
-    --project="\${CB_PROJECT}" \\
-    --service-account="projects/\${CB_PROJECT}/serviceAccounts/\${CB_SERVICE_ACCOUNT}" \\
+    --project="\${BUILD_PROJECT}" \\
+    --service-account="projects/\${BUILD_PROJECT}/serviceAccounts/\${BUILDER_SA_EMAIL}" \\
     --config="\${PROJECT_ROOT}/cicd/cloudbuild-apply.yaml" \\
     --substitutions="_TF_ACTION=destroy,$(_tf_substitutions)" \\
     --quiet
 
-  log_ok "Cloud resources destroyed (\${ENVIRONMENT})"
+  log_ok "Runtime infrastructure destroyed."
+}
+
+# ─── cloud-status / cloud-recover ─────────────────────────────────────
+
+cloud_status() {
+  # Show heartbeat for the most-likely active actions. cloud-status is
+  # diagnostic; it never mutates.
+  for action in admin-cloud-init admin-cloud-destroy cloud-infra cloud-clean cloud-app-deploy; do
+    printf '  %-22s %s\\n' "\${action}" "$(heartbeat_status "\${action}")"
+  done
+}
+
+cloud_recover() {
+  echo "Recovery state for all known actions:"
+  for action in admin-cloud-init admin-cloud-destroy cloud-infra cloud-clean cloud-app-deploy; do
+    echo ""
+    echo "[\${action}]"
+    recovery_summary "\${action}"
+  done
+}
+
+# Compatibility: legacy verbs from the pre-#141 scaffold. Stub out with a
+# helpful message rather than silently breaking downstream Makefiles that
+# someone forgot to update. This is the only back-compat — config and TF
+# are clean breaks.
+_legacy_stub() {
+  local old="\$1" new="\$2"
+  die "Verb '\${old}' has been removed. Use 'make \${new}' (three-role topology, #141)."
 }
 
 # ─── Dispatch ─────────────────────────────────────────────────────────
 
 case "\${1:-}" in
-  init)         init ;;
-  init-prod)    init_prod ;;
-  infra)        infra ;;
-  app-deploy)   app_deploy ;;
-  app-promote)  app_promote ;;
-  app-undeploy) app_undeploy ;;
-  clean)        clean ;;
-  *)            die "Usage: $0 {init|init-prod|infra|app-deploy|app-promote|app-undeploy|clean}" ;;
+  help|cloud-help)        help_cmd ;;
+  admin-cloud-init)       admin_cloud_init ;;
+  admin-cloud-destroy)    admin_cloud_destroy ;;
+  cloud-preflight)        cloud_preflight ;;
+  cloud-infra)            cloud_infra ;;
+  cloud-app-deploy)       cloud_app_deploy ;;
+  cloud-app-promote)      cloud_app_promote ;;
+  cloud-app-undeploy)     cloud_app_undeploy ;;
+  cloud-clean)            cloud_clean ;;
+  cloud-status)           cloud_status ;;
+  cloud-recover)          cloud_recover ;;
+  # Removed legacy verbs (#141 — breaking change). Stub with a clear redirect.
+  init)         _legacy_stub init admin-cloud-init ;;
+  init-prod)    _legacy_stub init-prod admin-cloud-init ;;
+  infra)        _legacy_stub infra cloud-infra ;;
+  app-deploy)   _legacy_stub app-deploy cloud-app-deploy ;;
+  app-promote)  _legacy_stub app-promote cloud-app-promote ;;
+  app-undeploy) _legacy_stub app-undeploy cloud-app-undeploy ;;
+  clean)        _legacy_stub clean cloud-clean ;;
+   *) die "Usage: $0 {help|admin-cloud-init|admin-cloud-destroy|cloud-preflight|cloud-infra|cloud-app-deploy|cloud-app-promote|cloud-app-undeploy|cloud-clean|cloud-status|cloud-recover}" ;;
 esac
 `
 }
@@ -1028,47 +1581,33 @@ options:
 `
 }
 
-function generateCloudbuildPlanYaml(): string {
-  return `# Terraform plan pipeline
-# Triggered by: pull request events
-# Runs terraform init + plan and outputs the plan for review
-steps:
-  # Initialize Terraform
-  - name: 'hashicorp/terraform:1.14'
-    dir: 'cicd/terraform'
-    args:
-      - 'init'
-      - '-backend-config=bucket=\${_TF_STATE_BUCKET}'
-      - '-backend-config=prefix=\${_TF_STATE_PREFIX}'
-    env:
-      - 'TF_IN_AUTOMATION=true'
-
-  # Run plan (or custom action)
-  - name: 'hashicorp/terraform:1.14'
-    dir: 'cicd/terraform'
-    args:
-      - '\${_TF_ACTION}'
-      - '-no-color'
-      - '-input=false'
-    env:
-      - 'TF_IN_AUTOMATION=true'
-      - 'TF_VAR_project_id=\${_PROJECT_ID}'
-      - 'TF_VAR_region=\${_REGION}'
+function _tfEnvBlock(): string {
+  // Shared TF_VAR_* env block for both plan and apply pipelines.
+  // Three-role topology: each role's project + region is passed
+  // through. When all three resolve to the same value, the provider
+  // aliases become functional duplicates (zero overhead).
+  return `      - 'TF_VAR_orchestration_project_id=\${_ORCH_PROJECT_ID}'
+      - 'TF_VAR_orchestration_region=\${_REGION}'
+      - 'TF_VAR_build_project_id=\${_BUILD_PROJECT_ID}'
+      - 'TF_VAR_build_region=\${_REGION}'
+      - 'TF_VAR_runtime_project_id=\${_RUNTIME_PROJECT_ID}'
+      - 'TF_VAR_runtime_region=\${_REGION}'
       - 'TF_VAR_service_name=\${_SERVICE_NAME}'
       - 'TF_VAR_image=\${_IMAGE}'
       - 'TF_VAR_domain=\${_DOMAIN}'
       - 'TF_VAR_min_instances=\${_MIN_INSTANCES}'
       - 'TF_VAR_max_instances=\${_MAX_INSTANCES}'
-      - 'TF_VAR_cb_service_account=\${_CB_SERVICE_ACCOUNT}'
+      - 'TF_VAR_builder_sa_email=\${_BUILDER_SA_EMAIL}'
       - 'TF_VAR_runtime_sa_name=\${_RUNTIME_SA_NAME}'
+      - 'TF_VAR_ar_repo=\${_SERVICE_NAME}'
       - 'TF_VAR_dns_project_id=\${_DNS_PROJECT_ID}'
       - 'TF_VAR_dns_managed_zone=\${_DNS_MANAGED_ZONE}'
       - 'TF_VAR_dns_record_name=\${_DNS_RECORD_NAME}'
-      - 'TF_VAR_cb_project=\${_CB_PROJECT_ID}'
-      - 'TF_VAR_ingress=\${_INGRESS}'
+      - 'TF_VAR_ingress=\${_INGRESS}'`
+}
 
-substitutions:
-  _TF_ACTION: 'plan'
+function _tfSubstitutionsBlock(defaultAction: string): string {
+  return `  _TF_ACTION: '${defaultAction}'
   _TF_STATE_BUCKET: ''
   _TF_STATE_PREFIX: 'app'
   _REGION: 'us-central1'
@@ -1077,26 +1616,23 @@ substitutions:
   _DOMAIN: ''
   _MIN_INSTANCES: '0'
   _MAX_INSTANCES: '3'
-  _CB_SERVICE_ACCOUNT: ''
+  _BUILDER_SA_EMAIL: ''
   _RUNTIME_SA_NAME: 'app-runtime'
   _DNS_PROJECT_ID: ''
   _DNS_MANAGED_ZONE: ''
   _DNS_RECORD_NAME: ''
-  _CB_PROJECT_ID: ''
-  _PROJECT_ID: ''
-  _INGRESS: 'all'
-
-options:
-  logging: CLOUD_LOGGING_ONLY
-`
+  _ORCH_PROJECT_ID: ''
+  _BUILD_PROJECT_ID: ''
+  _RUNTIME_PROJECT_ID: ''
+  _INGRESS: 'all'`
 }
 
-function generateCloudbuildApplyYaml(): string {
-  return `# Terraform apply pipeline
-# Triggered by: merge to main branch
-# Runs terraform init + apply (or destroy) with auto-approve
+function generateCloudbuildPlanYaml(): string {
+  return `# Terraform plan pipeline (three-role topology, #141)
+# Triggered by: pull request events
+# Runs terraform init + plan and outputs the plan for review.
+# Builder SA runs in build project; provisions runtime-project resources.
 steps:
-  # Initialize Terraform
   - name: 'hashicorp/terraform:1.14'
     dir: 'cicd/terraform'
     args:
@@ -1106,7 +1642,39 @@ steps:
     env:
       - 'TF_IN_AUTOMATION=true'
 
-  # Apply (or destroy)
+  - name: 'hashicorp/terraform:1.14'
+    dir: 'cicd/terraform'
+    args:
+      - '\${_TF_ACTION}'
+      - '-no-color'
+      - '-input=false'
+    env:
+      - 'TF_IN_AUTOMATION=true'
+${_tfEnvBlock()}
+
+substitutions:
+${_tfSubstitutionsBlock('plan')}
+
+options:
+  logging: CLOUD_LOGGING_ONLY
+`
+}
+
+function generateCloudbuildApplyYaml(): string {
+  return `# Terraform apply pipeline (three-role topology, #141)
+# Triggered by: merge to main branch.
+# Runs terraform init + apply (or destroy) with auto-approve.
+# Builder SA runs in build project; provisions runtime-project resources.
+steps:
+  - name: 'hashicorp/terraform:1.14'
+    dir: 'cicd/terraform'
+    args:
+      - 'init'
+      - '-backend-config=bucket=\${_TF_STATE_BUCKET}'
+      - '-backend-config=prefix=\${_TF_STATE_PREFIX}'
+    env:
+      - 'TF_IN_AUTOMATION=true'
+
   - name: 'hashicorp/terraform:1.14'
     dir: 'cicd/terraform'
     args:
@@ -1116,39 +1684,10 @@ steps:
       - '-input=false'
     env:
       - 'TF_IN_AUTOMATION=true'
-      - 'TF_VAR_project_id=\${_PROJECT_ID}'
-      - 'TF_VAR_region=\${_REGION}'
-      - 'TF_VAR_service_name=\${_SERVICE_NAME}'
-      - 'TF_VAR_image=\${_IMAGE}'
-      - 'TF_VAR_domain=\${_DOMAIN}'
-      - 'TF_VAR_min_instances=\${_MIN_INSTANCES}'
-      - 'TF_VAR_max_instances=\${_MAX_INSTANCES}'
-      - 'TF_VAR_cb_service_account=\${_CB_SERVICE_ACCOUNT}'
-      - 'TF_VAR_runtime_sa_name=\${_RUNTIME_SA_NAME}'
-      - 'TF_VAR_dns_project_id=\${_DNS_PROJECT_ID}'
-      - 'TF_VAR_dns_managed_zone=\${_DNS_MANAGED_ZONE}'
-      - 'TF_VAR_dns_record_name=\${_DNS_RECORD_NAME}'
-      - 'TF_VAR_cb_project=\${_CB_PROJECT_ID}'
-      - 'TF_VAR_ingress=\${_INGRESS}'
+${_tfEnvBlock()}
 
 substitutions:
-  _TF_ACTION: 'apply'
-  _TF_STATE_BUCKET: ''
-  _TF_STATE_PREFIX: 'app'
-  _REGION: 'us-central1'
-  _SERVICE_NAME: 'app'
-  _IMAGE: ''
-  _DOMAIN: ''
-  _MIN_INSTANCES: '0'
-  _MAX_INSTANCES: '3'
-  _CB_SERVICE_ACCOUNT: ''
-  _RUNTIME_SA_NAME: 'app-runtime'
-  _DNS_PROJECT_ID: ''
-  _DNS_MANAGED_ZONE: ''
-  _DNS_RECORD_NAME: ''
-  _CB_PROJECT_ID: ''
-  _PROJECT_ID: ''
-  _INGRESS: 'all'
+${_tfSubstitutionsBlock('apply')}
 
 options:
   logging: CLOUD_LOGGING_ONLY
@@ -1174,40 +1713,64 @@ function generateTfProviders(): string {
       source  = "hashicorp/random"
       version = "~> 3.0"
     }
-    time = {
-      source  = "hashicorp/time"
-      version = "~> 0.9"
-    }
   }
 }
 
+# ─── Three-role provider aliases (issue #141) ────────────────────────
+#
+# Each role gets a named provider alias. When all three roles resolve to
+# the same project (the 90% case), the aliases are functionally
+# identical — zero overhead. Splitting one or more roles later is a
+# config edit (TF_VAR_<role>_project_id), not a refactor.
+#
+# Resources opt into the alias for the role whose project owns them:
+#
+#   - Runtime resources (google_service_account.runtime,
+#     google_cloud_run_v2_service.app, LB/DNS in runtime project,
+#     run.invoker bindings) use provider = google.runtime.
+#   - Cross-project reads of build-project resources (AR repo)
+#     use provider = google.build.
+#   - Orchestration-project resources (if any: future agent SA
+#     management from TF, etc.) use provider = google.orchestration.
+#
+# Default (un-aliased) google provider points at the runtime project —
+# matches the common case where most resources live there.
+
 provider "google" {
-  project = var.project_id
-  region  = var.region
+  project = var.runtime_project_id
+  region  = var.runtime_region
 }
 
 provider "google-beta" {
-  project = var.project_id
-  region  = var.region
+  project = var.runtime_project_id
+  region  = var.runtime_region
 }
 
-# DNS provider alias — scoped to the (separate) DNS project that owns the
-# managed zone. Used only by resources in dns.tf when the LB+DNS stack is
-# enabled. Safe to leave configured with an empty project_id when disabled,
-# because no resources reference it in that case.
+provider "google" {
+  alias   = "orchestration"
+  project = var.orchestration_project_id
+  region  = var.orchestration_region
+}
+
+provider "google" {
+  alias   = "build"
+  project = var.build_project_id
+  region  = var.build_region
+}
+
+provider "google" {
+  alias   = "runtime"
+  project = var.runtime_project_id
+  region  = var.runtime_region
+}
+
+# DNS provider alias — scoped to the (separate) DNS project that owns
+# the managed zone. Used only by resources in dns.tf when the LB+DNS
+# stack is enabled. Safe to leave configured with an empty project_id
+# when disabled — no resources reference it in that case.
 provider "google" {
   alias   = "dns"
   project = var.dns_project_id
-}
-
-# Cloud Build project provider alias — scoped to the project that hosts the
-# deployer SA, the AR repo, and the TF state bucket. For the primary env
-# (staging) this equals var.project_id. For secondary envs (e.g. prod) it
-# differs, and is used to write the cross-project Artifact Registry reader
-# binding so the prod runtime SA can pull promoted images from staging's AR.
-provider "google" {
-  alias   = "cb_project"
-  project = var.cb_project
 }
 `
 }
@@ -1224,25 +1787,55 @@ terraform {
 }
 
 function generateTfVariables(): string {
-  return `variable "project_id" {
-  description = "GCP project ID"
+  return `# ─── Three-role topology (issue #141) ────────────────────────────────
+# Each role's project + region is a separate variable. When all three
+# resolve to the same value, the role split is invisible at the TF level
+# (the provider aliases become functional duplicates). Splitting later
+# is just a TF_VAR_<role>_project_id change.
+
+variable "orchestration_project_id" {
+  description = "Orchestration project — where the agent SA lives (operator identity)."
   type        = string
 }
 
-variable "region" {
-  description = "GCP region for resources"
+variable "orchestration_region" {
+  description = "Region for orchestration-project resources (rare; provided for symmetry)."
   type        = string
   default     = "us-central1"
 }
 
+variable "build_project_id" {
+  description = "Build project — hosts the builder SA, Cloud Build, Artifact Registry, TF state bucket."
+  type        = string
+}
+
+variable "build_region" {
+  description = "Region for build-project resources (AR repo, TF state bucket)."
+  type        = string
+  default     = "us-central1"
+}
+
+variable "runtime_project_id" {
+  description = "Runtime project — hosts the runtime SA and Cloud Run service. Also the default provider's project."
+  type        = string
+}
+
+variable "runtime_region" {
+  description = "Region for runtime-project resources (Cloud Run, LB/DNS)."
+  type        = string
+  default     = "us-central1"
+}
+
+# ─── Service config ──────────────────────────────────────────────────
+
 variable "service_name" {
-  description = "Name of the Cloud Run service and related resources"
+  description = "Name of the Cloud Run service and related resources."
   type        = string
   default     = "app"
 }
 
 variable "image" {
-  description = "Container image to deploy. When empty, Cloud Run uses a placeholder image (us-docker.pkg.dev/cloudrun/container/hello:latest) until the real app is deployed via cloud-app-deploy."
+  description = "Container image to deploy. When empty (or the __placeholder__ sentinel), Cloud Run uses the upstream hello-world image until cloud-app-deploy is run."
   type        = string
   default     = ""
 }
@@ -1254,27 +1847,43 @@ variable "domain" {
 }
 
 variable "min_instances" {
-  description = "Minimum number of Cloud Run instances"
+  description = "Minimum number of Cloud Run instances."
   type        = number
   default     = 0
 }
 
 variable "max_instances" {
-  description = "Maximum number of Cloud Run instances"
+  description = "Maximum number of Cloud Run instances."
   type        = number
   default     = 3
 }
 
-variable "cb_service_account" {
-  description = "Cloud Build deployer service account email for IAM management"
+variable "ingress" {
+  description = "Cloud Run ingress mode. 'all' allows public *.run.app traffic. 'internal-and-cloud-load-balancing' locks ingress to the external HTTPS LB / internal VPC sources."
+  type        = string
+  default     = "all"
+}
+
+# ─── Service accounts ────────────────────────────────────────────────
+
+variable "builder_sa_email" {
+  description = "Builder SA email (Cloud Build identity that runs this Terraform). Created by admin-cloud-init. Referenced for cross-project AR reader binding."
   type        = string
 }
 
 variable "runtime_sa_name" {
-  description = "Short name for the Cloud Run runtime service account"
+  description = "Short name for the Cloud Run runtime service account. Created by Terraform in the runtime project."
   type        = string
   default     = "app-runtime"
 }
+
+variable "ar_repo" {
+  description = "Artifact Registry repository ID in the build project (created by admin-cloud-init; read by TF via data source)."
+  type        = string
+  default     = "app"
+}
+
+# ─── DNS / LB stack (opt-in) ─────────────────────────────────────────
 
 variable "dns_project_id" {
   description = "GCP project ID hosting the Cloud DNS managed zone (separate per env). Empty disables LB+DNS stack."
@@ -1283,228 +1892,75 @@ variable "dns_project_id" {
 }
 
 variable "dns_managed_zone" {
-  description = "GCP resource name (not DNS name) of the existing managed zone, e.g. 'kunall-demo-altostrat-com'"
+  description = "GCP resource name (not DNS name) of the existing managed zone, e.g. 'kunall-demo-altostrat-com'."
   type        = string
   default     = ""
 }
 
 variable "dns_record_name" {
-  description = "FQDN with trailing dot for the A record, e.g. 'app.example.com.'"
+  description = "FQDN with trailing dot for the A record, e.g. 'app.example.com.'."
   type        = string
   default     = ""
-}
-
-variable "cb_project" {
-  description = "Cloud Build project ID (where deployer SA + AR repo live). Equals project_id for the primary env; differs for secondary envs (e.g. prod)."
-  type        = string
-}
-
-variable "ingress" {
-  description = "Cloud Run ingress mode. 'all' allows public *.run.app traffic. 'internal-and-cloud-load-balancing' locks ingress to the external HTTPS LB / internal VPC sources."
-  type        = string
-  default     = "all"
 }
 `
 }
 
 function generateTfMain(): string {
-  return `# ─── GCP API Enablement ──────────────────────────────────────────────
+  return `# ─── Resource construction only (issue #141 lesson 1) ────────────────
 #
-# APIs are enabled in two phases to break a chicken-and-egg cycle:
+# This Terraform NEVER does any of the following:
 #
-#   1. \`bootstrap_apis\` — enables the meta-APIs (serviceusage, iam,
-#      cloudresourcemanager) that all subsequent gcloud/TF calls need.
-#      No \`depends_on\` — these MUST come first. Without serviceusage
-#      enabled, the project_iam_member bindings below would 403.
+#   * Enable APIs (google_project_service).  --> admin-cloud-init does this.
+#   * Grant project-wide IAM to the builder SA.  --> admin-cloud-init does this.
+#   * Create the Artifact Registry repo.  --> admin-cloud-init does this.
+#   * Create the Terraform state bucket.  --> admin-cloud-init does this.
 #
-#   2. \`apis\` — enables the runtime APIs (run, artifactregistry,
-#      cloudbuild, compute). Depends on \`time_sleep.wait_for_iam\` so
-#      the deployer SA's IAM has propagated before TF tries to operate
-#      on those APIs through it.
+# Why: doing any of those above requires the builder SA to hold
+# \`projectIamAdmin\` and \`serviceUsageAdmin\` — which defeats the
+# agent's least-privilege custom-role model. The agent can impersonate
+# the builder via Cloud Build, so anything granted to the builder
+# becomes part of the agent's effective authority.
 #
-# This split is what makes a brand-new-project apply work without any
-# prior gcloud bootstrap. Previously the whole \`apis\` set depended on
-# IAM bindings whose grants needed serviceusage already on, so the only
-# reason apply succeeded was that cloud-init Steps 1–4 had already
-# enabled serviceusage via gcloud.
-
-resource "google_project_service" "bootstrap_apis" {
-  for_each = toset([
-    "serviceusage.googleapis.com",
-    "iam.googleapis.com",
-    "cloudresourcemanager.googleapis.com",
-  ])
-  project            = var.project_id
-  service            = each.value
-  disable_on_destroy = false
-}
-
-resource "google_project_service" "apis" {
-  for_each = toset([
-    "run.googleapis.com",
-    "artifactregistry.googleapis.com",
-    "cloudbuild.googleapis.com",
-    "compute.googleapis.com",
-  ])
-  service            = each.value
-  disable_on_destroy = false
-
-  depends_on = [time_sleep.wait_for_iam]
-}
-
-# ─── Deployer SA: Functional roles (self-granted via projectIamAdmin) ──
+# Generated TF works with a builder SA that holds ONLY the 6 predefined
+# functional roles (see scripts/cloud.sh::_step_grant_builder_roles).
 #
-# All deployer IAM bindings depend on \`bootstrap_apis\` so the
-# serviceusage / iam / cloudresourcemanager APIs are guaranteed to be on
-# before the IAM API tries to write the binding (which would otherwise
-# 403 on a brand-new project).
+# Pre-existing build-project resources (AR repo) are read via \`data\`
+# sources. This makes the dependency on admin-cloud-init explicit at
+# PLAN time: a missing repo fails with a clear "data source not found"
+# error, instead of a confusing IAM error at apply time.
 
-resource "google_project_iam_member" "deployer_run_admin" {
-  project = var.project_id
-  role    = "roles/run.admin"
-  member  = "serviceAccount:\${var.cb_service_account}"
-
-  depends_on = [google_project_service.bootstrap_apis]
-}
-
-resource "google_project_iam_member" "deployer_ar_admin" {
-  project = var.project_id
-  role    = "roles/artifactregistry.admin"
-  member  = "serviceAccount:\${var.cb_service_account}"
-
-  depends_on = [google_project_service.bootstrap_apis]
-}
-
-resource "google_project_iam_member" "deployer_sa_user" {
-  project = var.project_id
-  role    = "roles/iam.serviceAccountUser"
-  member  = "serviceAccount:\${var.cb_service_account}"
-
-  depends_on = [google_project_service.bootstrap_apis]
-}
-
-# Self-escalation chain extenders. With these two grants, the deployer SA
-# can bootstrap the rest of its IAM purely from a single bootstrap role
-# (roles/resourcemanager.projectIamAdmin) granted on the project — needed
-# so secondary envs (prod) can be bootstrapped via cloud-init-prod with
-# just projectIamAdmin granted by the prod owner. On the primary env
-# (staging) these are idempotent no-ops because cloud-init Step 4 already
-# grants the same roles via gcloud.
-
-resource "google_project_iam_member" "deployer_serviceusage_admin" {
-  project = var.project_id
-  role    = "roles/serviceusage.serviceUsageAdmin"
-  member  = "serviceAccount:\${var.cb_service_account}"
-
-  depends_on = [google_project_service.bootstrap_apis]
-}
-
-resource "google_project_iam_member" "deployer_sa_creator" {
-  project = var.project_id
-  role    = "roles/iam.serviceAccountCreator"
-  member  = "serviceAccount:\${var.cb_service_account}"
-
-  depends_on = [google_project_service.bootstrap_apis]
-}
-
-# Compute network admin: required by the LB stack (global address, NEG,
-# SSL cert, URL map, target proxies, forwarding rules). Granted only when
-# the LB stack is enabled (gated by local.enable_lb).
-resource "google_project_iam_member" "deployer_network_admin" {
-  count   = local.enable_lb ? 1 : 0
-  project = var.project_id
-  role    = "roles/compute.networkAdmin"
-  member  = "serviceAccount:\${var.cb_service_account}"
-
-  depends_on = [google_project_service.bootstrap_apis]
-}
-
-# Compute LB admin: required by the LB stack (backend services, URL maps,
-# SSL certificates, target proxies, forwarding rules, serverless NEGs).
-# Granted only when the LB stack is enabled (gated by local.enable_lb).
-resource "google_project_iam_member" "deployer_lb_admin" {
-  count   = local.enable_lb ? 1 : 0
-  project = var.project_id
-  role    = "roles/compute.loadBalancerAdmin"
-  member  = "serviceAccount:\${var.cb_service_account}"
-
-  depends_on = [google_project_service.bootstrap_apis]
-}
-
-# ─── Wait for IAM propagation ───────────────────────────────
-# GCP IAM changes take 60-120s to propagate across regions/services.
-# Resources that depend on the deployer SA's functional roles must wait
-# for propagation, otherwise they hit eventual-consistency 403s.
+# ─── Pre-existing AR repo (read-only) ────────────────────────────────
 #
-# IMPORTANT: \`time_sleep\` only sleeps on create or when one of its OWN
-# attributes (triggers, create_duration, destroy_duration) changes.
-# Adding bindings to \`depends_on\` does NOT re-trigger the wait.
-#
-# We key \`triggers\` on the SORTED SET OF ROLES granted (not on the
-# binding resource IDs). This is intentional for idempotency: a
-# conditional binding flipping in/out (e.g., LB admin appearing when
-# the LB stack is enabled) re-keys an ID-based trigger and forces a
-# spurious 120s wait on every apply that touches IAM. Keying on the
-# role set means the sleep only re-fires when the set of roles
-# actually changes — which is the only case where propagation needs
-# to be re-awaited.
+# Created by admin-cloud-init in the build project. Referenced by:
+#   - The cross-project runtime-SA reader binding below.
+#   - LB/DNS outputs (image URI computation).
 
-resource "time_sleep" "wait_for_iam" {
-  depends_on = [
-    google_project_iam_member.deployer_run_admin,
-    google_project_iam_member.deployer_ar_admin,
-    google_project_iam_member.deployer_sa_user,
-    google_project_iam_member.deployer_serviceusage_admin,
-    google_project_iam_member.deployer_sa_creator,
-    google_project_iam_member.deployer_network_admin,
-    google_project_iam_member.deployer_lb_admin,
-  ]
-
-  triggers = {
-    iam_roles = sha256(jsonencode(sort(compact([
-      "roles/run.admin",
-      "roles/artifactregistry.admin",
-      "roles/iam.serviceAccountUser",
-      "roles/serviceusage.serviceUsageAdmin",
-      "roles/iam.serviceAccountCreator",
-      local.enable_lb ? "roles/compute.networkAdmin" : "",
-      local.enable_lb ? "roles/compute.loadBalancerAdmin" : "",
-    ]))))
-  }
-
-  create_duration = "120s"
+data "google_artifact_registry_repository" "app" {
+  provider      = google.build
+  project       = var.build_project_id
+  location      = var.build_region
+  repository_id = var.ar_repo
 }
 
 # ─── Runtime SA: Cloud Run application identity ─────────────────────
+#
+# Created in the runtime project. This IS owned by Terraform — it's an
+# application-identity resource, not a deploy-plane resource.
 
 resource "google_service_account" "runtime" {
+  provider     = google.runtime
   account_id   = var.runtime_sa_name
   display_name = "\${var.service_name} Cloud Run Runtime"
-  project      = var.project_id
-
-  depends_on = [google_project_service.apis]
-}
-
-# ─── Artifact Registry ────────────────────────────────────────────────
-
-resource "google_artifact_registry_repository" "app" {
-  depends_on = [
-    google_project_service.apis,
-    time_sleep.wait_for_iam,
-  ]
-
-  location      = var.region
-  repository_id = var.service_name
-  format        = "DOCKER"
-  description   = "Container images for \${var.service_name}"
-  labels        = { app = var.service_name }
+  project      = var.runtime_project_id
 }
 
 # ─── Cloud Run Service ───────────────────────────────────────────────
 
 resource "google_cloud_run_v2_service" "app" {
+  provider = google.runtime
+  project  = var.runtime_project_id
   name     = var.service_name
-  location = var.region
+  location = var.runtime_region
   labels   = { app = var.service_name }
 
   # Ingress mode is configurable. Set var.ingress to
@@ -1519,7 +1975,7 @@ resource "google_cloud_run_v2_service" "app" {
     labels          = { app = var.service_name }
 
     containers {
-      # The \`__placeholder__\` sentinel is passed by \`cloud.sh app-undeploy\`
+      # The \`__placeholder__\` sentinel is passed by \`cloud.sh cloud-app-undeploy\`
       # to revert the service to the upstream hello-world image without
       # tearing down the Cloud Run resource. We treat it (and the empty
       # string, for safety) the same as "no image specified".
@@ -1543,19 +1999,14 @@ resource "google_cloud_run_v2_service" "app" {
     percent = 100
     type    = "TRAFFIC_TARGET_ALLOCATION_TYPE_LATEST"
   }
-
-  depends_on = [
-    google_project_service.apis,
-    time_sleep.wait_for_iam,
-  ]
 }
 
 # ─── IAM: Allow unauthenticated access (public service) ─────────────
-# Remove this block if the service should require authentication.
+# Bound on Terraform's own resource (the Cloud Run service), not on the
+# project. Remove this block if the service should require authentication.
 
 resource "google_cloud_run_v2_service_iam_member" "public" {
-  depends_on = [time_sleep.wait_for_iam]
-
+  provider = google.runtime
   project  = google_cloud_run_v2_service.app.project
   location = google_cloud_run_v2_service.app.location
   name     = google_cloud_run_v2_service.app.name
@@ -1563,44 +2014,26 @@ resource "google_cloud_run_v2_service_iam_member" "public" {
   member   = "allUsers"
 }
 
-# ─── Cross-project AR access (secondary envs only) ──────────────────
+# ─── Cross-project AR access (when runtime != build project) ────────
 #
-# When this env's runtime project differs from the CB project (i.e., this
-# is a secondary env like prod), the runtime SA needs read access to the
-# primary env's AR repo to pull promoted images. The deployer SA already
-# has artifactregistry.admin on CB_PROJECT (granted by the primary env's
-# TF state via the existing deployer_ar_admin resource), so this binding
-# is authorized to write through the google.cb_project provider alias.
+# When the runtime project differs from the build project (production
+# tenancy pattern), the runtime SA needs read access to the build
+# project's AR repo to pull images. Bound on the AR repo (Terraform's
+# resource visibility via the data source), not on the project.
 #
-# On the primary env (staging) where project_id == cb_project, the
-# binding is skipped — the runtime SA already has access via in-project
-# IAM granted elsewhere.
-#
-# We resolve the repo via a \`data\` source instead of hardcoding
-# \`repository = var.service_name\`. This catches misconfiguration (typo,
-# the primary env not yet bootstrapped, repo renamed out from under us)
-# at PLAN time with a clear "data source not found" error, rather than
-# at apply time with a confusing IAM-binding error against a phantom
-# resource.
+# When runtime == build, the binding is skipped — runtime SA already has
+# implicit access by virtue of living in the same project as the repo.
 
 locals {
-  is_secondary_env = var.project_id != var.cb_project
-}
-
-data "google_artifact_registry_repository" "primary" {
-  count         = local.is_secondary_env ? 1 : 0
-  provider      = google.cb_project
-  project       = var.cb_project
-  location      = var.region
-  repository_id = var.service_name
+  cross_project_ar = var.runtime_project_id != var.build_project_id
 }
 
 resource "google_artifact_registry_repository_iam_member" "runtime_ar_reader" {
-  count      = local.is_secondary_env ? 1 : 0
-  provider   = google.cb_project
-  project    = var.cb_project
-  location   = var.region
-  repository = data.google_artifact_registry_repository.primary[0].repository_id
+  count      = local.cross_project_ar ? 1 : 0
+  provider   = google.build
+  project    = var.build_project_id
+  location   = var.build_region
+  repository = data.google_artifact_registry_repository.app.repository_id
   role       = "roles/artifactregistry.reader"
   member     = "serviceAccount:\${google_service_account.runtime.email}"
 }
@@ -1613,9 +2046,23 @@ function generateTfOutputs(): string {
   value       = google_cloud_run_v2_service.app.uri
 }
 
+output "runtime_sa_email" {
+  description = "Runtime SA email (Cloud Run app identity)."
+  value       = google_service_account.runtime.email
+}
+
 output "artifact_registry_repo" {
-  description = "Artifact Registry repository URL"
-  value       = "\${var.region}-docker.pkg.dev/\${var.project_id}/\${google_artifact_registry_repository.app.repository_id}"
+  description = "Artifact Registry repository URL (in the build project)."
+  value       = "\${var.build_region}-docker.pkg.dev/\${var.build_project_id}/\${data.google_artifact_registry_repository.app.repository_id}"
+}
+
+output "topology" {
+  description = "Resolved three-role topology — useful for cloud-help output."
+  value = {
+    orchestration = var.orchestration_project_id
+    build         = var.build_project_id
+    runtime       = var.runtime_project_id
+  }
 }
 
 # ─── External HTTPS LB / DNS outputs ─────────────────────────────────
@@ -1650,30 +2097,15 @@ output "ssl_cert_name" {
 function generateTfLb(): string {
   return `# ─── External HTTPS Load Balancer in front of Cloud Run ──────────────
 #
-# IMPORTANT: This file defines \`local.enable_lb\` and
-# \`google_compute_global_address.lb_ip\`, which are referenced from
-# dns.tf and from the lb_ip / dns_fqdn / ssl_cert_name outputs in
-# outputs.tf. Do NOT delete this file to "disable the LB stack" — that
-# breaks dns.tf and the outputs with confusing
-# "local does not exist" / "resource not declared" errors.
+# All resources here live in the RUNTIME project (var.runtime_project_id)
+# and use provider = google.runtime. They're gated by local.enable_lb.
 #
-# To disable the LB+DNS stack, leave the four gating variables empty in
-# your tfvars / Cloud Build substitutions (var.domain,
-# var.dns_project_id, var.dns_managed_zone, var.dns_record_name). All
-# resources here use \`count = local.enable_lb ? 1 : 0\` and become inert
-# when the gates are unset.
-#
-# Architecture:
-#   client → reserved IPv4 (anycast) → global external HTTPS LB
-#          → serverless NEG → Cloud Run
+# To disable the LB+DNS stack, leave the four gating variables empty
+# (var.domain, var.dns_project_id, var.dns_managed_zone, var.dns_record_name).
 #
 # To force traffic through the LB only, set var.ingress to
 # "internal-and-cloud-load-balancing" — then direct *.run.app hits return
 # 403 and the LB becomes the only public entry point.
-#
-# All resources are gated by \`local.enable_lb\`. When any of dns_project_id /
-# dns_managed_zone / dns_record_name / domain are empty, no LB resources
-# are created — the stack is opt-in.
 
 locals {
   enable_lb = (
@@ -1686,78 +2118,71 @@ locals {
 
 # 1. Reserved global IPv4 — the anycast IP advertised in DNS.
 resource "google_compute_global_address" "lb_ip" {
-  count   = local.enable_lb ? 1 : 0
-  name    = "\${var.service_name}-lb-ip"
-  project = var.project_id
-
-  depends_on = [google_project_service.apis, time_sleep.wait_for_iam]
+  count    = local.enable_lb ? 1 : 0
+  provider = google.runtime
+  name     = "\${var.service_name}-lb-ip"
+  project  = var.runtime_project_id
 }
 
 # 2. Serverless NEG → Cloud Run. The NEG itself is free.
 resource "google_compute_region_network_endpoint_group" "cloud_run_neg" {
   count                 = local.enable_lb ? 1 : 0
+  provider              = google.runtime
   name                  = "\${var.service_name}-neg"
   network_endpoint_type = "SERVERLESS"
-  region                = var.region
-  project               = var.project_id
+  region                = var.runtime_region
+  project               = var.runtime_project_id
 
   cloud_run {
     service = google_cloud_run_v2_service.app.name
   }
-
-  depends_on = [google_project_service.apis, time_sleep.wait_for_iam]
 }
 
 # 3. Backend service. No health check needed for serverless NEGs.
 resource "google_compute_backend_service" "app" {
   count                 = local.enable_lb ? 1 : 0
+  provider              = google.runtime
   name                  = "\${var.service_name}-backend"
-  project               = var.project_id
+  project               = var.runtime_project_id
   protocol              = "HTTPS"
   load_balancing_scheme = "EXTERNAL_MANAGED"
 
   backend {
     group = google_compute_region_network_endpoint_group.cloud_run_neg[0].id
   }
-
-  depends_on = [google_project_service.apis, time_sleep.wait_for_iam]
 }
 
 # 4. URL map for HTTPS traffic — routes everything to the backend.
 resource "google_compute_url_map" "https" {
   count           = local.enable_lb ? 1 : 0
+  provider        = google.runtime
   name            = "\${var.service_name}-https"
-  project         = var.project_id
+  project         = var.runtime_project_id
   default_service = google_compute_backend_service.app[0].id
-
-  depends_on = [google_project_service.apis, time_sleep.wait_for_iam]
 }
 
-# 5. Google-managed SSL cert (classic). Provisioning is asynchronous;
-#    the resource returns as soon as it's submitted (status PROVISIONING).
-#    Cert reaches ACTIVE 15-60 min after DNS resolves to the LB IP.
+# 5. Google-managed SSL cert (classic). Provisioning is asynchronous.
 resource "google_compute_managed_ssl_certificate" "app" {
-  count   = local.enable_lb ? 1 : 0
-  name    = "\${var.service_name}-cert"
-  project = var.project_id
+  count    = local.enable_lb ? 1 : 0
+  provider = google.runtime
+  name     = "\${var.service_name}-cert"
+  project  = var.runtime_project_id
 
   managed {
     domains = [var.domain]
   }
 
-  # Recreate cert if the domain list changes — old cert can't be reused.
   lifecycle {
     create_before_destroy = true
   }
-
-  depends_on = [google_project_service.apis, time_sleep.wait_for_iam]
 }
 
-# 6. Target HTTPS proxy — terminates TLS using the managed cert.
+# 6. Target HTTPS proxy.
 resource "google_compute_target_https_proxy" "app" {
   count            = local.enable_lb ? 1 : 0
+  provider         = google.runtime
   name             = "\${var.service_name}-https-proxy"
-  project          = var.project_id
+  project          = var.runtime_project_id
   url_map          = google_compute_url_map.https[0].id
   ssl_certificates = [google_compute_managed_ssl_certificate.app[0].id]
 }
@@ -1765,8 +2190,9 @@ resource "google_compute_target_https_proxy" "app" {
 # 7. Forwarding rule (443) — binds the reserved IP to the HTTPS proxy.
 resource "google_compute_global_forwarding_rule" "https" {
   count                 = local.enable_lb ? 1 : 0
+  provider              = google.runtime
   name                  = "\${var.service_name}-https-fr"
-  project               = var.project_id
+  project               = var.runtime_project_id
   target                = google_compute_target_https_proxy.app[0].id
   ip_address            = google_compute_global_address.lb_ip[0].id
   port_range            = "443"
@@ -1775,32 +2201,33 @@ resource "google_compute_global_forwarding_rule" "https" {
 
 # 8. URL map that 301-redirects all HTTP traffic to HTTPS.
 resource "google_compute_url_map" "http_redirect" {
-  count   = local.enable_lb ? 1 : 0
-  name    = "\${var.service_name}-http-redirect"
-  project = var.project_id
+  count    = local.enable_lb ? 1 : 0
+  provider = google.runtime
+  name     = "\${var.service_name}-http-redirect"
+  project  = var.runtime_project_id
 
   default_url_redirect {
     https_redirect         = true
     strip_query            = false
     redirect_response_code = "MOVED_PERMANENTLY_DEFAULT"
   }
-
-  depends_on = [google_project_service.apis, time_sleep.wait_for_iam]
 }
 
 # 9. Target HTTP proxy for the redirect URL map.
 resource "google_compute_target_http_proxy" "app" {
-  count   = local.enable_lb ? 1 : 0
-  name    = "\${var.service_name}-http-proxy"
-  project = var.project_id
-  url_map = google_compute_url_map.http_redirect[0].id
+  count    = local.enable_lb ? 1 : 0
+  provider = google.runtime
+  name     = "\${var.service_name}-http-proxy"
+  project  = var.runtime_project_id
+  url_map  = google_compute_url_map.http_redirect[0].id
 }
 
 # 10. Forwarding rule (80) — same reserved IP, different port.
 resource "google_compute_global_forwarding_rule" "http" {
   count                 = local.enable_lb ? 1 : 0
+  provider              = google.runtime
   name                  = "\${var.service_name}-http-fr"
-  project               = var.project_id
+  project               = var.runtime_project_id
   target                = google_compute_target_http_proxy.app[0].id
   ip_address            = google_compute_global_address.lb_ip[0].id
   port_range            = "80"
@@ -1812,23 +2239,9 @@ resource "google_compute_global_forwarding_rule" "http" {
 function generateTfDns(): string {
   return `# ─── DNS A record (in separate DNS project) ──────────────────────────
 #
-# IMPORTANT: This file depends on \`local.enable_lb\` and
-# \`google_compute_global_address.lb_ip\`, both defined in lb.tf. Do NOT
-# delete lb.tf or dns.tf to "disable the LB+DNS stack" — that breaks
-# this file and the lb_ip / dns_fqdn / ssl_cert_name outputs with
-# confusing "local does not exist" errors.
-#
-# To disable the stack, leave the four gating variables empty in your
-# tfvars / Cloud Build substitutions (var.domain, var.dns_project_id,
-# var.dns_managed_zone, var.dns_record_name). All resources here use
-# \`count = local.enable_lb ? 1 : 0\` and become inert when the gates
-# are unset.
-#
 # Writes a single A record into a pre-existing managed zone owned by a
-# different GCP project (\`var.dns_project_id\`). The deployer SA must hold
-# \`roles/dns.admin\` on that project — granted via gcloud during
-# \`make cloud-init\` (see scripts/cloud.sh::init Step 6/6).
-#
+# different GCP project (var.dns_project_id). The builder SA must hold
+# roles/dns.admin on that project — granted by admin-cloud-init.
 # Terraform never owns the zone itself, only the record set.
 
 resource "google_dns_record_set" "app" {
@@ -1849,10 +2262,41 @@ resource "google_dns_record_set" "app" {
 
 function generateConfigPy(): string {
   return `#!/usr/bin/env python3
-"""Parse config.toml and emit shell variable assignments.
+"""Parse config.toml (role-axis + environment-axis) and emit shell exports.
 
-Reads [gcp.default] as base config, merges overrides from
-[gcp.{ENVIRONMENT}], and prints KEY='value' lines for eval.
+Resolution order (#141): env > role > defaults > error.
+
+Schema (#141):
+
+    [gcp.defaults]          # required catch-all (the 90% case)
+    project = "..."
+    region  = "..."
+
+    [gcp.orchestration]     # role override, empty => inherit defaults
+    project = ""
+    region  = ""
+
+    [gcp.build]             # role override
+    project = ""
+    region  = ""
+
+    [gcp.runtime]           # role override
+    project = ""
+    region  = ""
+
+Environment-axis layering (#115) is layered ON TOP of the role axis:
+
+    [gcp.production.runtime]
+    project = "acme-prod"   # only overrides runtime in production
+
+The active environment is selected via ENVIRONMENT env var (default: staging).
+
+The .env file is read by scripts/common.sh (NOT here); .env values
+override everything below at the shell level via export precedence.
+
+Same parser is the source of truth for shell scripts and Terraform.
+Terraform sees the resolved values as TF_VAR_* env vars set in the
+Cloud Build apply config.
 """
 
 import os
@@ -1873,76 +2317,139 @@ except ModuleNotFoundError:
         sys.exit(1)
 
 
+def _resolve(config: dict, env: str, role: str, key: str, default=None):
+    """Resolve a key with precedence: env-role > role > env > defaults > default.
+
+    Lookups (first hit wins):
+      [gcp.<env>.<role>].<key>
+      [gcp.<role>].<key>
+      [gcp.<env>].<key>
+      [gcp.defaults].<key>
+    """
+    gcp = config.get('gcp', {})
+    candidates = [
+        gcp.get(env, {}).get(role, {}).get(key),
+        gcp.get(role, {}).get(key),
+        gcp.get(env, {}).get(key),
+        gcp.get('defaults', {}).get(key),
+    ]
+    for v in candidates:
+        if v not in (None, ''):
+            return v
+    return default
+
+
+def _emit(name: str, value):
+    """Shell-quote a value and emit \`KEY='value'\` for eval."""
+    if value is None:
+        value = ''
+    s = str(value).replace("'", "'\\\\''")
+    print(f"{name}='{s}'")
+
+
 def main():
     config_path = os.path.join(os.path.dirname(__file__), '..', 'config.toml')
     if not os.path.exists(config_path):
-        print(f"echo 'ERROR: config.toml not found at {config_path}'",
-              file=sys.stderr)
-        sys.exit(1)
+        # No config.toml? Quiet exit — scripts/common.sh handles defaults.
+        return
 
     with open(config_path, 'rb') as f:
         config = tomllib.load(f)
 
     env = os.environ.get('ENVIRONMENT', 'staging')
 
-    # Project-level config
+    # ─── Project-level ─────────────────────────────────────────
     project = config.get('project', {})
     project_name = project.get('name', 'app')
 
-    # GCP defaults
-    defaults = config.get('gcp', {}).get('default', {})
-    tf_defaults = defaults.get('terraform', {})
+    _emit('ENVIRONMENT', env)
+    _emit('PROJECT_NAME', project_name)
 
-    # Environment overrides
-    env_overrides = config.get('gcp', {}).get(env, {})
+    # ─── Three-role topology ──────────────────────────────────
+    # Resolve each role's project + region with env > role > defaults precedence.
+    # Defaults must be set; otherwise resolution returns '' and the bash
+    # layer dies with a clear error.
+    orch_project    = _resolve(config, env, 'orchestration', 'project', '')
+    orch_region     = _resolve(config, env, 'orchestration', 'region',  '')
+    build_project   = _resolve(config, env, 'build',         'project', '')
+    build_region    = _resolve(config, env, 'build',         'region',  '')
+    runtime_project = _resolve(config, env, 'runtime',       'project', '')
+    runtime_region  = _resolve(config, env, 'runtime',       'region',  '')
 
-    # Merge: env overrides win
-    resolved = {**defaults, **env_overrides}
-    # Remove nested 'terraform' from resolved (handled separately)
-    resolved.pop('terraform', None)
+    if not _resolve(config, env, 'defaults', 'project'):
+        # The role axis tolerates empty roles ONLY when defaults is set.
+        # Surface this loudly: a single typo in [gcp.defaults] would
+        # silently produce three empty role projects.
+        print(
+            "echo 'ERROR: [gcp.defaults].project is required in config.toml "
+            "(role-axis topology requires a catch-all default)' >&2",
+            file=sys.stdout,
+        )
+        print("exit 1", file=sys.stdout)
+        sys.exit(1)
 
-    # Terraform config (no env override for terraform section)
-    tf_config = tf_defaults
+    _emit('ORCH_PROJECT',    orch_project)
+    _emit('ORCH_REGION',     orch_region)
+    _emit('BUILD_PROJECT',   build_project)
+    _emit('BUILD_REGION',    build_region)
+    _emit('RUNTIME_PROJECT', runtime_project)
+    _emit('RUNTIME_REGION',  runtime_region)
 
-    # Derive SA emails — deployer SA always from defaults (Cloud Build project)
-    cb_project = defaults.get('project_id', '')
-    cb_sa_name = defaults.get('deployer_sa', f'{project_name}-deployer')
-    cb_sa_email = f'{cb_sa_name}@{cb_project}.iam.gserviceaccount.com'
+    # Legacy aliases for back-compat with snippets that still use the
+    # pre-role-topology names. Map to the most likely role.
+    _emit('GCP_PROJECT', runtime_project)
+    _emit('GCP_REGION',  runtime_region or 'us-central1')
+    _emit('CB_PROJECT',  build_project)
 
-    # Resolved target project
-    project_id = resolved.get('project_id', '')
+    # ─── Resource & deployment knobs (env > defaults) ──────────
+    _emit('DOMAIN',           _resolve(config, env, 'runtime', 'domain',           ''))
+    _emit('DNS_PROJECT_ID',   _resolve(config, env, 'runtime', 'dns_project_id',   ''))
+    _emit('DNS_MANAGED_ZONE', _resolve(config, env, 'runtime', 'dns_managed_zone', ''))
+    _emit('DNS_RECORD_NAME',  _resolve(config, env, 'runtime', 'dns_record_name',  ''))
+    _emit('MIN_INSTANCES',    _resolve(config, env, 'runtime', 'min_instances', '0'))
+    _emit('MAX_INSTANCES',    _resolve(config, env, 'runtime', 'max_instances', '3'))
+    _emit('CPU',              _resolve(config, env, 'runtime', 'cpu',    '1'))
+    _emit('MEMORY',           _resolve(config, env, 'runtime', 'memory', '512Mi'))
+    _emit('INGRESS',          _resolve(config, env, 'runtime', 'ingress', 'all'))
 
-    # Runtime SA for the target environment
-    runtime_sa_name = resolved.get('runtime_sa', f'{project_name}-runtime')
-    runtime_sa_email = f'{runtime_sa_name}@{project_id}.iam.gserviceaccount.com'
+    # ─── Service accounts ──────────────────────────────────────
+    # Agent SA in orchestration project, builder SA in build project,
+    # runtime SA in runtime project. Names default to <project-name>-<role>.
+    agent_sa_name   = _resolve(config, env, 'orchestration', 'agent_sa',   f'{project_name}-agent')
+    builder_sa_name = _resolve(config, env, 'build',         'builder_sa', f'{project_name}-builder')
+    runtime_sa_name = _resolve(config, env, 'runtime',       'runtime_sa', f'{project_name}-runtime')
 
-    # Deployer SA name (for gcloud iam create in init)
-    deployer_sa_name = defaults.get('deployer_sa', f'{project_name}-deployer')
+    _emit('AGENT_SA_NAME',   agent_sa_name)
+    _emit('BUILDER_SA_NAME', builder_sa_name)
+    _emit('RUNTIME_SA_NAME', runtime_sa_name)
 
-    # Auto-derive TF state prefix
-    tf_state_prefix = f'{project_name}/{env}'
+    _emit('AGENT_SA_EMAIL',   f'{agent_sa_name}@{orch_project}.iam.gserviceaccount.com')
+    _emit('BUILDER_SA_EMAIL', f'{builder_sa_name}@{build_project}.iam.gserviceaccount.com')
+    _emit('RUNTIME_SA_EMAIL', f'{runtime_sa_name}@{runtime_project}.iam.gserviceaccount.com')
 
-    # Output shell variables
-    print(f"ENVIRONMENT='{env}'")
-    print(f"PROJECT_NAME='{project_name}'")
-    print(f"GCP_PROJECT='{project_id}'")
-    print(f"GCP_REGION='{resolved.get('region', 'us-central1')}'")
-    print(f"DOMAIN='{resolved.get('domain', '')}'")
-    print(f"DNS_PROJECT_ID='{resolved.get('dns_project_id', '')}'")
-    print(f"DNS_MANAGED_ZONE='{resolved.get('dns_managed_zone', '')}'")
-    print(f"DNS_RECORD_NAME='{resolved.get('dns_record_name', '')}'")
-    print(f"DEPLOYER_SA_NAME='{deployer_sa_name}'")
-    print(f"RUNTIME_SA_NAME='{runtime_sa_name}'")
-    print(f"CB_PROJECT='{cb_project}'")
-    print(f"CB_SERVICE_ACCOUNT='{cb_sa_email}'")
-    print(f"RUNTIME_SA_EMAIL='{runtime_sa_email}'")
-    print(f"MIN_INSTANCES='{resolved.get('min_instances', '0')}'")
-    print(f"MAX_INSTANCES='{resolved.get('max_instances', '3')}'")
-    print(f"CPU='{resolved.get('cpu', '1')}'")
-    print(f"MEMORY='{resolved.get('memory', '512Mi')}'")
-    print(f"INGRESS='{resolved.get('ingress', 'all')}'")
-    print(f"TF_STATE_BUCKET='{tf_config.get('state_bucket', '')}'")
-    print(f"TF_STATE_PREFIX='{tf_state_prefix}'")
+    # Legacy: CB_SERVICE_ACCOUNT used to mean "builder SA email".
+    _emit('CB_SERVICE_ACCOUNT', f'{builder_sa_name}@{build_project}.iam.gserviceaccount.com')
+
+    # ─── Custom role ID ────────────────────────────────────────
+    # GCP custom role IDs must be camelCase (no dashes/underscores).
+    def _camel(name: str) -> str:
+        parts = name.replace('_', '-').split('-')
+        return parts[0] + ''.join(p[:1].upper() + p[1:] for p in parts[1:])
+
+    deployer_role_id = _resolve(
+        config, env, 'orchestration', 'deployer_role_id',
+        f'{_camel(project_name)}Deployer',
+    )
+    _emit('DEPLOYER_ROLE_ID', deployer_role_id)
+
+    # ─── AR repo + TF state ────────────────────────────────────
+    _emit('AR_REPO',         _resolve(config, env, 'build', 'ar_repo', project_name))
+    _emit('TF_STATE_BUCKET', _resolve(config, env, 'build', 'state_bucket', ''))
+    # TF state prefix is auto-derived; rarely overridden.
+    _emit('TF_STATE_PREFIX', f'{project_name}/{env}')
+
+    # ─── Agent role expiry (days) ─────────────────────────────
+    _emit('AGENT_ROLE_EXPIRY_DAYS', _resolve(config, env, 'orchestration', 'agent_role_expiry_days', '30'))
 
 
 if __name__ == '__main__':
@@ -1951,67 +2458,401 @@ if __name__ == '__main__':
 }
 
 function generateConfigTomlExample(): string {
-  return `# Project Configuration
+  return `# Project Configuration — three-role topology (#141)
+#
 # Copy this file to config.toml and fill in your values.
 # config.toml is gitignored — never commit it.
+# .env layered on top for sensitive overrides (see .env.example).
+#
+# Resolution order (handled by scripts/config.py):
+#   env-var > [gcp.<env>.<role>] > [gcp.<role>] > [gcp.<env>] > [gcp.defaults] > error
+#
+# The role axis (orchestration / build / runtime) is primary; the
+# environment axis (staging / production) layers on top.
+#
+# 90% case: fill in [gcp.defaults].project only. All three roles
+# collapse onto one project — fine for personal/hobby use.
+#
+# Split case: set [gcp.runtime].project to a separate prod project
+# while keeping orchestration + build on the dev project.
 
 [project]
 name = "app"
 
-# Default GCP settings (inherited by all environments)
-[gcp.default]
-project_id = "your-gcp-project-id"
-region = "us-central1"
-domain = ""
-min_instances = 0
-max_instances = 3
-cpu = "1"
-memory = "512Mi"
-ingress = "all"
-deployer_sa = "app-deployer"
-runtime_sa = "app-runtime"
-
-# DNS / external HTTPS LB stack (opt-in).
-# Leave empty to disable the LB+DNS stack — Cloud Run remains reachable
-# only via its *.run.app URL. Set all three together (and \`domain\` above)
-# to provision the LB and write the DNS A record.
+# ─── REQUIRED: catch-all defaults ──────────────────────────────────
 #
-#   dns_project_id   - GCP project ID hosting the Cloud DNS managed zone
-#                      (a SEPARATE project from the runtime project, by
-#                      convention; the deployer SA is granted
-#                      roles/dns.admin on it during cloud-init).
-#   dns_managed_zone - GCP RESOURCE NAME of the existing managed zone,
-#                      e.g. 'kunall-demo-altostrat-com' (NOT the DNS name).
-#   dns_record_name  - Fully-qualified record name with a trailing dot,
-#                      e.g. 'app.example.com.'.
-dns_project_id = ""
-dns_managed_zone = ""
-dns_record_name = ""
+# Every role inherits from here when its own section is empty.
+# Set project + region; everything else has sensible defaults.
 
-[gcp.default.terraform]
-state_bucket = "your-tfstate-bucket"
-# state_prefix is auto-derived: {project.name}/{ENVIRONMENT}
+[gcp.defaults]
+project = "your-gcp-project-id"
+region  = "us-central1"
 
-# ─── Per-environment overrides ─────────────────────────
-# Each section inherits from [gcp.default].
-# Only specify values that differ from the defaults.
+# ─── Role-axis sections ────────────────────────────────────────────
+#
+# Each role can override the defaults. Empty = inherit. The three roles
+# play distinct parts in the deploy lifecycle:
+#
+#   orchestration — where humans/agents *issue* commands. Hosts the
+#                   agent SA that runs daily deploys + operator CLI
+#                   tools. The custom role (cicd/iam/*-deployer-role.yaml)
+#                   is created here.
+#   build         — where CI runs. Hosts the builder SA, Cloud Build,
+#                   Artifact Registry, Terraform state bucket.
+#   runtime       — where deployed services run. Hosts the runtime SA,
+#                   Cloud Run services, and any service-managed resources.
+#
+# When all three resolve to the same project (the 90% case), the role
+# split is invisible to the operator but the bootstrap script and
+# Terraform are already structured to split later — no refactor needed.
 
-[gcp.staging]
-# Uses all defaults — override here if staging needs different values.
-# Example LB+DNS setup:
-#   domain = "app.example.com"
-#   dns_project_id = "your-staging-dns-project"
-#   dns_managed_zone = "your-zone-resource-name"
-#   dns_record_name = "app.example.com."
+[gcp.orchestration]
+project = ""    # empty = inherit from [gcp.defaults]
+region  = ""
+# agent_sa = "..."             # default: {project-name}-agent
+# deployer_role_id = "..."     # default: {projectName}Deployer (camelCase)
+# agent_role_expiry_days = 30  # 30-day expiry on agent → custom-role binding
 
-[gcp.production]
-project_id = "your-prod-project-id"
-domain = "your-prod-domain.example.com"
-min_instances = 1
-max_instances = 10
-# dns_project_id = "your-prod-dns-project"
-# dns_managed_zone = "your-prod-zone-resource-name"
-# dns_record_name = "your-prod-domain.example.com."
+[gcp.build]
+project = ""
+region  = ""
+# builder_sa   = "..."         # default: {project-name}-builder
+# ar_repo      = "..."         # default: {project-name}
+# state_bucket = "..."         # REQUIRED for cloud-infra; no sane default
+
+[gcp.runtime]
+project = ""
+region  = ""
+# runtime_sa     = "..."       # default: {project-name}-runtime
+# min_instances  = 0
+# max_instances  = 3
+# cpu            = "1"
+# memory         = "512Mi"
+# ingress        = "all"       # or "internal-and-cloud-load-balancing"
+# domain         = ""          # custom domain (LB+DNS opt-in)
+# dns_project_id = ""
+# dns_managed_zone = ""
+# dns_record_name = ""
+
+# ─── Environment-axis overrides (per #115) ─────────────────────────
+#
+# These layer ON TOP of the role axis. The resolver prefers
+# [gcp.<env>.<role>] > [gcp.<role>] for any key. Use them when an
+# environment changes WHICH project hosts a role (e.g. prod runtime
+# moves to a separate project for tenancy reasons).
+
+# [gcp.staging]
+# Inherits everything by default.
+
+# [gcp.production]
+# Override which project owns the runtime role in prod (split topology).
+# [gcp.production.runtime]
+# project        = "acme-prod"
+# region         = "us-east1"
+# min_instances  = 1
+# max_instances  = 10
+# domain         = "app.example.com"
+# dns_project_id = "acme-dns"
+# dns_managed_zone = "example-com"
+# dns_record_name  = "app.example.com."
+`
+}
+
+// ─── .env.example Generation ─────────────────────────────────────────
+//
+// .env layers on top of config.toml. Mark sensitive keys clearly.
+// Loaded by scripts/common.sh; never committed (gitignored).
+
+function generateEnvExample(): string {
+  return `# Environment overrides for sensitive values. NEVER commit this file.
+# Layered ON TOP of config.toml — anything set here overrides resolved values.
+# Copy to .env and fill in.
+#
+# Convention: structural shape lives in config.toml (committed), sensitive
+# values live here (gitignored). Per-user / per-machine overrides too.
+#
+# Resolution order (see scripts/config.py): .env > config.toml > error.
+
+# ─── Environment selection ──────────────────────────────────
+# Selects which env-axis section of config.toml is active.
+# ENVIRONMENT=staging
+# ENVIRONMENT=production
+
+# ─── Sensitive: project IDs ────────────────────────────────
+# Override per-role projects if you don't want them in committed config.toml.
+# Useful for personal sandboxes, hackathon projects, or any case where the
+# project ID is itself sensitive (carries org / billing info).
+# ORCH_PROJECT=your-orchestration-project
+# BUILD_PROJECT=your-build-project
+# RUNTIME_PROJECT=your-runtime-project
+
+# ─── Sensitive: billing / billing-attached IDs ─────────────
+# DNS_PROJECT_ID=your-dns-project
+
+# ─── Sensitive: per-operator identity ──────────────────────
+# When CI runs as a service account but local operators run as themselves,
+# the agent SA short-name may differ per environment.
+# AGENT_SA_NAME=alice-dev-agent
+
+# ─── Sensitive: third-party API keys ───────────────────────
+# Never put these in config.toml.
+# COINGECKO_API_KEY=
+# OPENAI_API_KEY=
+
+# ─── Operator escape hatch ─────────────────────────────────
+# ORCH_FORCE_RESTART=1 invalidates the stepwise checkpoint and
+# restarts admin-cloud-init / admin-cloud-destroy from step 1.
+# Always safe (step idempotency is a contract). Uncomment when you
+# need to force a fresh run after a step list change.
+# ORCH_FORCE_RESTART=1
+
+# ─── Per-operation overrides ───────────────────────────────
+# Required for cloud-app-promote:
+# VERSION=v1.0.0
+# IMAGE=us-central1-docker.pkg.dev/<build-project>/<repo>/<svc>:sha-abc123f
+
+# Optional: skip confirm prompts in non-interactive runs.
+# CONFIRM=yes
+`
+}
+
+// ─── Custom Deployer Role YAML ──────────────────────────────────────
+//
+// The agent SA's curated custom role. Diff-reviewable in git. Bound to
+// the agent SA with a 30-day expiry (see scripts/cloud.sh::admin-cloud-init).
+// Modeled on kunal-labs/onchain-markets/cicd/iam/historical-deployer-role.yaml.
+//
+// Tightenable per-project; remove permissions the project doesn't need.
+// 37-permission default covers: AR push/pull, Cloud Run deploy, Cloud
+// Build submit/monitor, IAM SA management + actAs, GCS for TF state +
+// CB staging, Logging read, project-metadata read.
+
+function generateDeployerRoleYaml(projectName: string): string {
+  // GCP custom role IDs must be camelCase, no dashes.
+  const camel = projectName
+    .replace(/_/g, "-")
+    .split("-")
+    .map((p, i) => (i === 0 ? p : p.charAt(0).toUpperCase() + p.slice(1)))
+    .join("")
+  return `title: "${projectName} Deployer"
+description: "Curated permissions for the agent SA that deploys ${projectName} to Cloud Run via Cloud Build + Terraform. Bound with 30-day expiry. See cicd/iam/README.md (if present) and scripts/cloud.sh::admin-cloud-init."
+stage: GA
+includedPermissions:
+  # Artifact Registry — push/pull images for Cloud Run deploys.
+  - artifactregistry.repositories.uploadArtifacts
+  - artifactregistry.repositories.downloadArtifacts
+  - artifactregistry.repositories.get
+  - artifactregistry.repositories.list
+  # Cloud Run — the deploy target.
+  - run.services.create
+  - run.services.update
+  - run.services.delete
+  - run.services.get
+  - run.services.list
+  - run.services.getIamPolicy
+  - run.services.setIamPolicy
+  - run.revisions.get
+  - run.revisions.list
+  - run.operations.get
+  # Cloud Build — submit and monitor builds (the agent triggers builds
+  # which then run as the builder SA via --service-account).
+  - cloudbuild.builds.create
+  - cloudbuild.builds.get
+  - cloudbuild.builds.list
+  # IAM Service Accounts — create/manage builder + runtime SAs and
+  # impersonate them via actAs.
+  - iam.serviceAccounts.create
+  - iam.serviceAccounts.delete
+  - iam.serviceAccounts.get
+  - iam.serviceAccounts.list
+  - iam.serviceAccounts.actAs
+  - iam.serviceAccounts.getIamPolicy
+  - iam.serviceAccounts.setIamPolicy
+  # GCS — Terraform state bucket + Cloud Build staging bucket.
+  - storage.buckets.get
+  - storage.buckets.list
+  - storage.buckets.getIamPolicy
+  - storage.buckets.setIamPolicy
+  - storage.objects.create
+  - storage.objects.delete
+  - storage.objects.get
+  - storage.objects.list
+  - storage.objects.update
+  # Logging — inspect Cloud Build / Cloud Run logs after deploys.
+  - logging.logEntries.list
+  - logging.logs.list
+  # Project metadata — read-only visibility for diagnostics
+  # (cloud-preflight, app-deploy preflight checks).
+  - resourcemanager.projects.get
+  - resourcemanager.projects.getIamPolicy
+# Custom role ID used when this YAML is fed to gcloud iam roles create:
+# ${camel}Deployer
+`
+}
+
+// ─── ADR template for per-project cloud topology ────────────────────
+//
+// Generated as docs/decisions/ADR-template-cloud-topology.md. Projects
+// forking the scaffold copy this to ADR-XXX-cloud-topology.md and fill
+// it in. Format borrowed from onchain-markets/docs/decisions/ADR-017;
+// content is intentionally generic.
+
+function generateAdrTemplate(): string {
+  return `# ADR-XXX: Cloud topology — orchestration / build / runtime
+
+- **Status**: Proposed
+- **Date**: YYYY-MM-DD
+
+## Context
+
+This project uses the three-role topology scaffolded by \`lib-agents\`
+(see issue #141). The roles are:
+
+| Role            | What it owns                                          |
+|-----------------|-------------------------------------------------------|
+| orchestration   | Agent SA (operator identity), custom IAM role, daily-deploy entry point |
+| build           | Builder SA, Cloud Build, Artifact Registry, TF state |
+| runtime         | Runtime SA, Cloud Run service, service-managed resources |
+
+Every role can collapse to the same project (the 90% case) or split.
+The split is a config edit, not a code refactor — bootstrap script,
+Terraform, and operator commands all work identically; only IAM grants
+branch on local-vs-cross-project.
+
+## Decision
+
+**Topology for this project**: <FILL IN — collapsed / partial-split / fully-split>
+
+| Role            | Project                                | Region   |
+|-----------------|----------------------------------------|----------|
+| orchestration   | \`<your-project>\`                       | \`<region>\` |
+| build           | \`<your-project>\`                       | \`<region>\` |
+| runtime         | \`<your-project>\`                       | \`<region>\` |
+
+**Rationale for the chosen split** (delete the cases that don't apply):
+
+- *Collapsed (one project)*: personal sandbox, hackathon, single-tenant
+  hobby project. No tenancy boundary needed; minimum IAM surface.
+- *Build + runtime collapsed, orchestration split*: agent identity lives
+  outside the deploy plane (e.g. operator runs from a workstation
+  project that is separate from where services run).
+- *Orchestration + build collapsed, runtime split*: production tenancy
+  pattern — services run in a tenant-owned project; the build plane
+  (where source + secrets exist transiently) stays in a separate
+  ops-owned project.
+- *Fully split*: regulated environments, large orgs, multi-tenant ops
+  where each role belongs to a different team.
+
+## TF / admin-cloud-init boundary (non-negotiable)
+
+Per #141 lesson 1, Terraform does **not** mutate project scope. The
+boundary is:
+
+| Layer                | Owns                                                          |
+|----------------------|---------------------------------------------------------------|
+| \`admin-cloud-init\`   | API enablement; AR repo creation; TF state bucket creation; project-wide IAM of other principals (agent SA → custom role; builder SA → predefined functional roles; agent SA → actAs on builder SA) |
+| Terraform (\`main.tf\`)| Resource construction: runtime SA, Cloud Run service, IAM bindings on Terraform's own resources (run.invoker, cross-project AR reader, LB/DNS) |
+
+The generated TF works with a builder SA that holds ONLY the 6
+predefined functional roles, no \`projectIamAdmin\` or
+\`serviceUsageAdmin\`. Adding either to the builder defeats the agent's
+least-privilege custom-role model — the agent can impersonate the
+builder via Cloud Build, so anything granted to the builder becomes
+part of the agent's effective authority.
+
+If a project-scope concern needs automation, add a step to
+\`admin_cloud_init\` (run as Owner once), not a Terraform resource.
+
+## Consequences
+
+**Positive**
+
+- Operators see the same Make targets regardless of topology — the
+  collapsed and split cases share one operator interface.
+- The custom role is diff-reviewable; tightening it doesn't require
+  re-pivoting the bootstrap script.
+- 30-day expiry on agent → custom-role forces credential rotation
+  gracefully (\`make admin-cloud-init\` refreshes idempotently).
+
+**Negative**
+
+- A split topology adds cross-project IAM grants the operator must
+  understand (each \`_grant_role\` call branches local-vs-cross).
+- The first-time bootstrap requires Owner on each distinct project
+  in the topology (not necessarily the same person for every project).
+
+## Alternatives considered
+
+- *Single SA with broad project roles* — what the pre-#141 scaffold
+  did, and what dex-arb-agent + onchain-markets started with. Rejected:
+  daily-handling risk is unbounded because the agent is project-wide
+  Owner-adjacent.
+- *Two SAs, but the deployer SA carries projectIamAdmin so TF can
+  self-escalate* — what the pre-H7 onchain-markets bootstrap did
+  (#116 original proposal). Rejected: TF self-escalation requires the
+  builder to hold the very roles the custom role was trying to keep
+  off the agent.
+
+## Reference
+
+- Issue \`kunallimaye/lib-agents#141\` — three-role topology + IAM hardening
+- Worked example: \`kunal-labs/onchain-markets/docs/decisions/ADR-017-per-component-deployment-topology.md\`
+- Origin postmortem: \`kunal-labs/onchain-markets#44\` (epic; 4 restructure passes)
+`
+}
+
+// ─── AGENTS.local.md boilerplate for detached-orchestration ─────────
+
+function generateAgentsLocalSection(): string {
+  return `## Detached Orchestration Convention (issue #140)
+
+This project uses the \`run_detached_with_heartbeat\` helpers in
+\`scripts/common.sh\`. Operators and agents MUST use the Makefile
+wrappers for any target that mutates external state, NOT direct
+\`bash scripts/cloud.sh ...\` invocations.
+
+**Why**: when the parent shell disconnects mid-deploy, the heartbeat
+file in \`.orchestration/\` preserves run state. \`make cloud-status\`
+shows whether a run is RUNNING / STALLED / COMPLETE / NEVER_STARTED;
+\`make cloud-recover\` reads the EXIT/HUP trap recovery file and helps
+the operator complete teardown. Direct \`bash\` invocation bypasses
+trap setup and leaves orphaned cloud resources on shell disconnect.
+
+### Operator escape hatch
+
+\`ORCH_FORCE_RESTART=1 make admin-cloud-init\` invalidates the stepwise
+checkpoint and restarts from step 1. Step idempotency is a contract;
+restart-from-1 is always safe. Use this when the step list has changed
+since the last partial run (the checkpoint is auto-invalidated when
+the step-list hash mismatches, but an explicit override is sometimes
+clearer for operators).
+
+### Lifecycle
+
+\`\`\`
+make admin-cloud-init    # Owner-tier bootstrap (8 idempotent steps)
+make cloud-preflight     # read-only audit; verify state
+make cloud-infra         # TF apply via Cloud Build (provisions runtime resources)
+make cloud-app-deploy    # build image + swap Cloud Run revision
+make cloud-status        # check on long-running detached operations
+make cloud-recover       # if something went wrong: read recovery hints
+make cloud-clean         # TF destroy (runtime only; bootstrap stays)
+make admin-cloud-destroy # Owner-tier teardown (preserves TF state + AR by default)
+\`\`\`
+
+### Triggers for this module
+
+This project includes the \`detached-orchestration\` scaffold module
+because it has at least one of:
+
+- A \`cicd/cloudbuild*.yaml\` (uses Cloud Build).
+- A \`cicd/terraform/\` directory (tfstate-lock hazard).
+- Make targets that call \`gcloud builds submit\`, \`terraform apply\`,
+  or \`terraform destroy\` (multi-minute remote operations).
+
+If you fork this project and any of those go away, you can remove the
+heartbeat/checkpoint machinery — but keep the Tier-1 hygiene snippets
+(traps, stable log paths, exit-code discipline) regardless.
 `
 }
 
@@ -2048,6 +2889,9 @@ function gitignoreEntries(pt: ProjectType): string[] {
     ".cache/",
     "*.log",
     "logs/",
+    "",
+    "# Detached orchestration state (heartbeat/checkpoint/recovery files, #140)",
+    ".orchestration/",
   ]
 
   const perLang: Record<ProjectType, string[]> = {
@@ -2064,9 +2908,31 @@ function gitignoreEntries(pt: ProjectType): string[] {
 
 // ─── Component Scaffolding Helpers ───────────────────────────────────
 
-type ScaffoldComponent = "makefile" | "scripts" | "container" | "cloudbuild" | "terraform" | "gitignore"
+type ScaffoldComponent =
+  | "makefile"
+  | "scripts"
+  | "container"
+  | "cloudbuild"
+  | "terraform"
+  | "iam"
+  | "adr"
+  | "agentslocal"
+  | "gitignore"
 
-const ALL_COMPONENTS: ScaffoldComponent[] = ["makefile", "scripts", "container", "cloudbuild", "terraform", "gitignore"]
+// ALL_COMPONENTS is the Full CI/CD bundle (the default when no
+// components arg is provided). Order matters for display — list in the
+// rough order that operators read.
+const ALL_COMPONENTS: ScaffoldComponent[] = [
+  "makefile",
+  "scripts",
+  "container",
+  "cloudbuild",
+  "terraform",
+  "iam",
+  "adr",
+  "agentslocal",
+  "gitignore",
+]
 
 async function scaffoldMakefile(root: string, pt: ProjectType, force: boolean): Promise<string[]> {
   return [
@@ -2088,14 +2954,81 @@ async function scaffoldScripts(root: string, pt: ProjectType, force: boolean): P
     // alongside the shell scripts so the cloud workflow is self-contained.
     safeWrite(join(dir, "config.py"), generateConfigPy(), force),
     // config.toml.example lives at the project root (the real config.toml
-    // is gitignored). It documents the multi-environment shape that
-    // scripts/config.py and scripts/cloud.sh expect.
+    // is gitignored). Documents role-axis + env-axis shape (#141).
     safeWrite(join(root, "config.toml.example"), generateConfigTomlExample(), force),
+    // .env.example lives at the project root. Sensitive overrides + the
+    // ORCH_FORCE_RESTART escape hatch are documented here.
+    safeWrite(join(root, ".env.example"), generateEnvExample(), force),
   ]
   try {
     await Bun.$`chmod +x ${dir}/*.sh`.text()
   } catch { /* non-fatal */ }
   return results
+}
+
+// Detect the project's short name from the directory name. Used to name
+// the custom deployer-role YAML and the GCP custom role ID.
+function projectShortName(root: string): string {
+  // Resolve absolute path so basename works correctly.
+  // No filesystem call beyond resolving; cheap.
+  const parts = root.split("/").filter(Boolean)
+  const last = parts.length > 0 ? parts[parts.length - 1] : "app"
+  // Sanitize for use as a YAML filename + GCP custom role ID base.
+  return last.replace(/[^a-zA-Z0-9-]/g, "-") || "app"
+}
+
+function scaffoldIam(root: string, force: boolean): string[] {
+  const dir = join(root, "cicd", "iam")
+  ensureDir(dir)
+  const projName = projectShortName(root)
+  return [
+    "── IAM (custom deployer role) ──",
+    safeWrite(
+      join(dir, `${projName}-deployer-role.yaml`),
+      generateDeployerRoleYaml(projName),
+      force,
+    ),
+  ]
+}
+
+function scaffoldAdr(root: string, force: boolean): string[] {
+  const dir = join(root, "docs", "decisions")
+  ensureDir(dir)
+  return [
+    "── ADR template (cloud topology) ──",
+    safeWrite(
+      join(dir, "ADR-template-cloud-topology.md"),
+      generateAdrTemplate(),
+      force,
+    ),
+  ]
+}
+
+// Append the detached-orchestration convention section to AGENTS.local.md.
+// We APPEND (not overwrite) because AGENTS.local.md is operator-owned —
+// the scaffold should never blow away their custom local conventions.
+function scaffoldAgentsLocal(root: string, _force: boolean): string[] {
+  const path = join(root, "AGENTS.local.md")
+  const section = generateAgentsLocalSection()
+  const sectionMarker = "## Detached Orchestration Convention (issue #140)"
+  if (existsSync(path)) {
+    const existing = readFileSync(path, "utf-8")
+    if (existing.includes(sectionMarker)) {
+      return ["── AGENTS.local.md ──", `  SKIP: ${path} (section already present)`]
+    }
+    const updated = existing.replace(/\n+$/, "") + "\n\n" + section
+    writeFileSync(path, updated)
+    return ["── AGENTS.local.md ──", `  APPENDED: detached-orchestration section to ${path}`]
+  }
+  // Create new with a brief header so the file is self-documenting.
+  const header = `# Local Agent Conventions
+
+This file lives alongside \`AGENTS.md\` and captures conventions that are
+specific to this project. Subagents read both.
+
+`
+  writeFileSync(path, header + section)
+  return ["── AGENTS.local.md ──", `  CREATED: ${path}`]
 }
 
 function scaffoldContainer(root: string, pt: ProjectType, force: boolean): string[] {
@@ -2168,16 +3101,36 @@ function scaffoldGitignore(root: string, pt: ProjectType): string[] {
 export const scaffold = tool({
   description:
     "Generate project operational structure: Makefile, scripts/, cicd/Dockerfile, " +
-    "cicd/cloudbuild*.yaml, cicd/terraform/, and .gitignore. Detects project type " +
-    "and tailors all files. Use the 'components' parameter to generate only specific " +
-    "parts, or omit it to generate everything. Skips existing files unless force=true.",
+    "cicd/cloudbuild*.yaml, cicd/terraform/, cicd/iam/<deployer-role>.yaml, " +
+    "docs/decisions/ADR-template-cloud-topology.md, AGENTS.local.md " +
+    "(detached-orchestration section), and .gitignore. Implements the " +
+    "three-role topology (orchestration/build/runtime) from issue #141 + " +
+    "the Tier-2 detached-orchestration helpers from issue #140. " +
+    "Detects project type and tailors all files. Use the 'components' " +
+    "parameter to generate only specific parts, or omit it to generate " +
+    "the Full CI/CD bundle. Skips existing files unless force=true.",
   args: {
     components: tool.schema
-      .array(tool.schema.enum(["makefile", "scripts", "container", "cloudbuild", "terraform", "gitignore"]))
+      .array(
+        tool.schema.enum([
+          "makefile",
+          "scripts",
+          "container",
+          "cloudbuild",
+          "terraform",
+          "iam",
+          "adr",
+          "agentslocal",
+          "gitignore",
+        ]),
+      )
       .optional()
       .describe(
-        "Which components to scaffold. Options: makefile, scripts, container, " +
-        "cloudbuild, terraform, gitignore. Omit to generate everything.",
+        "Which components to scaffold. Options: makefile, scripts, " +
+        "container, cloudbuild, terraform, iam (custom deployer-role YAML), " +
+        "adr (cloud-topology ADR template), agentslocal " +
+        "(detached-orchestration section in AGENTS.local.md), gitignore. " +
+        "Omit to generate the Full CI/CD bundle.",
       ),
     force: tool.schema
       .boolean()
@@ -2194,8 +3147,8 @@ export const scaffold = tool({
         : ALL_COMPONENTS
 
     const results: string[] = [
-      "Project Scaffold",
-      "================",
+      "Project Scaffold (three-role topology, #141 + #140)",
+      "=====================================================",
       `Detected project type: ${projectLabel(pt)}`,
       `Components: ${components.join(", ")}`,
       "",
@@ -2218,6 +3171,15 @@ export const scaffold = tool({
         case "terraform":
           results.push(...scaffoldTerraform(root, force))
           break
+        case "iam":
+          results.push(...scaffoldIam(root, force))
+          break
+        case "adr":
+          results.push(...scaffoldAdr(root, force))
+          break
+        case "agentslocal":
+          results.push(...scaffoldAgentsLocal(root, force))
+          break
         case "gitignore":
           results.push(...scaffoldGitignore(root, pt))
           break
@@ -2225,8 +3187,19 @@ export const scaffold = tool({
       results.push("")
     }
 
-    results.push("================")
-    results.push("Scaffold complete. Run 'make help' to see available targets.")
+    results.push("=====================================================")
+    results.push("Scaffold complete.")
+    results.push("")
+    results.push("Next steps for the Full CI/CD bundle:")
+    results.push("  1. cp config.toml.example config.toml  (fill in [gcp.defaults].project)")
+    results.push("  2. cp .env.example .env                (any sensitive overrides)")
+    results.push("  3. make cloud-help                     (verify resolved topology)")
+    results.push("  4. make admin-cloud-init               (Owner-tier 8-step bootstrap)")
+    results.push("  5. make cloud-preflight                (read-only audit)")
+    results.push("  6. make cloud-infra                    (TF apply via Cloud Build)")
+    results.push("  7. make cloud-app-deploy               (image build + revision swap)")
+    results.push("")
+    results.push("Run 'make help' to see all available targets.")
 
     return results.join("\n")
   },

--- a/tools/scaffold.ts
+++ b/tools/scaffold.ts
@@ -315,10 +315,12 @@ print_topology() {
 
 # Returns 0 (true) when role_a project equals role_b project.
 # Usage: same_project ORCH_PROJECT BUILD_PROJECT && echo collapsed
+#
+# Uses bash indirect expansion (\${!var}) instead of \`eval\` — avoids the
+# class of code-injection risk that \`eval\` on caller-supplied strings
+# carries, even though every caller here passes a hardcoded identifier.
 same_project() {
-  local a_val b_val
-  a_val="$(eval "echo \\\${$1:-}")"
-  b_val="$(eval "echo \\\${$2:-}")"
+  local a_val="\${!1:-}" b_val="\${!2:-}"
   [[ -n "\${a_val}" && "\${a_val}" == "\${b_val}" ]]
 }
 
@@ -334,6 +336,10 @@ mkdir -p "\${LOG_DIR}"
 start_log() {
   local action="\${1:-unknown}"
   LOG_FILE="\${LOG_DIR}/$(date +%Y%m%d-%H%M%S)-\${action}.log"
+  # Set SCRIPT_ACTION so the EXIT/INT/TERM/HUP trap handler can name the
+  # action in its forensic log line — without this, only detached-orchestrated
+  # runs (which set SCRIPT_ACTION inside run_detached_*) had meaningful context.
+  SCRIPT_ACTION="\${action}"
   exec > >(tee -a "\${LOG_FILE}") 2>&1
   log_info "Logging to \${LOG_FILE}"
 }
@@ -793,14 +799,39 @@ _tf_substitutions() {
   echo "\${subs}"
 }
 
+# Resolve the caller's gcloud quota project once and cache it in
+# CALLER_PROJECT. Used by _grant_role to decide whether a grant is
+# cross-project (caller's quota project ≠ target).
+#
+# Why this matters: the --billing-project flag routes the API call's
+# quota+billing to the target project, which is required when the
+# caller's quota project differs from the target (otherwise an org
+# policy can reject with "no billing project"). The previous
+# implementation compared against ORCH_PROJECT, which only matched
+# the caller's project by coincidence in fully-collapsed topologies.
+# In split-orch topologies (or any case where \`gcloud config\` points
+# at a project other than ORCH_PROJECT), the branch misfired —
+# missing the flag for genuine cross-project grants, or adding it
+# unnecessarily for local grants.
+_resolve_caller_project() {
+  if [[ -z "\${CALLER_PROJECT:-}" ]]; then
+    CALLER_PROJECT="$(gcloud config get-value project 2>/dev/null || true)"
+    if [[ -z "\${CALLER_PROJECT}" ]]; then
+      die "Unable to detect caller's gcloud project. Run 'gcloud config set project <id>' first."
+    fi
+    log_info "  caller project (gcloud quota): \${CALLER_PROJECT}"
+  fi
+}
+
 # Cross-project IAM grant helper. Each grant in admin-cloud-init may target
-# the local project (current role) or a different one (cross-project). The
-# behavior is uniform — branch on local-vs-cross-project for the operator
+# the local project (caller's quota project) or a different one (cross-project).
+# The behavior is uniform — branch on caller-vs-target for the operator
 # warning message and the --billing-project flag.
 _grant_role() {
   local target_project="\$1" member="\$2" role="\$3"
+  _resolve_caller_project
   local extra_flag=""
-  if [[ "\${target_project}" != "\${ORCH_PROJECT}" ]]; then
+  if [[ "\${target_project}" != "\${CALLER_PROJECT}" ]]; then
     extra_flag="--billing-project=\${target_project}"
     log_info "  cross-project grant: \${role} on \${target_project} for \${member}"
   fi
@@ -851,12 +882,17 @@ _step_enable_apis() {
     "logging.googleapis.com"
   )
   # API enable is per-project (each role's project that owns resources).
-  # Build project needs build-time APIs; runtime needs runtime APIs.
+  # Build, runtime, AND orchestration need APIs — orchestration needs
+  # iam.googleapis.com + cloudresourcemanager.googleapis.com so the
+  # agent SA management and custom-role creation steps work.
   # We enable the full set on each distinct project for simplicity —
-  # idempotent and cheap.
-  local projects=()
-  projects+=("\${BUILD_PROJECT}")
+  # idempotent and cheap. Dedup by value across all three roles.
+  local projects=("\${BUILD_PROJECT}")
   same_project BUILD_PROJECT RUNTIME_PROJECT || projects+=("\${RUNTIME_PROJECT}")
+  if ! same_project ORCH_PROJECT BUILD_PROJECT \\
+      && ! same_project ORCH_PROJECT RUNTIME_PROJECT; then
+    projects+=("\${ORCH_PROJECT}")
+  fi
   for p in "\${projects[@]}"; do
     log_info "  enabling APIs on \${p}..."
     for api in "\${apis[@]}"; do
@@ -935,6 +971,12 @@ _step_create_agent_sa_and_bind() {
 
   # Bind agent SA to custom role on orchestration project with 30-day expiry.
   # Expiry condition forces graceful credential rotation (re-run admin-cloud-init).
+  #
+  # Guard against empty AGENT_ROLE_EXPIRY_DAYS: BSD date (macOS) silently
+  # emits 'now' when the relative offset is empty, which would bind the
+  # role with an already-expired condition. common.sh sets a default of 30,
+  # but be explicit about the failure mode if it ever gets cleared.
+  [[ -n "\${AGENT_ROLE_EXPIRY_DAYS}" ]] || die "AGENT_ROLE_EXPIRY_DAYS is empty. Set it in config.toml ([gcp.orchestration].agent_role_expiry_days) or .env, or accept the 30-day default in common.sh."
   local expiry_ts
   expiry_ts="$(date -u -d "+\${AGENT_ROLE_EXPIRY_DAYS} days" '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null \\
     || date -u -v+\${AGENT_ROLE_EXPIRY_DAYS}d '+%Y-%m-%dT%H:%M:%SZ')"
@@ -997,6 +1039,7 @@ admin_cloud_init() {
   print_topology
   require_cmd gcloud
   _require_topology
+  _resolve_caller_project
   [[ -z "\${TF_STATE_BUCKET}" ]] && die "TF_STATE_BUCKET is not set."
 
   if [[ "\${CONFIRM:-}" != "yes" ]]; then


### PR DESCRIPTION
**BREAKING CHANGE** — closes #141, #140.

Implements the three-role topology (orchestration / build / runtime) from #141 and the Tier-1 hygiene + Tier-2 detached-orchestration helpers from #140 in a single bundle. Folded together because both issues touch the same generator templates in `tools/scaffold.ts`, the same `commands/scaffold.md`, and the same skills (`cloudbuild-ops`, `gcloud-ops`, `makefile-ops`).

## What changes (operator-facing)

### `config.toml` schema (BREAKING)

Old environment-axis schema (`[gcp.default]` + `[gcp.staging]` + `[gcp.production]`) is GONE. Replaced with the **role-axis** schema:

```toml
[gcp.defaults]
project = "kunal-scratch"
region  = "asia-northeast1"

[gcp.orchestration]   # empty = inherit from [gcp.defaults]
[gcp.build]
[gcp.runtime]

# Environment-axis layering per #115 still works on top:
[gcp.production.runtime]
project = "acme-prod"   # only overrides runtime in production
```

90% case: fill in `[gcp.defaults].project` only — all three roles collapse to one project, fine for personal/hobby use. Split case: set `[gcp.runtime].project` to a separate prod project. **The split is a config edit, not a code refactor.**

### Make targets (BREAKING)

Old → New verb mapping:

| Old                         | New                          |
|-----------------------------|------------------------------|
| `make cloud-init`           | `make admin-cloud-init`      |
| `make cloud-init-prod`      | `make admin-cloud-init`      |
| `make cloud-infra`          | `make cloud-infra`           |
| `make cloud-app-deploy`     | `make cloud-app-deploy`      |
| `make cloud-app-promote`    | `make cloud-app-promote`     |
| `make cloud-app-undeploy`   | `make cloud-app-undeploy`    |
| `make cloud-clean`          | `make cloud-clean`           |
| —                           | `make cloud-help` *(new)*    |
| —                           | `make cloud-preflight` *(new)*|
| —                           | `make admin-cloud-destroy` *(new)*|
| —                           | `make cloud-status` *(new — #140)*|
| —                           | `make cloud-recover` *(new — #140)*|

Bash dispatch in `scripts/cloud.sh` stubs the old verbs with a clear redirect message ("Verb 'init' has been removed. Use 'make admin-cloud-init' (three-role topology, #141).").

### Terraform (BREAKING)

Generated `cicd/terraform/` is now **resource construction only**. The following are GONE:

- `google_project_service.bootstrap_apis` / `.apis` — API enable moves to `admin-cloud-init`
- `google_project_iam_member.deployer_run_admin` / `deployer_ar_admin` / `deployer_sa_user` / `deployer_serviceusage_admin` / `deployer_sa_creator` / `deployer_network_admin` / `deployer_lb_admin` — TF self-escalation forbidden (#141 lesson 1)
- `time_sleep.wait_for_iam` — moot without TF doing IAM
- `google_artifact_registry_repository.app` (resource) — now a `data` source (created by `admin-cloud-init`)

Generated TF works with a builder SA that holds ONLY **6 predefined functional roles**: `run.admin`, `artifactregistry.admin`, `iam.serviceAccountUser`, `iam.serviceAccountAdmin`, `logging.logWriter`, `storage.admin`. NO `projectIamAdmin`, NO `serviceUsageAdmin`. **Anyone with the old bundle's TF must remove those broad grants from the builder SA after re-scaffolding.**

Three provider aliases: `google.orchestration`, `google.build`, `google.runtime`. When all three roles collapse to one project, the aliases are functionally identical (zero overhead).

### New files generated

- **`.env.example`** — sensitive overrides + the `ORCH_FORCE_RESTART=1` escape hatch
- **`cicd/iam/<project>-deployer-role.yaml`** — curated 37-permission custom role for the agent SA, bound by `admin-cloud-init` with a 30-day expiry condition (#141 lesson 2)
- **`docs/decisions/ADR-template-cloud-topology.md`** — projects copy and fill in
- **`AGENTS.local.md`** detached-orchestration convention section (appended, not overwritten)

### `scripts/common.sh` adds (#140)

- Tier-1 hygiene: traps on EXIT/INT/TERM/HUP, stable `logs/<timestamp>-<action>.log` paths, exit-code discipline. `set -euo pipefail` + `die` already there.
- Tier-2 detached orchestration:
  - `run_detached_stepwise` — N idempotent steps, checkpoint after each, resume on re-run, **restart-from-1 when step-list-hash mismatches** (per #141 lesson 3 — fixes the kunal-labs/onchain-markets#89 bug class).
  - `run_detached_cloudbuild` — single atomic remote job + heartbeat.
  - `heartbeat_status` / `recovery_summary` — read state for `make cloud-status` / `make cloud-recover`.
- `ORCH_FORCE_RESTART=1` escape hatch documented prominently in both `scripts/cloud.sh` header and `Makefile` footer.

### Operator CLI conventions (#141 lesson 5 + #140)

- Rust scaffold: `make local-run` now defaults to `cargo run --release` (was `cargo run`). Dev profile users need an explicit `local-run-dev` target.
- "Makefile = operator interface, scripts = implementation" codified in `skills/makefile-ops/SKILL.md` as a hard rule. Generated `scripts/cloud.sh` carries the same warning in its header.
- Distinct bin names across sibling crates documented in `skills/makefile-ops/SKILL.md`.

### `commands/scaffold.md`

- Menu option renamed: **"Full CI/CD + Three-Role Topology + LB+DNS"**. The pre-#141 menu wording is GONE.
- New **"When should I run `/scaffold`?"** section covering 5 trigger scenarios: fresh repo, lib-agents upgrade, incremental add, topology change, custom-role tightening.
- Post-scaffold checklist updated for the new lifecycle.

### Skills updates

- `skills/cloudbuild-ops/SKILL.md` — three-role topology, custom-role pattern, builder-SA's 6 predefined roles, the **non-negotiable** TF / admin-cloud-init boundary, the 6 lessons from #141.
- `skills/gcloud-ops/SKILL.md` — `format=full` identity-token pattern (#141 lesson 4), cross-project IAM grant pattern.
- `skills/makefile-ops/SKILL.md` — Makefile = operator interface hard rule, `--release` default, distinct bin names.

## Smoke test (dry-run)

Scaffolded into a pilot workspace, all generated files render with valid syntax:

| Check                                                                 | Result |
|-----------------------------------------------------------------------|--------|
| `terraform fmt -check -recursive`                                     | PASS (zero formatting issues) |
| `terraform init -backend=false` + `terraform validate`                | PASS (`Success! The configuration is valid.`) |
| `shellcheck -S warning` on all generated `scripts/*.sh`               | PASS (zero warnings) |
| `bash -n` on all generated `scripts/*.sh`                             | PASS |
| `python3 -m py_compile scripts/config.py`                             | PASS |
| `config.py` against `config.toml.example` (collapsed case)            | Emits all expected shell exports |
| `config.py` with `[gcp.production.runtime]` override + `ENVIRONMENT=production` | Correctly produces split topology; runtime SA email updates to the prod project |
| `make -n` on every `cloud-*` / `admin-*` / `local-*` / `container-*` target | PASS |
| `make help` renders all targets with descriptions                     | PASS |
| `bash scripts/cloud.sh help` prints resolved topology + classifies it | PASS (correctly identifies "collapsed", "production tenancy pattern", etc.) |
| `_step_list_hash` stable across runs with same steps                  | PASS |
| `_step_list_hash` differs on step-list change                         | PASS (the #141 lesson 3 invalidation mechanism works) |
| All YAMLs parse via PyYAML                                            | PASS |
| Custom deployer-role YAML has 37 permissions                          | PASS |

## What still needs human verification on real GCP before tagging this release

The sandbox can't reach live GCP. Before tagging this release as a major version, someone with Owner on a real GCP project should:

1. End-to-end lifecycle:
   - `make admin-cloud-init` (Owner-tier) — verify 8 steps run idempotently
   - `make cloud-preflight` — verify per-role-aware messaging matches reality
   - `make cloud-infra` — `terraform apply` runs as builder SA without `projectIamAdmin`
   - `make cloud-app-deploy` — image build + Cloud Run revision swap
   - `curl <service_url>` — confirm the deployed app responds
2. **Cross-project IAM grant in `_grant_role`** — the dry-run exercises the local-project path only. A real split topology (e.g. `[gcp.runtime].project = "different-project"`) is needed to exercise the `--billing-project` branch.
3. **30-day expiry on the agent → custom-role binding** — TTL-based; verify the binding actually expires after 30 days.
4. **`terraform apply` against a real GCS backend** — the dry-run does `init -backend=false`. A real backend exercises the state lock + state-write path.
5. **`format=full` identity-token client code** — none generated today; pattern is documented in the gcloud-ops skill for when it lands.

## Motivating downstream failures

This PR is driven by real production incidents. Cited so future-readers can understand the design rationale:

- **`kunal-labs/onchain-markets#44`** (epic) + PRs #81, #86, #87, #88, #89, #90, #91, #92 — origin of #141's 6 lessons. 4 restructure passes (H6 → H7 → H7.5 → H7.6) for what was supposed to be "deploy a Cloud Run service in Tokyo." Each restructure was a fix for a real architectural bug that should have been caught by the scaffold from day one.
- **`kunal-labs/dex-arb-agent#136`** — origin of #140's Tier-1 hygiene + detached-orchestration module. Operator-driven `make local-cloud-deploy` died on parent-shell disconnect; remote Cloud Build ran to SUCCESS but the local orchestrator that was supposed to drive subsequent capture-window + teardown phases was gone. Cloud Run kept burning ~43 minutes of Tokyo compute past intended teardown.

## Files modified / created

Modified:
- `tools/scaffold.ts` (large rewrite — all generators except dockerfile/dockerignore/local.sh/container.sh body; +2 new scaffold components: iam, adr, agentslocal)
- `commands/scaffold.md` (menu + new "When to run /scaffold?" section)
- `skills/cloudbuild-ops/SKILL.md`
- `skills/gcloud-ops/SKILL.md`
- `skills/makefile-ops/SKILL.md`

Created:
- `CHANGELOG.md` (new — BREAKING CHANGE notice + motivating-failure refs)

## Acceptance criteria

### From #141

- [x] New `/scaffold` Full CI/CD bundle output includes role-axis `config.toml` schema with `[gcp.defaults]` catch-all + per-role overrides.
- [x] `.env.example` generated alongside, documenting which keys can override.
- [x] `scripts/config.py` resolves `env > role > defaults > error`.
- [x] `scripts/cloud.sh` generates role-aware bootstrap with cross-project IAM branching, custom-role YAML reference, stepwise orchestration with step-list-hash checkpoint invalidation.
- [x] `cicd/terraform/` generates resource-construction only — NO API enable, NO project IAM self-escalation, AR repo as data source.
- [x] `cicd/iam/<deployer-role>.yaml` generated with curated 37-permission list.
- [x] Makefile exposes `cloud-*` and `admin-*` verbs; `cloud-help` prints resolved topology.
- [x] Skills updated: cloudbuild-ops, gcloud-ops, makefile-ops.

### From #140

- [x] Tier-1 hygiene snippets present in `common.sh` template, applied to every new project.
- [x] Tier-2 `detached-orchestration` module exists as conditional scaffold component (always included in the Full CI/CD bundle, which is the default).
- [x] `AGENTS.local.md` template section for the convention included when the bundle is scaffolded.
- [x] CHANGELOG points back to `kunal-labs/dex-arb-agent#136` and `kunal-labs/onchain-markets#44` as motivating failures.

### Combined

- [x] BREAKING CHANGE clearly flagged in PR body and CHANGELOG. Major version bump on release.
- [x] `commands/scaffold.md` has a "When should I run `/scaffold`?" section covering 5 trigger scenarios.

Closes #141
Closes #140

cc @kunallimaye
