### PR TITLE
docs(changelog): promote [Unreleased] to [0.2.2]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to `lib-agents` are documented here.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/);
 this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] — three-role topology + detached orchestration (BREAKING)
+## [Unreleased]
+
+## [0.2.2] - 2026-06-02 — three-role topology + detached orchestration (BREAKING)
 
 Closes [#141](https://github.com/kunallimaye/lib-agents/issues/141) and
 [#140](https://github.com/kunallimaye/lib-agents/issues/140).


### PR DESCRIPTION
## Summary

CHANGELOG hygiene follow-up to the [v0.2.2 release](https://github.com/kunallimaye/lib-agents/releases/tag/v0.2.2)
(tag `e6ea4ee`, published 2026-06-02).

## Why

The v0.2.2 release was cut from `main` HEAD `e6ea4ee` and published
successfully. `CHANGELOG.md` was **intentionally not touched** during
that release per the release brief's conservative instruction — the
release-cut task was scoped to tagging + publishing only.

This left `[Unreleased]` still containing the v0.2.2 contents. Without
this PR, the next contributor opening a PR would believe their change
is the first entry under `[Unreleased]` when it actually isn't.

## What changed

`CHANGELOG.md` only:

- Renamed `## [Unreleased] — three-role topology + detached orchestration (BREAKING)`
  to `## [0.2.2] - 2026-06-02 — three-role topology + detached orchestration (BREAKING)`
  (descriptive suffix preserved).
- Inserted a fresh empty `## [Unreleased]` section above the new `[0.2.2]` heading.

## What didn't change

- No comparison links exist at the bottom of `CHANGELOG.md` today, so
  the conditional Keep-a-Changelog link-update step (per the issue
  scope item 3) is a no-op. This PR is promote-only, not a format
  upgrade.
- No existing CHANGELOG entries were reformatted.
- No new entries were added.
- No other files touched.

## Diff stats

`1 file changed, 3 insertions(+), 1 deletion(-)`

Closes #164