### PR TITLE
chore(docs): unstale post-#142 cloud verbs in skills, README, and deploy command

### DIFF
--- a/agents/devops/README.md
+++ b/agents/devops/README.md
@@ -37,7 +37,8 @@ All operational tasks go through Makefile targets. The Makefile is a thin wrappe
 |--------|---------|--------|
 | Local dev | `local-init`, `local-clean`, `local-build`, `local-run` | `scripts/local.sh` |
 | Container dev | `container-init`, `container-clean`, `container-build`, `container-run` | `scripts/container.sh` |
-| Cloud runtime | `cloud-init`, `cloud-build`, `cloud-deploy`, `cloud-clean` | `scripts/cloud.sh` |
+| Cloud runtime (developer) | `cloud-preflight`, `cloud-infra`, `cloud-app-deploy`, `cloud-app-promote`, `cloud-app-undeploy`, `cloud-clean` | `scripts/cloud.sh` |
+| Cloud runtime (owner) | `admin-cloud-init`, `admin-cloud-destroy` | `scripts/cloud.sh` |
 
 ### Scaffolded Project Structure
 

--- a/commands/deploy.md
+++ b/commands/deploy.md
@@ -13,11 +13,20 @@ This is a deployment workflow. After pre-flight passes, check if a Makefile
 exists:
 
 **If Makefile exists with standard targets:**
-Use `make` targets for the deployment:
+Use `make` targets for the deployment. Post-#142 the cloud verbs are
+split into developer-tier (Terraform infra + app lifecycle) and owner-tier
+(project bootstrap):
+
 - Container build: `make container-build`
 - Container run: `make container-run`
-- Cloud build: `make cloud-build`
-- Cloud deploy: `make cloud-deploy`
+- Cloud preflight (audit auth/quota/config): `make cloud-preflight`
+- Cloud infra (Terraform plan + apply via Cloud Build): `make cloud-infra`
+- Cloud app deploy (image build + Cloud Run revision swap): `make cloud-app-deploy`
+- Cloud app promote (semver-tagged promotion): `make cloud-app-promote`
+- Cloud app undeploy (revert/rollback active revision): `make cloud-app-undeploy`
+- Admin cloud init (owner-only project bootstrap): `make admin-cloud-init`
+- Admin cloud destroy (owner-only teardown): `make admin-cloud-destroy`
+- Cloud clean (remove generated cloud artifacts locally): `make cloud-clean`
 
 **If no Makefile exists:**
 Offer to scaffold one first using the scaffold tool, then use the targets.

--- a/skills/makefile-ops/SKILL.md
+++ b/skills/makefile-ops/SKILL.md
@@ -24,8 +24,20 @@ project's development workflow.
 |--------|------|-------|-------|------------|------|------|
 | **Local dev** | `local-init` | `local-clean` | `local-build` | `local-run` | `local-test` | `local-lint` |
 | **Container dev** | `container-init` | `container-clean` | `container-build` | `container-run` | — | — |
-| **Cloud runtime** | `cloud-init` | `cloud-clean` | `cloud-build` | `cloud-deploy` | — | — |
+| **Cloud runtime** | `admin-cloud-init` † | `cloud-clean` | `cloud-infra` | `cloud-app-deploy` | `cloud-preflight` | — |
 | **Logs** | — | `logs-clean` | — | — | — | `logs-list` / `logs-last` |
+
+† Cloud runtime adds **admin-tier** and **app lifecycle** verbs beyond the
+standard table (post-#142):
+
+- `admin-cloud-init` — owner-only project bootstrap (APIs, service accounts,
+  IAM bindings, state buckets); requires Owner role.
+- `admin-cloud-destroy` — owner-only teardown of admin-managed resources.
+- `cloud-infra` — Terraform plan + apply via Cloud Build (developer-tier).
+- `cloud-app-deploy` — image build + Cloud Run revision swap.
+- `cloud-app-promote` — semver-tagged promotion of a tested revision.
+- `cloud-app-undeploy` — revert/rollback the active revision.
+- `cloud-preflight` — pre-deploy audit (auth, quota, config, IAM checks).
 
 ### Thin-wrapper Pattern
 
@@ -171,7 +183,7 @@ target execution generates a timestamped log file in `logs/`:
 ```
 logs/20260307-143022-local-build.log
 logs/20260307-143155-container-run.log
-logs/20260307-150000-cloud-deploy.log
+logs/20260307-150000-cloud-app-deploy.log
 ```
 
 These log files capture all stdout and stderr output from the command,


### PR DESCRIPTION
## Summary

PR #142 renamed the cloud Makefile vocabulary from four old verbs (`cloud-init` / `cloud-build` / `cloud-deploy` / `cloud-clean`) to a role-aware eight-verb set (`admin-cloud-init`, `admin-cloud-destroy`, `cloud-preflight`, `cloud-infra`, `cloud-app-deploy`, `cloud-app-promote`, `cloud-app-undeploy`, `cloud-clean`). User-facing docs still referenced the old verbs — after a fresh scaffold operators would be told to run targets that no longer exist.

## Changes

- **`skills/makefile-ops/SKILL.md`** — Updated the "Cloud runtime" row in the "Three Domains, Six Actions" table with post-#142 spellings. Added a footnote enumerating the full role-aware vocab since the new verbs exceed the table column slots. Updated example log filename `cloud-deploy.log` → `cloud-app-deploy.log`.
- **`agents/devops/README.md`** — Split the single "Cloud runtime" row into "Cloud runtime (developer)" and "Cloud runtime (owner)" rows to reflect the developer-tier / owner-tier separation introduced by #142.
- **`commands/deploy.md`** — Replaced `make cloud-build` / `make cloud-deploy` with the new verbs and enumerated the additional ones so `/deploy` doesn't silently lose options.

## Smoke test

```
git grep -nE '(^|[^-a-z])cloud-(init|build|deploy)\b'
```

Returns only:
- `CHANGELOG.md` migration note (intentional historical reference).
- `skills/cloudbuild-ops/SKILL.md:287` educational comparison ("`...`, not `init` / `cloud-init` / `init-prod`") explaining the rename. Intentional.

No other matches in user-facing docs.

Closes #145
Refs #143
