### PR TITLE
chore(ci): add shellcheck step to repo-hygiene workflow

### DIFF
--- a/.github/workflows/repo-hygiene.yml
+++ b/.github/workflows/repo-hygiene.yml
@@ -57,3 +57,20 @@ jobs:
             exit 1
           fi
           echo "OK: no broken opencode file directives in tracked config files."
+
+  shellcheck:
+    name: shellcheck
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run shellcheck
+        # Pinned to v2.0.0 (latest stable as of 2026-06) to avoid
+        # supply-chain risk from a moving `master` ref. Bump deliberately.
+        # Scope: all tracked .sh files (install.sh + install/lib-*.sh).
+        # Severity: warning (warnings + errors fail; info-level does not).
+        # Tighten to -S info in a follow-up once any backlog is cleared.
+        uses: ludeeus/action-shellcheck@2.0.0
+        env:
+          SHELLCHECK_OPTS: -S warning

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,6 +133,16 @@ script.
 - `time_sleep.wait_for_iam` (see BREAKING).
 - The pre-#141 menu wording in `commands/scaffold.md`.
 
+### Tooling
+
+- **`chore(ci):`** added a `shellcheck` job to the `repo-hygiene`
+  workflow ([#160](https://github.com/kunallimaye/lib-agents/issues/160)).
+  Scans `install.sh` and `install/lib-*.sh` at severity `warning` using
+  `ludeeus/action-shellcheck@2.0.0` (tag-pinned). Existing violations
+  fixed inline (SC2155, SC2207, one dead assignment); 17 cross-module
+  globals and intentional single-iteration loops carry documented
+  per-line suppressions. See PR for full violation-count breakdown.
+
 ### Motivating downstream failures
 
 Both issues were driven by real production incidents in downstream

--- a/install.sh
+++ b/install.sh
@@ -50,7 +50,9 @@ else
 fi
 AGENTS_DIR="${SCRIPT_DIR:+${SCRIPT_DIR}/agents}"
 REPO_ROOT="${SCRIPT_DIR}"
+# shellcheck disable=SC2034  # SHARED_RESOURCES_INSTALLED consumed by install/lib-install.sh install_shared_resources()
 SHARED_RESOURCES_INSTALLED=false
+# shellcheck disable=SC2034  # SOURCE_COMMIT consumed by install/lib-manifest.sh write_manifest()
 SOURCE_COMMIT=""
 
 # Profile state
@@ -58,6 +60,7 @@ PROFILE_NAME=""
 declare -a PROFILE_AGENTS=()
 declare -A PROFILE_AGENT_SKILLS=()   # agent -> space-separated skill list
 declare -a PROFILE_ALL_SKILLS=()     # UNION of all agent_skills values
+# shellcheck disable=SC2034  # PROFILE_DESCRIPTION parsed by install/lib-profiles.sh; reader not yet wired up. Keep so adding a list-profiles consumer is a one-line change.
 PROFILE_DESCRIPTION=""
 
 # Manifest state (populated by lib-manifest.sh functions)
@@ -295,9 +298,14 @@ if [ "$DO_UPDATE" = true ]; then
       rm -rf "${local_target}/skills"
     fi
 
-    # Reset shared resources flag to force reinstall
+    # Reset shared resources flag to force reinstall. All three are
+    # cross-module globals (lib-install.sh, lib-manifest.sh, lib-update.sh)
+    # which shellcheck cannot see when scanning install.sh in isolation.
+    # shellcheck disable=SC2034  # SHARED_RESOURCES_INSTALLED consumed by lib-install.sh
     SHARED_RESOURCES_INSTALLED=false
+    # shellcheck disable=SC2034  # MANIFEST_ENTRIES consumed by lib-manifest.sh, lib-update.sh
     MANIFEST_ENTRIES=()
+    # shellcheck disable=SC2034  # INSTALLED_AGENTS_LIST consumed by lib-manifest.sh, lib-update.sh
     INSTALLED_AGENTS_LIST=()
 
     # Install agents from profile

--- a/install/lib-install.sh
+++ b/install/lib-install.sh
@@ -31,6 +31,7 @@ ensure_agents_source() {
   fi
   AGENTS_DIR="${TEMP_DIR}/agents"
   REPO_ROOT="${TEMP_DIR}"
+  # shellcheck disable=SC2034  # Consumed by lib-manifest.sh write_manifest()
   SOURCE_COMMIT=$(git -C "${TEMP_DIR}" rev-parse HEAD 2>/dev/null || echo "unknown")
   ok "Downloaded agent definitions to temp directory"
   echo ""
@@ -215,7 +216,8 @@ install_shared_resources() {
   if [ -d "${REPO_ROOT}/tools" ]; then
     for tool_file in "${REPO_ROOT}/tools"/*.ts; do
       if [ -f "$tool_file" ]; then
-        local tool_name=$(basename "$tool_file")
+        local tool_name
+        tool_name=$(basename "$tool_file")
         local tool_dest="${target}/tools/${tool_name}"
         if [ "$use_link" = true ]; then
           ln -sf "$(realpath "$tool_file")" "$tool_dest"
@@ -233,7 +235,8 @@ install_shared_resources() {
   if [ -d "${REPO_ROOT}/commands" ]; then
     for cmd_file in "${REPO_ROOT}/commands"/*.md; do
       if [ -f "$cmd_file" ]; then
-        local cmd_name=$(basename "$cmd_file")
+        local cmd_name
+        cmd_name=$(basename "$cmd_file")
         local cmd_dest="${target}/commands/${cmd_name}"
         if [ "$use_link" = true ]; then
           ln -sf "$(realpath "$cmd_file")" "$cmd_dest"
@@ -274,7 +277,8 @@ install_shared_resources() {
       # No profile: install ALL skills
       for skill_dir in "${REPO_ROOT}/skills"/*/; do
         if [ -d "$skill_dir" ] && [ -f "${skill_dir}/SKILL.md" ]; then
-          local skill_name=$(basename "$skill_dir")
+          local skill_name
+          skill_name=$(basename "$skill_dir")
           local skill_dest_dir="${target}/skills/${skill_name}"
           mkdir -p "$skill_dest_dir"
           if [ "$use_link" = true ]; then
@@ -295,7 +299,8 @@ install_shared_resources() {
     mkdir -p "${target}/prompts"
     for prompt_file in "${REPO_ROOT}/prompts"/*.md; do
       if [ -f "$prompt_file" ]; then
-        local prompt_name=$(basename "$prompt_file")
+        local prompt_name
+        prompt_name=$(basename "$prompt_file")
         local prompt_dest="${target}/prompts/${prompt_name}"
         if [ "$use_link" = true ]; then
           ln -sf "$(realpath "$prompt_file")" "$prompt_dest"
@@ -429,6 +434,10 @@ install_agent() {
     project_root="${HOME}/.config/opencode"
   fi
 
+  # Single-element list today; extension point for future root-level
+  # user files (e.g. AGENTS.local.md). See also lib-manifest.sh,
+  # lib-update.sh.
+  # shellcheck disable=SC2043  # Intentional single-iteration list for forward extensibility
   for root_file in AGENTS.md; do
     if [ -f "${REPO_ROOT}/${root_file}" ]; then
       local root_dest="${project_root}/${root_file}"
@@ -461,8 +470,9 @@ install_agent() {
   if [ -d "${REPO_ROOT}/commands" ]; then
     for cmd_file in "${REPO_ROOT}/commands"/*.md; do
       if [ -f "$cmd_file" ]; then
-        local cmd_name=$(basename "$cmd_file" .md)
-        local cmd_desc=$(grep "^description:" "$cmd_file" | head -1 | sed 's/^description:\s*//')
+        local cmd_name cmd_desc
+        cmd_name=$(basename "$cmd_file" .md)
+        cmd_desc=$(grep "^description:" "$cmd_file" | head -1 | sed 's/^description:\s*//')
         echo "    /${cmd_name}$(printf '%*s' $((16 - ${#cmd_name})) '')- ${cmd_desc}"
       fi
     done

--- a/install/lib-logging.sh
+++ b/install/lib-logging.sh
@@ -6,12 +6,15 @@
 [ -n "${LIB_AGENTS_LOGGING_LOADED:-}" ] && return 0
 LIB_AGENTS_LOGGING_LOADED=1
 
-# Colors
+# Colors. Global assignments; consumed across all lib-*.sh modules
+# (status/update/install/profiles/manifest) which source this file once.
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 BLUE='\033[0;34m'
+# shellcheck disable=SC2034  # CYAN consumed by lib-status.sh, lib-update.sh
 CYAN='\033[0;36m'
+# shellcheck disable=SC2034  # BOLD consumed by lib-status.sh, lib-update.sh
 BOLD='\033[1m'
 NC='\033[0m' # No Color
 

--- a/install/lib-manifest.sh
+++ b/install/lib-manifest.sh
@@ -123,7 +123,12 @@ write_manifest() {
   ok "Manifest written to ${manifest_path}"
 }
 
-# Read an existing manifest into associative arrays
+# Read an existing manifest into associative arrays.
+# All MANIFEST_* globals below are populated by read_manifest() and
+# consumed by lib-status.sh (display) and lib-update.sh (diffing).
+# They are declared at file scope so re-sourcing is a no-op; assignments
+# happen inside read_manifest(). They are not `export`ed to child
+# processes -- they are shell-scope globals only.
 # Sets: MANIFEST_HASHES[path]=hash, MANIFEST_TIERS[path]=tier, MANIFEST_COMMIT, MANIFEST_URL, MANIFEST_AT, MANIFEST_AGENTS_CSV, MANIFEST_MODE
 declare -A MANIFEST_HASHES=()
 declare -A MANIFEST_TIERS=()
@@ -154,7 +159,10 @@ read_manifest() {
     [[ -z "$line" ]] && continue
     [[ "$line" == \#* ]] && continue
 
-    # Parse header fields
+    # Parse header fields. All MANIFEST_* assignments below are file-scope
+    # globals consumed by lib-status.sh and lib-update.sh after this file
+    # is sourced; shellcheck cannot see cross-file usage.
+    # shellcheck disable=SC2034  # MANIFEST_* are cross-module globals (see header comment)
     case "$line" in
       source_commit=*)
         MANIFEST_COMMIT="${line#source_commit=}"
@@ -242,7 +250,9 @@ generate_manifest_for_existing() {
     done
   fi
 
-  # Scan user-tier root files
+  # Scan user-tier root files. Single-element list today; extension
+  # point for future root-level user files (e.g. AGENTS.local.md).
+  # shellcheck disable=SC2043  # Intentional single-iteration list for forward extensibility
   for root_file in AGENTS.md; do
     if [ -f "${project_root}/${root_file}" ]; then
       record_file "${project_root}/${root_file}" "user"

--- a/install/lib-profiles.sh
+++ b/install/lib-profiles.sh
@@ -111,6 +111,7 @@ parse_profile() {
         if [[ "$line" =~ ^name:\ *(.*) ]]; then
           PROFILE_NAME="${BASH_REMATCH[1]}"
         elif [[ "$line" =~ ^description:\ *(.*) ]]; then
+          # shellcheck disable=SC2034  # Parsed for future profile-listing UX; currently no reader. Keep the parse so adding a reader is a one-line change.
           PROFILE_DESCRIPTION="${BASH_REMATCH[1]}"
         elif [[ "$line" == "agents:" ]]; then
           current_section="agents"
@@ -166,7 +167,9 @@ parse_profile() {
   done
 
   # Sort for deterministic output
-  IFS=$'\n' PROFILE_ALL_SKILLS=($(sort <<<"${PROFILE_ALL_SKILLS[*]}")); unset IFS
+  if [ "${#PROFILE_ALL_SKILLS[@]}" -gt 0 ]; then
+    mapfile -t PROFILE_ALL_SKILLS < <(printf '%s\n' "${PROFILE_ALL_SKILLS[@]}" | sort)
+  fi
 }
 
 # Validate that all agents and skills referenced in the profile exist
@@ -295,7 +298,6 @@ inject_profile_skills() {
   local injected=false
   local in_fm=false
   local in_sk=false
-  local last_skill_line=""
 
   # Strategy: find the last "allow" or "deny" line in the skill: section,
   # and insert new entries after it
@@ -320,7 +322,9 @@ inject_profile_skills() {
 
     if [ "$in_sk" = true ]; then
       if [[ "$line" =~ ^[[:space:]]{4}[a-z\"*] ]]; then
-        last_skill_line="$line"
+        # Still inside the skill: section; keep scanning. (Previously
+        # captured the line into `last_skill_line`, but nothing read it.)
+        :
       else
         if [[ ! "$line" =~ ^[[:space:]]*$ ]]; then
           # We've left the skill section — inject before this line
@@ -454,7 +458,10 @@ apply_prompt_overlays() {
   local profile_dir="$2"
   local profile_name="$3"
 
-  # plan.md was removed in PR #152 (orphan at runtime); only build remains
+  # plan.md was removed in PR #152 (orphan at runtime); only build remains.
+  # Loop kept (vs collapsing to a single block) as an extension point for
+  # future overlayable prompt files.
+  # shellcheck disable=SC2043  # Intentional single-iteration list for forward extensibility
   for prompt_name in build; do
     local overlay="${profile_dir}/prompts/${prompt_name}.md"
     local dest="${target}/prompts/${prompt_name}.md"

--- a/install/lib-status.sh
+++ b/install/lib-status.sh
@@ -64,7 +64,9 @@ show_status() {
   for path in "${!MANIFEST_HASHES[@]}"; do
     sorted_paths+=("$path")
   done
-  IFS=$'\n' sorted_paths=($(sort <<<"${sorted_paths[*]}")); unset IFS
+  if [ "${#sorted_paths[@]}" -gt 0 ]; then
+    mapfile -t sorted_paths < <(printf '%s\n' "${sorted_paths[@]}" | sort)
+  fi
 
   for path in "${sorted_paths[@]}"; do
     local stored_hash="${MANIFEST_HASHES[$path]}"

--- a/install/lib-update.sh
+++ b/install/lib-update.sh
@@ -61,7 +61,9 @@ prune_backups() {
   done
 
   # Sort by name (timestamps sort lexicographically)
-  IFS=$'\n' backups=($(sort <<<"${backups[*]}")); unset IFS
+  if [ "${#backups[@]}" -gt 0 ]; then
+    mapfile -t backups < <(printf '%s\n' "${backups[@]}" | sort)
+  fi
 
   local count=${#backups[@]}
   if [ "$count" -gt "$keep" ]; then
@@ -158,7 +160,8 @@ update_installation() {
     if [ -d "${REPO_ROOT}/tools" ]; then
       for f in "${REPO_ROOT}/tools"/*.ts; do
         [ -f "$f" ] || continue
-        local dest="${target}/tools/$(basename "$f")"
+        local dest
+        dest="${target}/tools/$(basename "$f")"
         NEW_FILES["$dest"]="$f"
         NEW_TIERS["$dest"]="shared"
         NEW_HASHES["$dest"]=$(compute_hash "$f")
@@ -171,7 +174,8 @@ update_installation() {
     if [ -d "${REPO_ROOT}/commands" ]; then
       for f in "${REPO_ROOT}/commands"/*.md; do
         [ -f "$f" ] || continue
-        local dest="${target}/commands/$(basename "$f")"
+        local dest
+        dest="${target}/commands/$(basename "$f")"
         NEW_FILES["$dest"]="$f"
         NEW_TIERS["$dest"]="shared"
         NEW_HASHES["$dest"]=$(compute_hash "$f")
@@ -201,7 +205,8 @@ update_installation() {
     if [ -d "${REPO_ROOT}/prompts" ]; then
       for f in "${REPO_ROOT}/prompts"/*.md; do
         [ -f "$f" ] || continue
-        local dest="${target}/prompts/$(basename "$f")"
+        local dest
+        dest="${target}/prompts/$(basename "$f")"
         NEW_FILES["$dest"]="$f"
         NEW_TIERS["$dest"]="shared"
         NEW_HASHES["$dest"]=$(compute_hash "$f")
@@ -232,6 +237,10 @@ update_installation() {
 
   # Scan new source: root config files (user tier)
   if should_include_type "configs" "$only_filter"; then
+    # Single-element list today; extension point for future root-level
+    # user files (e.g. AGENTS.local.md). See also lib-install.sh,
+    # lib-manifest.sh.
+    # shellcheck disable=SC2043  # Intentional single-iteration list for forward extensibility
     for root_file in AGENTS.md; do
       if [ -f "${REPO_ROOT}/${root_file}" ]; then
         local dest="${project_root}/${root_file}"


### PR DESCRIPTION
Closes #160.

## Summary

Adds a `shellcheck` job to the existing `repo-hygiene` GitHub Actions workflow, pinned to `ludeeus/action-shellcheck@2.0.0` (latest stable as of June 2026 — pinned to a tag rather than `master` to avoid supply-chain risk from a moving ref). Severity is `warning`, matching the issue plan.

The action's default discovery picks up the 7 tracked `.sh` files automatically:

```
install.sh
install/lib-install.sh
install/lib-logging.sh
install/lib-manifest.sh
install/lib-profiles.sh
install/lib-status.sh
install/lib-update.sh
```

## Severity & scope

- **Severity:** `-S warning` (warnings + errors fail the build; info-level findings do not). Tightening to `-S info` is deferred to a follow-up per the plan.
- **Files scanned:** 7 (listed above).
- **CI shellcheck version:** 0.11.0 (`stable` from the pinned action).

## Violation breakdown

`shellcheck v0.11.0` reported **34 warnings** against the pre-change tree (0 errors). All addressed before the green CI run:

| Category | Count | Action |
|---|---|---|
| SC2155 — declare/assign masking return | 8 | **Fixed inline** — split `local foo=$(...)` into `local foo; foo=$(...)`. Files: `lib-install.sh` (5), `lib-update.sh` (3). |
| SC2207 — prefer `mapfile` over `$(...)` array splitting | 3 | **Fixed inline** — replaced `IFS=$'\n' arr=($(sort <<<...))` with `mapfile -t arr < <(printf '%s\n' "${arr[@]}" \| sort)`. Files: `lib-profiles.sh`, `lib-status.sh`, `lib-update.sh`. |
| SC2034 — `last_skill_line` (genuine dead assignment) | 1 | **Removed**, control-flow no-op comment preserved in `lib-profiles.sh`. |
| SC2034 — cross-module globals | 18 underlying / 11 line-level suppressions | **Suppressed with justification.** Each disable cites its cross-file consumer. |
| SC2043 — intentional single-iteration loops | 4 | **Suppressed with justification.** Each loop is a forward-extension point (`for root_file in AGENTS.md`, `for prompt_name in build`). |

**Totals:** 12 fixed inline, 22 suppressed (15 line-level `# shellcheck disable=` directives — one `case`-level disable in `lib-manifest.sh` covers 8 `MANIFEST_*` assignments).

The 5 install.sh suppressions surfaced after the first CI run: CI runs shellcheck per-file (so it cannot see cross-file usage of `SHARED_RESOURCES_INSTALLED`, `SOURCE_COMMIT`, `PROFILE_DESCRIPTION`, `MANIFEST_ENTRIES`, `INSTALLED_AGENTS_LIST`), while my initial local invocation scanned all files together. Added per-line disables to match the convention.

## Suppression inventory

Every suppression has a one-line justification per the plan's step 3.

### SC2034 (unused variable — cross-module globals)

In `install.sh`:
- `SHARED_RESOURCES_INSTALLED` (twice — top-level + function-local reset) — "Consumed by lib-install.sh install_shared_resources()".
- `SOURCE_COMMIT` — "Consumed by install/lib-manifest.sh write_manifest()".
- `PROFILE_DESCRIPTION` — "Parsed by install/lib-profiles.sh; reader not yet wired up".
- `MANIFEST_ENTRIES` (function-local reset) — "Consumed by lib-manifest.sh, lib-update.sh".
- `INSTALLED_AGENTS_LIST` (function-local reset) — "Consumed by lib-manifest.sh, lib-update.sh".

In `install/lib-install.sh`:
- `SOURCE_COMMIT` (downloaded-source branch) — "Consumed by lib-manifest.sh write_manifest()".

In `install/lib-logging.sh`:
- `CYAN` — "consumed by lib-status.sh, lib-update.sh".
- `BOLD` — "consumed by lib-status.sh, lib-update.sh".

In `install/lib-manifest.sh`:
- `read_manifest()` (single disable above a `case`, covers all 8 `MANIFEST_*` parse-into assignments) — "MANIFEST_* are cross-module globals (see header comment)".

In `install/lib-profiles.sh`:
- `PROFILE_DESCRIPTION` (parse site) — "Parsed for future profile-listing UX; currently no reader. Keep the parse so adding a reader is a one-line change."

### SC2043 (single-iteration loop — extension point)

- `install/lib-install.sh:for root_file in AGENTS.md` — "Intentional single-iteration list for forward extensibility".
- `install/lib-manifest.sh:for root_file in AGENTS.md` — same.
- `install/lib-update.sh:for root_file in AGENTS.md` — same.
- `install/lib-profiles.sh:for prompt_name in build` — same (plan.md removed in PR #152; build remains).

## Smoke testing

Verified locally with `shellcheck v0.11.0` (the same version CI runs, downloaded as a static binary):

```
$ for f in install.sh install/lib-*.sh; do
    shellcheck -S warning "$f" && echo "OK $f" || echo "FAIL $f"
  done
OK install.sh
OK install/lib-install.sh
OK install/lib-logging.sh
OK install/lib-manifest.sh
OK install/lib-profiles.sh
OK install/lib-status.sh
OK install/lib-update.sh
```

Also re-ran `bash -n` on all 7 files (still passes, as expected post-#159) and a manual sourcing test:

```
$ bash -c '. install/lib-logging.sh && . install/lib-manifest.sh \
  && . install/lib-profiles.sh && . install/lib-status.sh \
  && . install/lib-update.sh && . install/lib-install.sh \
  && echo "All sourced OK"'
All sourced OK
```

`./install.sh --list` and `./install.sh --profiles` both still render correctly (output unchanged).

**First CI run:** failed (5 install.sh-only warnings that local cross-file scan didn't surface). **Fix-up commit added the missing suppressions; second CI run green.**

## CHANGELOG

Entry added under `## [Unreleased]` → new `### Tooling` subsection.

## Plan acceptance criteria

- [x] `.github/workflows/repo-hygiene.yml` runs shellcheck on `install.sh` and `install/lib-*.sh`.
- [x] Green CI run.
- [x] PR body documents severity, violation count, and suppression count.
- [x] CHANGELOG entry added.
- [x] No scope creep — only the 7 shell files + workflow + CHANGELOG were touched.

## Out of scope (per plan)

- No other workflows touched.
- No pre-commit hooks added.
- No shell refactoring beyond shellcheck findings.
- Severity not tightened past `warning` in this PR.
