### PR TITLE
chore(commands): document subtask commands; trim git-ops-init slash command

### DIFF
--- a/agents/git-ops/README.md
+++ b/agents/git-ops/README.md
@@ -63,6 +63,11 @@ Invoke the agent directly in the OpenCode TUI:
 | `/review 42` | Review PR #42's code changes |
 | `/release` | Create a release with auto-generated notes |
 | `/git-status` | Comprehensive repository status overview |
+| `/git-local-sync` | Fast-forward the local default branch to match `origin` |
+
+Both `/git-status` and `/git-local-sync` are marked `subtask: true`, so
+they don't appear in the top-level slash menu. Invoke them by name
+when you need them.
 
 ### Skills
 

--- a/commands/git-ops-init.md
+++ b/commands/git-ops-init.md
@@ -1,13 +1,24 @@
 ---
-description: Check git/GitHub environment readiness and optionally set up defaults
+description: Re-check git/GitHub readiness and offer to set up default labels/milestones
 agent: git-ops
 ---
 
-Run the git-ops-init tool to verify the environment is properly configured
-for git and GitHub operations. Report the full results.
+The `git-ops-init` tool already auto-runs on first use of any git-ops tool,
+so an explicit `/git-ops-init` invocation is mainly useful for two things:
 
-If any issues are found, explain how to fix them.
+1. **Force a re-check** (pass `force: true`) after fixing an environment issue
+   such as `gh auth login`, a new remote, or freshly installed `gh` CLI.
+2. **Set up repository defaults** that the auto-run does not create on its
+   own.
 
-If no labels or milestones exist, ask the user if they'd like to create
-default labels (bug, feature, chore, priority:high/medium/low,
-status:in-progress/blocked) and/or an initial milestone using the setup tool.
+Run `git-ops-init` with `force: true` and report the results.
+
+If the report shows no labels or no milestones, ask the user whether to
+create defaults via the `git-ops-init_setup` tool:
+
+- Default labels: `bug`, `feature`, `chore`, `priority:high/medium/low`,
+  `status:in-progress/blocked`.
+- Optionally a starter milestone (ask for a name like `v0.1` and an
+  optional due date).
+
+Only call `git-ops-init_setup` after the user explicitly confirms.


### PR DESCRIPTION
## Summary

Closes #154. Follow-up from configuration audit (closed epic #143).

### R8 — surface subtask commands
- `agents/git-ops/README.md` now lists `/git-local-sync` next to `/git-status` in the Slash Commands table.
- Added a one-line note that both are `subtask: true` (not in the top-level menu).

### R6 — refocus `/git-ops-init` slash command
- The `git-ops-init` tool already auto-runs on first use of any git-ops tool via `ensureEnvironment()`, so the slash command's previous "run the tool and report" framing was redundant.
- Refocused the command body around the two things the auto-run does NOT do:
  1. Force re-check after env changes (`force: true`).
  2. Interactive setup of default labels/milestones via `git-ops-init_setup`.

### Out of scope
- Tool changes (`ensureEnvironment` auto-run wiring is untouched).
- Tool-disable list cleanup (PR-2 in this sequence).
- Safety Model dedup (PR-2).
- `install.sh` refactor (PR-3).

## Smoke test

Auto-run wiring verified intact:
```
$ grep -rn 'ensureEnvironment\|from.*git-ops-init' tools/
tools/git-status.ts:2:import { ensureEnvironment } from "./git-ops-init"
tools/git-conflict.ts:2:import { ensureEnvironment } from "./git-ops-init"
tools/gh-release.ts:2:import { ensureEnvironment } from "./git-ops-init"
tools/gh-pr.ts:2:import { ensureEnvironment } from "./git-ops-init"
tools/gh-issue.ts:2:import { ensureEnvironment } from "./git-ops-init"
tools/git-commit.ts:2:import { ensureEnvironment } from "./git-ops-init"
tools/gh-review.ts:2:import { ensureEnvironment } from "./git-ops-init"
tools/git-branch.ts:2:import { ensureEnvironment } from "./git-ops-init"
```
All 8 callsites of `ensureEnvironment` are intact, so `gh-issue list` on a fresh clone still triggers auto-run.