### PR TITLE
fix(install): --link + --profile writes through symlinks and corrupts source files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,6 +143,24 @@ script.
   globals and intentional single-iteration loops carry documented
   per-line suppressions. See PR for full violation-count breakdown.
 
+### Fixed
+
+- **`fix(install):`** refuse the `--link` + `--profile` (and
+  `--link` + `--all`) combination at argument-parsing time
+  ([#161](https://github.com/kunallimaye/lib-agents/issues/161)).
+  Previously these combinations were silent footguns: `--link`
+  installs agent.md files as symlinks back into the source repo, and
+  profile-skill injection then wrote THROUGH the symlinks, corrupting
+  the canonical `agents/*/agent.md` files in the lib-agents source
+  tree. The installer now exits 2 with a clear error and a
+  pick-one-of-these table. This is approach (b) — refuse the
+  combination — from the issue; a symlink-resolution / replace-with-real
+  approach (a) is deferred. The PR does not repair any
+  previously-corrupted source files; it only prevents new corruption.
+  A `SYMLINK HAZARD` block comment above `inject_profile_skills` in
+  `install/lib-profiles.sh` documents the invariant for future
+  maintainers.
+
 ### Motivating downstream failures
 
 Both issues were driven by real production incidents in downstream

--- a/install.sh
+++ b/install.sh
@@ -225,6 +225,34 @@ while [ $# -gt 0 ]; do
   esac
 done
 
+# Refuse --link + --profile (and --link + --all, since --all is shorthand
+# for --profile default). Profile-skill injection writes through to the
+# installed agent.md file; with --link, that destination is a symlink
+# back into the source repo, so the write corrupts the canonical
+# lib-agents source tree. See issue #161 and the SYMLINK HAZARD comment
+# above inject_profile_skills() in install/lib-profiles.sh.
+#
+# This guard MUST run before any install action (ensure_agents_source,
+# install_shared_resources, install_agent) -- by the time injection
+# runs, the symlinks already point into the source tree.
+if [ "$USE_LINK" = "link" ] && { [ -n "$PROFILE_ARG" ] || [ "$INSTALL_ALL" = true ]; }; then
+  err ""
+  err "Cannot combine --link with --profile (or --all)."
+  err ""
+  err "Reason: profile-skill injection writes to the installed agent.md"
+  err "files. With --link, those destinations are symlinks back into the"
+  err "lib-agents source repo, so the writes go THROUGH the symlinks and"
+  err "corrupt the canonical source tree (issue #161)."
+  err ""
+  err "Pick one:"
+  err "  --link alone                       development, no profile customization"
+  err "  --profile NAME --project           real-copy install with profile (recommended)"
+  err "  --profile NAME --global            same, installed globally"
+  err "  --all --project                    real-copy install with default profile"
+  err ""
+  exit 2
+fi
+
 echo ""
 echo "========================================="
 echo "  lib-agents installer"

--- a/install/lib-profiles.sh
+++ b/install/lib-profiles.sh
@@ -229,8 +229,23 @@ get_skill_description() {
   fi
 }
 
-# Inject profile skills into an installed agent.md
-# Adds permission.skill entries and appends Profile Skills section
+# inject_profile_skills -- inject profile-specific skill allow-entries
+# into the installed agent.md file's frontmatter, and append a "Profile
+# Skills" section to the body.
+#
+# SYMLINK HAZARD: This function WRITES to the destination agent.md.
+# When install.sh is invoked with --link, the destination is a symlink
+# back into the source repo, and the write goes THROUGH the symlink,
+# corrupting the canonical lib-agents source tree (issue #161).
+#
+# The --link + --profile combination is refused at argument-parsing
+# time in install.sh (search for "Cannot combine --link with --profile").
+# If you are tempted to relax that guard, you MUST first switch this
+# function to detect symlinked destinations and replace them with real
+# copies before writing -- otherwise you reintroduce the bug filed as
+# #161.
+#
+# Adds permission.skill entries and appends Profile Skills section.
 inject_profile_skills() {
   local agent_md="$1"
   local agent_name="$2"


### PR DESCRIPTION
Closes #161.

## Summary

Combining `--link` (symlink install) with `--profile NAME` (or `--all`, which is shorthand for `--profile default`) caused profile-skill injection to write THROUGH the symlinked `agent.md` destinations back into the canonical lib-agents source tree, silently corrupting `agents/*/agent.md` source files.

This PR takes **approach (b)** from the issue plan — refuse the combination at argument-parsing time. Approach (a) (symlink-resolution: replace the destination symlink with a real copy before injection) is deferred; (b) is fail-fast safe and avoids the "some files are symlinks, some aren't" inconsistency that (a) would introduce.

**This PR does NOT repair any previously-corrupted source files** — per the plan, that is a separate cleanup. This PR prevents new corruption only.

## Implementation

### Guard at argument-parsing time (`install.sh`)

Immediately after the `while [ $# -gt 0 ]` parse loop completes — **before** `ensure_agents_source`, `install_shared_resources`, or `install_agent` runs — the installer checks:

```bash
if [ "$USE_LINK" = "link" ] && { [ -n "$PROFILE_ARG" ] || [ "$INSTALL_ALL" = true ]; }; then
  err "..."
  exit 2
fi
```

The guard MUST run before any install action, because by the time `inject_profile_skills` runs, the agent.md symlinks have already been created and there is no clean rollback.

The condition covers all three problematic invocations:

| Form | Triggers because |
|---|---|
| `--link --profile NAME` | `USE_LINK="link"` && `PROFILE_ARG` non-empty |
| `--link --all` | `USE_LINK="link"` && `INSTALL_ALL=true` (which is `--profile default` shorthand) |
| `--update --profile NAME --link` | Same first condition (profile switch path also calls `inject_profile_skills`) |

Exit code is **2** (misuse convention).

### `SYMLINK HAZARD` block comment (`install/lib-profiles.sh`)

A block comment is added immediately above `inject_profile_skills()` documenting the invariant. It calls out:

- The function writes to the destination `agent.md`.
- With `--link`, that destination is a symlink into the source repo.
- The guard in `install.sh` is the actual protection.
- A future maintainer who wants to relax the guard MUST first teach this function to detect symlinked destinations and replace them with real copies — otherwise the bug returns.

This is preventive documentation, not protection — the guard is the protection.

## Smoke-test evidence

All tests run from a clean `/tmp/pilot-161-test/` against the workspace as source. Canonical `agents/*/agent.md` SHA256 baseline captured before testing and verified byte-identical after.

| # | Command | Expected | Actual | Result |
|---|---|---|---|---|
| A | `./install.sh git-ops --link --profile content --project` | Exit 2, no writes, clear error | Exit 2, no files written, full error message | **PASS** |
| B | `./install.sh git-ops --link --project` | Exit 0, symlinks created | Exit 0, `agents/git-ops.md` symlinked back to source | **PASS** |
| C | `./install.sh --profile content --project` | Exit 0, real-file copies | Exit 0, real files (not symlinks), injection ran cleanly | **PASS** |
| D | `./install.sh --all --project` | Exit 0, real-file copies | Exit 0, real files, all 7 agents installed | **PASS** |
| E (bonus) | `./install.sh --all --link --project` | Exit 2 (via the `--all` branch of the guard) | Exit 2, no files written | **PASS** |

### Test A output (the new error)

```
[ERROR]
[ERROR] Cannot combine --link with --profile (or --all).
[ERROR]
[ERROR] Reason: profile-skill injection writes to the installed agent.md
[ERROR] files. With --link, those destinations are symlinks back into the
[ERROR] lib-agents source repo, so the writes go THROUGH the symlinks and
[ERROR] corrupt the canonical source tree (issue #161).
[ERROR]
[ERROR] Pick one:
[ERROR]   --link alone                       development, no profile customization
[ERROR]   --profile NAME --project           real-copy install with profile (recommended)
[ERROR]   --profile NAME --global            same, installed globally
[ERROR]   --all --project                    real-copy install with default profile
[ERROR]
exit=2
```

### Canonical source files unchanged

Before any smoke test:

```
cb8d3dc38eb93ef2350cce0487fac956566a2fddc6a98bf3d7a5182ec1ff0bd6  agents/devops/agent.md
94425fd8bb5dc5e771b61229dec7c8b0457c86ff5ef6fc8a2adf8eb9ad622200  agents/docs/agent.md
6d7521cb4c69a7c8062c703dccb82ef4a14db1b71cff2893ae0cf101ea10d580  agents/git-ops/agent.md
b7801356cbabf329c123be815a7823759606a91caa5d40eac42f1eac0e9a3c86  agents/ideate/agent.md
b6b7ca092ed4c8831a124130a283421778ff81347bf06aeb8cc2462e0652f58a  agents/orchestrator/agent.md
f1f5b29e5a695d1e36509fcd3a390f2aa68fa86651eafe0020e577b9ca977c54  agents/pilot/agent.md
40ad81851c436c54f0ff8f39975b72901e1777978de4f23efc5305e800ee4a5c  agents/scribe/agent.md
```

After Tests A → E: **identical** (`diff` returned no differences; `git diff HEAD -- agents/` returned 0 lines).

## CI

- `shellcheck` (the gate landed in #160) passes on the touched files.
- `bash -n install.sh` passes.

## Plan acceptance criteria

- [x] `./install.sh ... --link --profile=NAME ...` exits non-zero (code **2**) with a clear error explaining why and what to do instead.
- [x] `./install.sh ... --link ...` (no profile) still works as before.
- [x] `./install.sh ... --profile NAME ...` (no link) still works as before.
- [x] `./install.sh ... --all --profile NAME ...` still works as before.
- [x] Canonical `agents/*/agent.md` source files byte-identical to HEAD after all test cases.
- [x] `install/lib-profiles.sh` has a `SYMLINK HAZARD` comment above `inject_profile_skills`.
- [x] PR body documents the test matrix and before/after behavior.
- [x] CHANGELOG entry added.

## Out of scope (per plan)

- Approach (a) — symlink-resolution / replace-with-real-copy — deferred.
- No repair of pre-existing corrupted source files (would be a separate audit + cleanup PR).
- No broader install-lifecycle refactor.
- No change to default install mode.
- No changes to manifest / backup / rollback paths.
