### PR TITLE
fix(agents): troubleshooting skill perm, dead skill ref, agent-workspace tool naming

### DIFF
--- a/agents/devops/agent.md
+++ b/agents/devops/agent.md
@@ -37,7 +37,7 @@ permission:
     container-ops: allow
     cloudbuild-ops: allow
     gcloud-ops: allow
-    log-analysis: allow
+    troubleshooting: allow
   bash:
     "*": allow
 ---
@@ -218,7 +218,7 @@ After completing the requested work:
    - Set `delete_branch: true` to clean up the remote branch
    - If merge fails (e.g., conflicts, branch protection rules), report the
      failure and leave the PR open
-8. **Clean up workspace** -- Run `agent_workspace_destroy` to remove the
+8. **Clean up workspace** -- Run `agent-workspace_destroy` to remove the
    isolated clone from `/tmp/agent-*`. Do NOT destroy the workspace until
    the PR is merged or the review loop is complete.
 9. **Report back** -- Summarize what was done, the PR URL, the linked issue,

--- a/agents/docs/agent.md
+++ b/agents/docs/agent.md
@@ -30,7 +30,7 @@ tools:
   pilot-workspace_*: false
   pilot-run_*: false
   # Disable agent workspace tools (handled by devops/git-ops)
-  agent_workspace_*: false
+  agent-workspace_*: false
 permission:
   skill:
     "*": deny

--- a/agents/git-ops/agent.md
+++ b/agents/git-ops/agent.md
@@ -53,10 +53,10 @@ working tree:
 1. If a workspace path is provided in the prompt, use it directly -- pass it
    as the `workspace` parameter to all git tools.
 2. If no workspace path is provided and you need to mutate branches, use
-   `agent_workspace_create` to create an isolated clone first.
+   `agent-workspace_create` to create an isolated clone first.
 3. For read-only operations (view issue, list PRs, list branches, log, diff),
    workspace is NOT needed -- operate directly on the main repo.
-4. Use `agent_workspace_destroy` when done with the workspace.
+4. Use `agent-workspace_destroy` when done with the workspace.
 
 **CRITICAL**: When a workspace path is provided, ALL git-mutating operations
 (stage, commit, push, branch create/switch, PR create) MUST use the workspace.

--- a/agents/ideate/agent.md
+++ b/agents/ideate/agent.md
@@ -29,7 +29,7 @@ tools:
   readme-scaffold: false
   readme-validate: false
   # Disable agent workspace tools (handled by devops/git-ops)
-  agent_workspace_*: false
+  agent-workspace_*: false
   skill: false
 permission:
   bash:

--- a/agents/pilot/agent.md
+++ b/agents/pilot/agent.md
@@ -26,7 +26,7 @@ tools:
   git-ops-init_*: false
   git-status_*: false
   # Disable agent workspace tools (handled by devops/git-ops)
-  agent_workspace_*: false
+  agent-workspace_*: false
   readme-analyze: false
   readme-scaffold: false
   readme-validate: false

--- a/agents/scribe/agent.md
+++ b/agents/scribe/agent.md
@@ -36,7 +36,7 @@ tools:
   pilot-workspace_*: false
   pilot-run_*: false
   # Disable agent workspace tools
-  agent_workspace_*: false
+  agent-workspace_*: false
 permission:
   skill:
     "*": deny

--- a/commands/review.md
+++ b/commands/review.md
@@ -39,7 +39,7 @@ number is required. The PR itself provides all necessary context.
 ## Phase 3: Fix and re-review (max 2 iterations)
 
 7. Check out the PR branch in an isolated workspace
-   (use agent_workspace_create)
+   (use agent-workspace_create)
 8. Fix the issues identified in the review
 9. Stage, commit, and push the fixes (delegate to @git-ops with workspace path)
 10. Re-review: delegate to @git-ops to get the updated PR diff and re-analyze
@@ -47,6 +47,6 @@ number is required. The PR itself provides all necessary context.
     delete_branch: true
 12. If issues remain after 2 remediation rounds → leave the PR open with
     a review comment listing remaining issues for manual review
-13. Destroy workspace (agent_workspace_destroy)
+13. Destroy workspace (agent-workspace_destroy)
 14. Report: PR status (merged or open with remaining issues), summary of
     fixes applied

--- a/profiles/content/PROFILE.md
+++ b/profiles/content/PROFILE.md
@@ -18,6 +18,7 @@ agent_skills:
     - container-ops
     - cloudbuild-ops
     - gcloud-ops
+    - troubleshooting
   git-ops:
     - git-pr-workflow
     - git-release
@@ -55,6 +56,7 @@ a dedicated scribe agent pinned to Gemini 3.1 Pro for its 1M context window.
 | `container-ops` | devops | Podman container operations |
 | `cloudbuild-ops` | devops | Cloud Build CI/CD patterns |
 | `gcloud-ops` | devops | Google Cloud Platform operations |
+| `troubleshooting` | devops | Log/metric/system troubleshooting |
 | `git-pr-workflow` | git-ops | PR creation and review |
 | `git-release` | git-ops | Release management |
 | `readme-conventions` | docs | README best practices |

--- a/profiles/default/PROFILE.md
+++ b/profiles/default/PROFILE.md
@@ -19,6 +19,7 @@ agent_skills:
     - container-ops
     - cloudbuild-ops
     - gcloud-ops
+    - troubleshooting
   git-ops:
     - git-pr-workflow
     - git-release
@@ -56,6 +57,7 @@ workflow.
 | `container-ops` | devops | Podman container operations |
 | `cloudbuild-ops` | devops | Cloud Build CI/CD patterns |
 | `gcloud-ops` | devops | Google Cloud Platform operations |
+| `troubleshooting` | devops | Log/metric/system troubleshooting |
 | `git-pr-workflow` | git-ops | PR creation and review |
 | `git-release` | git-ops | Release management |
 | `readme-conventions` | docs | README best practices |

--- a/skills/devops-workflow/SKILL.md
+++ b/skills/devops-workflow/SKILL.md
@@ -197,7 +197,7 @@ Use conventional commits: `type(scope): description`
 After a PR is merged (either via the self-review-merge loop or manually),
 clean up to prevent branch accumulation:
 
-1. Destroy workspace: `agent_workspace_destroy` (if not already destroyed).
+1. Destroy workspace: `agent-workspace_destroy` (if not already destroyed).
    The workspace is kept alive during the review loop for remediation fixes,
    and destroyed only after the PR is merged or the loop completes.
 2. Delete local branch: `git branch -d <branch>` (in the main repo)

--- a/tools/agent-workspace.ts
+++ b/tools/agent-workspace.ts
@@ -315,7 +315,7 @@ export const destroy = tool({
     )
 
     if (wsIndex === -1) {
-      return `Workspace '${args.name}' not found in manifest. Use agent_workspace_list to see active workspaces.`
+      return `Workspace '${args.name}' not found in manifest. Use agent-workspace_list to see active workspaces.`
     }
 
     const ws = manifest.workspaces[wsIndex]

--- a/tools/branch-cleanup.ts
+++ b/tools/branch-cleanup.ts
@@ -3,7 +3,7 @@ import { tool } from "@opencode-ai/plugin"
 const WORKSPACE_DESC =
   "Path to an agent workspace (clone). When provided, git commands run " +
   "inside the workspace instead of the main working tree. Use the path " +
-  "returned by agent_workspace_create."
+  "returned by agent-workspace_create."
 
 async function run(
   cmd: string[],

--- a/tools/gh-pr.ts
+++ b/tools/gh-pr.ts
@@ -4,7 +4,7 @@ import { ensureEnvironment } from "./git-ops-init"
 const WORKSPACE_DESC =
   "Path to an agent workspace (clone). When provided, gh commands run " +
   "inside the workspace instead of the main working tree. Use the path " +
-  "returned by agent_workspace_create."
+  "returned by agent-workspace_create."
 
 async function ghRun(args: string[], workspace?: string): Promise<string> {
   const envErr = await ensureEnvironment()

--- a/tools/git-branch.ts
+++ b/tools/git-branch.ts
@@ -4,7 +4,7 @@ import { ensureEnvironment } from "./git-ops-init"
 const WORKSPACE_DESC =
   "Path to an agent workspace (clone). When provided, git commands run " +
   "inside the workspace instead of the main working tree. Use the path " +
-  "returned by agent_workspace_create."
+  "returned by agent-workspace_create."
 
 async function gitRun(args: string[], workspace?: string): Promise<string> {
   const envErr = await ensureEnvironment()

--- a/tools/git-commit.ts
+++ b/tools/git-commit.ts
@@ -4,7 +4,7 @@ import { ensureEnvironment } from "./git-ops-init"
 const WORKSPACE_DESC =
   "Path to an agent workspace (clone). When provided, git commands run " +
   "inside the workspace instead of the main working tree. Use the path " +
-  "returned by agent_workspace_create."
+  "returned by agent-workspace_create."
 
 async function gitRun(args: string[], workspace?: string): Promise<string> {
   const envErr = await ensureEnvironment()

--- a/tools/git-conflict.ts
+++ b/tools/git-conflict.ts
@@ -4,7 +4,7 @@ import { ensureEnvironment } from "./git-ops-init"
 const WORKSPACE_DESC =
   "Path to an agent workspace (clone). When provided, git commands run " +
   "inside the workspace instead of the main working tree. Use the path " +
-  "returned by agent_workspace_create."
+  "returned by agent-workspace_create."
 
 async function gitRun(args: string[], workspace?: string): Promise<string> {
   const envErr = await ensureEnvironment()

--- a/tools/git-status.ts
+++ b/tools/git-status.ts
@@ -4,7 +4,7 @@ import { ensureEnvironment } from "./git-ops-init"
 const WORKSPACE_DESC =
   "Path to an agent workspace (clone). When provided, git commands run " +
   "inside the workspace instead of the main working tree. Use the path " +
-  "returned by agent_workspace_create."
+  "returned by agent-workspace_create."
 
 async function gitRun(args: string[], workspace?: string): Promise<string> {
   const envErr = await ensureEnvironment()


### PR DESCRIPTION
## Summary

Three related functional bugs in agent configuration discovered by the lib-agents configuration audit (epic #143):

- **B1**: `troubleshooting` skill was permission-denied to the devops agent. `/troubleshoot` command failed silently because the skill wasn't on devops' allow-list. Added to allow-list and to both profile devops skill lists.
- **B2**: Dead skill reference `log-analysis` removed. Skill was renamed to `troubleshooting` in PR #109 / commit `ddcb4ee`; allow-list was never migrated.
- **B3**: Tool-ID hyphenation inconsistency for `agent-workspace` tools. The tool file is `tools/agent-workspace.ts`; OpenCode preserves hyphens in tool IDs, so actual IDs are `agent-workspace_create`, etc. Prose used `agent_workspace_*` (underscore) in 11 files, including permission `false` globs that silently failed to match the real tool IDs.

## Files changed

**Agents** (skill perm + tool-ID prose/globs):
- `agents/devops/agent.md` — perm swap (`log-analysis` → `troubleshooting`) + post-work step 8 prose
- `agents/git-ops/agent.md` — workspace isolation rules prose
- `agents/{pilot,scribe,ideate,docs}/agent.md` — `agent-workspace_*: false` permission globs

**Commands / skills / tools**:
- `commands/review.md` — workflow prose
- `skills/devops-workflow/SKILL.md` — post-merge cleanup
- `tools/agent-workspace.ts` — user-facing error message
- `tools/{git-status,gh-pr,git-conflict,git-branch,branch-cleanup,git-commit}.ts` — `WORKSPACE_DESC` parameter description strings

**Profiles**:
- `profiles/default/PROFILE.md` — added `troubleshooting` to devops skills list + skills table
- `profiles/content/PROFILE.md` — same

## Out-of-scope-but-related

The audit's PR-1 scope listed only the 3 prose locations for B3. While editing, several additional `agent_workspace_*` references were discovered (4 permission globs, 1 SKILL.md prose, 6 tool description strings, 1 error message). All have identical root cause and identical fix; they're included here so the smoke test (`git grep "agent_workspace_"` → zero) passes cleanly. The orchestrator agent already used correct hyphenated form and was the canonical reference.

## Verification (B3 hyphen-vs-underscore convention)

PR-1 applies the high-confidence fix based on the orchestrator's existing correct usage (`agent-workspace_list: true`). PR-4 will run a pilot experiment to definitively confirm OpenCode preserves hyphens in tool IDs. If REFUTED (unlikely), PR-1 would be reverted in a follow-up.

## Smoke tests (all pass)

```
git grep "agent_workspace_"          # zero matches
git grep "log-analysis"              # zero matches
grep "troubleshooting: allow" agents/devops/agent.md      # present
grep "troubleshooting" profiles/{default,content}/PROFILE.md  # present
```

Closes #144
Refs #143
